### PR TITLE
fix operand names conflicting with local variables in the generated functions

### DIFF
--- a/bindings/wrap.toml
+++ b/bindings/wrap.toml
@@ -13,6 +13,43 @@ show_c_function_prototype = false
 printer_blacklist = [
     "MAKE_MLIR_PYTHON_QUALNAME",
 ]
+output_ignorelist = [
+    "MlirTypeID",
+    "MlirTypeIDAllocator",
+    "MlirLlvmThreadPool",
+    "MlirStringRef",
+    "MlirLogicalResult",
+    "MlirContext",
+    "MlirDialect",
+    "MlirDialectHandle",
+    "MlirDialectRegistry",
+    "MlirOperation",
+    "MlirOpOperand",
+    "MlirOpPrintingFlags",
+    "MlirBlock",
+    "MlirRegion",
+    "MlirSymbolTable",
+    "MlirAttribute",
+    "MlirIdentifier",
+    "MlirLocation",
+    "MlirModule",
+    "MlirType",
+    "MlirValue",
+    "MlirNamedAttribute",
+    "MlirOperationState",
+    "MlirAffineExpr",
+    "MlirAffineMap",
+    "MlirPass",
+    "MlirExternalPass",
+    "MlirPassManager",
+    "MlirOpPassManager",
+    "MlirExternalPassCallbacks",
+    "MlirDiagnostic",
+    "MlirExecutionEngine",
+    "MlirIntegerSet",
+    "MlirAsmState",
+    "MlirBytecodeWriterConfig",
+]
 
 [codegen]
 use_julia_bool = true

--- a/deps/tblgen/jl-generators.cc
+++ b/deps/tblgen/jl-generators.cc
@@ -142,7 +142,11 @@ namespace
     }
     // check if name colides with Julia keywords, generated module name, or "location":
     // https://docs.julialang.org/en/v1/base/base/#Keywords
-    std::vector<std::string> reservedKeywords = {"include", "location", "baremodule", "begin", "break", "catch", "const", "continue", "do", "else", "elseif", "end", "export", "false", "finally", "for", "function", "global", "if", "import", "let", "local", "macro", "module", "public", "quote", "return", "struct", "true", "try", "using", "while"};
+    // aditionally check that name doesn't conflict with local variables defined in the function (results, operands, owned_regions, successors, attributes)
+    std::vector<std::string> reservedKeywords = {
+      "results", "operands", "owned_regions", "successors", "attributes", 
+      "include", "location", "baremodule", "begin", "break", "catch", "const", "continue", "do", "else", "elseif", "end", "export", "false", "finally", "for", "function", "global", "if", "import", "let", "local", "macro", "module", "public", "quote", "return", "struct", "true", "try", "using", "while"
+      };
     if (modulename.has_value()) {
       reservedKeywords.push_back(modulename.value());
     }

--- a/src/API/14/libMLIR_h.jl
+++ b/src/API/14/libMLIR_h.jl
@@ -2,8 +2,13 @@ using CEnum
 
 const intptr_t = Clong
 
+"""
+    mlirStringRefCreate(str, length)
+
+Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
 end
 
 """
@@ -21,7 +26,9 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
+        string::MlirStringRef, other::MlirStringRef
+    )::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -110,7 +117,9 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
+        context::MlirContext, allow::Bool
+    )::Cvoid
 end
 
 """
@@ -119,7 +128,9 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
+        context::MlirContext
+    )::Bool
 end
 
 """
@@ -128,7 +139,9 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
+        context::MlirContext
+    )::intptr_t
 end
 
 """
@@ -137,7 +150,9 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
+        ctx::MlirContext, registry::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -155,7 +170,9 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
+        context::MlirContext, name::MlirStringRef
+    )::MlirDialect
 end
 
 """
@@ -164,7 +181,9 @@ end
 Set threading mode (must be set to false to print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
+        context::MlirContext, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -173,7 +192,9 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
+        context::MlirContext, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -200,7 +221,9 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
+        dialect1::MlirDialect, dialect2::MlirDialect
+    )::Bool
 end
 
 """
@@ -245,7 +268,9 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
+        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
+    )::MlirLocation
 end
 
 """
@@ -254,7 +279,9 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
+        callee::MlirLocation, caller::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -263,7 +290,12 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
+        ctx::MlirContext,
+        nLocations::intptr_t,
+        locations::Ptr{MlirLocation},
+        metadata::MlirAttribute,
+    )::MlirLocation
 end
 
 """
@@ -272,7 +304,9 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
+        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -317,7 +351,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
+        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -335,7 +371,9 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
+        context::MlirContext, _module::MlirStringRef
+    )::MlirModule
 end
 
 """
@@ -398,7 +436,9 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
+        name::MlirStringRef, loc::MlirLocation
+    )::MlirOperationState
 end
 
 """
@@ -407,23 +447,33 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
+        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
+        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
+        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
+    )::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
+        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
+    )::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
+        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
+    )::Cvoid
 end
 
 """
@@ -432,7 +482,9 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
+        state::Ptr{MlirOperationState}
+    )::Cvoid
 end
 
 """
@@ -459,7 +511,9 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
+        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
+    )::Cvoid
 end
 
 """
@@ -468,7 +522,9 @@ end
 Enable printing of debug information. If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, prettyForm::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
+        flags::MlirOpPrintingFlags, prettyForm::Bool
+    )::Cvoid
 end
 
 """
@@ -477,7 +533,9 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -486,7 +544,9 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -497,7 +557,9 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
+        state::Ptr{MlirOperationState}
+    )::MlirOperation
 end
 
 """
@@ -614,7 +676,9 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
+        op::MlirOperation, pos::intptr_t
+    )::MlirRegion
 end
 
 """
@@ -641,7 +705,9 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -650,7 +716,9 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
+        op::MlirOperation, pos::intptr_t, newValue::MlirValue
+    )::Cvoid
 end
 
 """
@@ -668,7 +736,9 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -686,7 +756,9 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
+        op::MlirOperation, pos::intptr_t
+    )::MlirBlock
 end
 
 """
@@ -704,7 +776,9 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
+        op::MlirOperation, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -713,7 +787,9 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -722,7 +798,9 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
+        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
+    )::Cvoid
 end
 
 """
@@ -731,7 +809,9 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -740,7 +820,9 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
+        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -749,7 +831,12 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
+        op::MlirOperation,
+        flags::MlirOpPrintingFlags,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -776,7 +863,9 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -785,7 +874,9 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -839,7 +930,9 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
+        region::MlirRegion, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -848,7 +941,9 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
+        region::MlirRegion, pos::intptr_t, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -857,7 +952,9 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -866,7 +963,9 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -893,7 +992,9 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
+        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
+    )::MlirBlock
 end
 
 """
@@ -974,7 +1075,9 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
+        block::MlirBlock, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -983,7 +1086,9 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
+        block::MlirBlock, pos::intptr_t, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -992,7 +1097,9 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1001,7 +1108,9 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1019,7 +1128,9 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
+        block::MlirBlock, type::MlirType, loc::MlirLocation
+    )::MlirValue
 end
 
 """
@@ -1037,7 +1148,9 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
+        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1145,7 +1258,9 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(
+        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1154,7 +1269,9 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
+        context::MlirContext, type::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -1199,7 +1316,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(
+        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1217,7 +1336,9 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
+        context::MlirContext, attr::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -1271,7 +1392,9 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
+        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1289,7 +1412,9 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
+        name::MlirIdentifier, attr::MlirAttribute
+    )::MlirNamedAttribute
 end
 
 """
@@ -1298,7 +1423,9 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
+        context::MlirContext, str::MlirStringRef
+    )::MlirIdentifier
 end
 
 """
@@ -1316,7 +1443,9 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
+        ident::MlirIdentifier, other::MlirIdentifier
+    )::Bool
 end
 
 """
@@ -1346,8 +1475,13 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
+"""
+    mlirTypeIDHashValue(typeID)
+
+Returns the hash value of the type id.
+"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
 end
 
 """
@@ -1401,7 +1535,9 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
+        symbolTable::MlirSymbolTable, name::MlirStringRef
+    )::MlirOperation
 end
 
 """
@@ -1410,7 +1546,9 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::MlirAttribute
 end
 
 """
@@ -1419,7 +1557,9 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1428,7 +1568,9 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
+        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
+    )::MlirLogicalResult
 end
 
 """
@@ -1437,7 +1579,12 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
+        from::MlirOperation,
+        allSymUsesVisible::Bool,
+        callback::Ptr{Cvoid},
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -1455,7 +1602,9 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1473,7 +1622,9 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
+        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1491,7 +1642,9 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
+        affineExpr::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1509,7 +1662,9 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
+        affineExpr::MlirAffineExpr
+    )::Int64
 end
 
 """
@@ -1518,7 +1673,9 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
+        affineExpr::MlirAffineExpr, factor::Int64
+    )::Bool
 end
 
 """
@@ -1527,7 +1684,9 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
+        affineExpr::MlirAffineExpr, position::intptr_t
+    )::Bool
 end
 
 """
@@ -1536,7 +1695,9 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
+        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
+    )::MlirAffineExpr
 end
 
 """
@@ -1554,7 +1715,9 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1563,7 +1726,9 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1581,7 +1746,9 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1590,7 +1757,9 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1608,7 +1777,9 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
+        ctx::MlirContext, constant::Int64
+    )::MlirAffineExpr
 end
 
 """
@@ -1635,7 +1806,9 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1653,7 +1826,9 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1671,7 +1846,9 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1689,7 +1866,9 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1707,7 +1886,9 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1725,7 +1906,9 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1734,7 +1917,9 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1770,7 +1955,9 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
+        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1797,7 +1984,9 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
+        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1806,7 +1995,13 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
+        ctx::MlirContext,
+        dimCount::intptr_t,
+        symbolCount::intptr_t,
+        nAffineExprs::intptr_t,
+        affineExprs::Ptr{MlirAffineExpr},
+    )::MlirAffineMap
 end
 
 """
@@ -1815,7 +2010,9 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
+        ctx::MlirContext, val::Int64
+    )::MlirAffineMap
 end
 
 """
@@ -1824,7 +2021,9 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
+        ctx::MlirContext, numDims::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1833,7 +2032,9 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
+        ctx::MlirContext, dims::intptr_t, results::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1842,7 +2043,9 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
+        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
+    )::MlirAffineMap
 end
 
 """
@@ -1887,7 +2090,9 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
+        affineMap::MlirAffineMap
+    )::Int64
 end
 
 """
@@ -1923,7 +2128,9 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
+        affineMap::MlirAffineMap, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1941,7 +2148,9 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
+        affineMap::MlirAffineMap
+    )::Bool
 end
 
 """
@@ -1959,7 +2168,9 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
+        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
+    )::MlirAffineMap
 end
 
 """
@@ -1968,7 +2179,9 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1977,7 +2190,9 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1985,8 +2200,16 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
+function mlirAffineMapReplace(
+    affineMap, expression, replacement, numResultDims, numResultSyms
+)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
+        affineMap::MlirAffineMap,
+        expression::MlirAffineExpr,
+        replacement::MlirAffineExpr,
+        numResultDims::intptr_t,
+        numResultSyms::intptr_t,
+    )::MlirAffineMap
 end
 
 """
@@ -1995,7 +2218,12 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
+        affineMaps::Ptr{MlirAffineMap},
+        size::intptr_t,
+        result::Ptr{Cvoid},
+        populateResult::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -2049,7 +2277,9 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2067,7 +2297,9 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2085,7 +2317,9 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2103,7 +2337,9 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -2112,7 +2348,9 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
+        attr::MlirAttribute, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2130,7 +2368,9 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
+        ctx::MlirContext, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2139,7 +2379,9 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
+        loc::MlirLocation, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2229,7 +2471,13 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
+        ctx::MlirContext,
+        dialectNamespace::MlirStringRef,
+        dataLength::intptr_t,
+        data::Cstring,
+        type::MlirType,
+    )::MlirAttribute
 end
 
 """
@@ -2238,7 +2486,9 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2265,7 +2515,9 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
+        ctx::MlirContext, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2274,7 +2526,9 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
+        type::MlirType, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2301,7 +2555,12 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
+        ctx::MlirContext,
+        symbol::MlirStringRef,
+        numReferences::intptr_t,
+        references::Ptr{MlirAttribute},
+    )::MlirAttribute
 end
 
 """
@@ -2310,7 +2569,9 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2319,7 +2580,9 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2328,7 +2591,9 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -2337,7 +2602,9 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2355,7 +2622,9 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
+        ctx::MlirContext, symbol::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2427,7 +2696,9 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 """
@@ -2436,7 +2707,9 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::Bool
 end
 
 """
@@ -2471,11 +2744,24 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
+"""
+    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
+
+Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
+
+The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
+
+A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
+"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
+        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
+    )::MlirAttribute
 end
 
 """
@@ -2484,43 +2770,63 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
+        shapedType::MlirType, element::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
+        shapedType::MlirType, element::Bool
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
+        shapedType::MlirType, element::UInt8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
+        shapedType::MlirType, element::Int8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
+        shapedType::MlirType, element::UInt32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
+        shapedType::MlirType, element::Int32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
+        shapedType::MlirType, element::UInt64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
+        shapedType::MlirType, element::Int64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
+        shapedType::MlirType, element::Cfloat
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
+        shapedType::MlirType, element::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2529,47 +2835,69 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
+    )::MlirAttribute
 end
 
 """
@@ -2578,7 +2906,9 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
+        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
+    )::MlirAttribute
 end
 
 """
@@ -2587,7 +2917,9 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
+        attr::MlirAttribute, shapedType::MlirType
+    )::MlirAttribute
 end
 
 """
@@ -2605,7 +2937,9 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -2617,35 +2951,51 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
+        attr::MlirAttribute
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
+        attr::MlirAttribute
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
+        attr::MlirAttribute
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
+        attr::MlirAttribute
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
+        attr::MlirAttribute
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
+        attr::MlirAttribute
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
+        attr::MlirAttribute
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2654,51 +3004,75 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirStringRef
 end
 
 """
@@ -2734,7 +3108,9 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
+        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -2743,7 +3119,9 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -2752,7 +3130,9 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -2779,7 +3159,9 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -2788,7 +3170,9 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -3058,7 +3442,9 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3067,7 +3453,9 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
+        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3103,7 +3491,9 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3112,7 +3502,13 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
+        loc::MlirLocation,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        elementType::MlirType,
+        encoding::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3139,7 +3535,9 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3166,7 +3564,13 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3175,7 +3579,14 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3184,7 +3595,9 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
+        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3193,7 +3606,13 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3202,7 +3621,9 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
+        elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3211,7 +3632,9 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3265,7 +3688,9 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
+    )::MlirType
 end
 
 """
@@ -3301,7 +3726,13 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
+        ctx::MlirContext,
+        numInputs::intptr_t,
+        inputs::Ptr{MlirType},
+        numResults::intptr_t,
+        results::Ptr{MlirType},
+    )::MlirType
 end
 
 """
@@ -3337,7 +3768,9 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
+        type::MlirType, pos::intptr_t
+    )::MlirType
 end
 
 """
@@ -3373,7 +3806,9 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
+        passManager::MlirPassManager
+    )::MlirOpPassManager
 end
 
 """
@@ -3382,7 +3817,9 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
+        passManager::MlirPassManager, _module::MlirModule
+    )::MlirLogicalResult
 end
 
 """
@@ -3391,7 +3828,9 @@ end
 Enable print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
+        passManager::MlirPassManager
+    )::Cvoid
 end
 
 """
@@ -3400,7 +3839,9 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
+        passManager::MlirPassManager, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -3409,7 +3850,9 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
+        passManager::MlirPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -3418,7 +3861,9 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
+        passManager::MlirOpPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -3427,7 +3872,9 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
+        passManager::MlirPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -3436,7 +3883,9 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
+        passManager::MlirOpPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -3445,7 +3894,9 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
+        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -3454,7 +3905,9 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
+        passManager::MlirOpPassManager, pipeline::MlirStringRef
+    )::MlirLogicalResult
 end
 
 function mlirRegisterConversionPasses()
@@ -3884,7 +4337,9 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
+        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -3893,7 +4348,9 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
+        diagnostic::MlirDiagnostic
+    )::MlirLocation
 end
 
 """
@@ -3902,7 +4359,9 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
+        diagnostic::MlirDiagnostic
+    )::MlirDiagnosticSeverity
 end
 
 """
@@ -3920,7 +4379,9 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
+        diagnostic::MlirDiagnostic, pos::intptr_t
+    )::MlirDiagnostic
 end
 
 """
@@ -3929,7 +4390,12 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
+        context::MlirContext,
+        handler::MlirDiagnosticHandler,
+        userData::Ptr{Cvoid},
+        deleteUserData::Ptr{Cvoid},
+    )::MlirDiagnosticHandlerID
 end
 
 """
@@ -3938,7 +4404,9 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
+        context::MlirContext, id::MlirDiagnosticHandlerID
+    )::Cvoid
 end
 
 """
@@ -3956,7 +4424,9 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
+        arg1::MlirDialectHandle
+    )::MlirStringRef
 end
 
 """
@@ -3965,7 +4435,9 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
+        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -3974,7 +4446,9 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::Cvoid
 end
 
 """
@@ -3983,7 +4457,9 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::MlirDialect
 end
 
 """
@@ -4095,7 +4571,9 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
+        pointee::MlirType, addressSpace::Cuint
+    )::MlirType
 end
 
 """
@@ -4113,7 +4591,9 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
+        elementType::MlirType, numElements::Cuint
+    )::MlirType
 end
 
 """
@@ -4122,7 +4602,12 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
+        resultType::MlirType,
+        nArgumentTypes::intptr_t,
+        argumentTypes::Ptr{MlirType},
+        isVarArg::Bool,
+    )::MlirType
 end
 
 """
@@ -4131,7 +4616,9 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
+        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
+    )::MlirType
 end
 
 """
@@ -4447,7 +4934,9 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -4456,7 +4945,9 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -4519,7 +5010,9 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
+        type::MlirType
+    )::Cuint
 end
 
 """
@@ -4528,7 +5021,9 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
+        type::MlirType, candidate::MlirType
+    )::Bool
 end
 
 """
@@ -4537,7 +5032,9 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
+        type::MlirType
+    )::MlirType
 end
 
 """
@@ -4546,7 +5043,9 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4564,7 +5063,9 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4582,7 +5083,9 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4599,8 +5102,16 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirAnyQuantizedTypeGet(
+    flags, storageType, expressedType, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -4617,8 +5128,18 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedTypeGet(
+    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        scale::Cdouble,
+        zeroPoint::Int64,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -4662,8 +5183,28 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(
+    flags,
+    storageType,
+    expressedType,
+    nDims,
+    scales,
+    zeroPoints,
+    quantizedDimension,
+    storageTypeMin,
+    storageTypeMax,
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        nDims::intptr_t,
+        scales::Ptr{Cdouble},
+        zeroPoints::Ptr{Int64},
+        quantizedDimension::Int32,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -4672,7 +5213,9 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
+        type::MlirType
+    )::intptr_t
 end
 
 """
@@ -4681,7 +5224,9 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
+        type::MlirType, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -4690,7 +5235,9 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
+        type::MlirType, pos::intptr_t
+    )::Int64
 end
 
 """
@@ -4699,7 +5246,9 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
+        type::MlirType
+    )::Int32
 end
 
 """
@@ -4726,7 +5275,9 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
+        expressedType::MlirType, min::Cdouble, max::Cdouble
+    )::MlirType
 end
 
 """
@@ -4778,7 +5329,9 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
+        attr::MlirAttribute
+    )::Bool
 end
 
 """
@@ -4786,8 +5339,17 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(
+    ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth
+)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
+        ctx::MlirContext,
+        numDimLevelTypes::intptr_t,
+        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
+        dimOrdering::MlirAffineMap,
+        pointerBitWidth::Cint,
+        indexBitWidth::Cint,
+    )::MlirAttribute
 end
 
 """
@@ -4796,7 +5358,9 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -4805,7 +5369,9 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirSparseTensorDimLevelType
 end
 
 """
@@ -4814,7 +5380,9 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
+        attr::MlirAttribute
+    )::MlirAffineMap
 end
 
 """
@@ -4823,7 +5391,9 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 """
@@ -4832,7 +5402,9 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -4869,7 +5441,9 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef})::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
+        op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}
+    )::MlirExecutionEngine
 end
 
 """
@@ -4896,7 +5470,9 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
+        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
+    )::MlirLogicalResult
 end
 
 """
@@ -4905,7 +5481,9 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -4914,7 +5492,9 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -4923,7 +5503,9 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
+        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -4932,7 +5514,9 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
+        jit::MlirExecutionEngine, fileName::MlirStringRef
+    )::Cvoid
 end
 
 """
@@ -4968,7 +5552,9 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
+        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -4986,7 +5572,9 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
+        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
+    )::MlirIntegerSet
 end
 
 """
@@ -4994,8 +5582,17 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
+function mlirIntegerSetGet(
+    context, numDims, numSymbols, numConstraints, constraints, eqFlags
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
+        context::MlirContext,
+        numDims::intptr_t,
+        numSymbols::intptr_t,
+        numConstraints::intptr_t,
+        constraints::Ptr{MlirAffineExpr},
+        eqFlags::Ptr{Bool},
+    )::MlirIntegerSet
 end
 
 """
@@ -5003,8 +5600,16 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
+function mlirIntegerSetReplaceGet(
+    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
+        set::MlirIntegerSet,
+        dimReplacements::Ptr{MlirAffineExpr},
+        symbolReplacements::Ptr{MlirAffineExpr},
+        numResultDims::intptr_t,
+        numResultSymbols::intptr_t,
+    )::MlirIntegerSet
 end
 
 """
@@ -5076,7 +5681,9 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
+        set::MlirIntegerSet, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -5085,7 +5692,9 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
+        set::MlirIntegerSet, pos::intptr_t
+    )::Bool
 end
 
 """
@@ -5094,7 +5703,9 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
+        operation::MlirOperation, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -5103,7 +5714,9 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
+        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -5126,8 +5739,30 @@ const MlirTypesCallback = Ptr{Nothing}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(
+    opName,
+    context,
+    location,
+    nOperands,
+    operands,
+    attributes,
+    nRegions,
+    regions,
+    callback,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
+        opName::MlirStringRef,
+        context::MlirContext,
+        location::MlirLocation,
+        nOperands::intptr_t,
+        operands::Ptr{MlirValue},
+        attributes::MlirAttribute,
+        nRegions::intptr_t,
+        regions::Ptr{MlirRegion},
+        callback::MlirTypesCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 function mlirRegisterTransformsPasses()
@@ -5221,4 +5856,3 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
-

--- a/src/API/14/libMLIR_h.jl
+++ b/src/API/14/libMLIR_h.jl
@@ -2,18 +2,6 @@ using CEnum
 
 const intptr_t = Clong
 
-"""
-    MlirStringRef
-
-| Field | Note                          |
-| :---- | :---------------------------- |
-| data  | Pointer to the first symbol.  |
-"""
-struct MlirStringRef
-    data::Cstring
-    length::Cint
-end
-
 function mlirStringRefCreate(str, length)
     @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
@@ -43,15 +31,6 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
-
-"""
-    MlirLogicalResult
-
-A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
-"""
-struct MlirLogicalResult
-    value::Int8
-end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -87,78 +66,6 @@ Creates a logical result representing a failure.
 """
 function mlirLogicalResultFailure()
     @ccall (MLIR_C_PATH[]).mlirLogicalResultFailure()::MlirLogicalResult
-end
-
-struct MlirContext
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialect
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialectRegistry
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOperation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPrintingFlags
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirBlock
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirRegion
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirSymbolTable
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirAttribute
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirIdentifier
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirLocation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirModule
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirType
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeID
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirValue
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirNamedAttribute
-
-Named MLIR attribute.
-
-A named attribute is essentially a (name, attribute) pair where the name is a string.
-"""
-struct MlirNamedAttribute
-    name::MlirIdentifier
-    attribute::MlirAttribute
 end
 
 """
@@ -483,22 +390,6 @@ Views the generic operation as a module. The returned module is null when the in
 """
 function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
-end
-
-struct MlirOperationState
-    name::MlirStringRef
-    location::MlirLocation
-    nResults::intptr_t
-    results::Ptr{MlirType}
-    nOperands::intptr_t
-    operands::Ptr{MlirValue}
-    nRegions::intptr_t
-    regions::Ptr{MlirRegion}
-    nSuccessors::intptr_t
-    successors::Ptr{MlirBlock}
-    nAttributes::intptr_t
-    attributes::Ptr{MlirNamedAttribute}
-    enableResultTypeInference::Bool
 end
 
 """
@@ -1549,10 +1440,6 @@ function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, user
     @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
-struct MlirAffineExpr
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirAffineExprGetContext(affineExpr)
 
@@ -1641,10 +1528,6 @@ Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
     @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
-end
-
-struct MlirAffineMap
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -3457,18 +3340,6 @@ function mlirFunctionTypeGetResult(type, pos)
     @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
-struct MlirPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirPassManager
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPassManager
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirPassManagerCreate(ctx)
 
@@ -3985,15 +3856,6 @@ function mlirIsGlobalDebugEnabled()
 end
 
 """
-    MlirDiagnostic
-
-An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
-"""
-struct MlirDiagnostic
-    ptr::Ptr{Cvoid}
-end
-
-"""
     MlirDiagnosticSeverity
 
 Severity of a diagnostic.
@@ -4086,10 +3948,6 @@ Emits an error at the given location through the diagnostics engine. Used for te
 """
 function mlirEmitError(location, message)
     @ccall (MLIR_C_PATH[]).mlirEmitError(location::MlirLocation, message::Cstring)::Cvoid
-end
-
-struct MlirDialectHandle
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -5005,10 +4863,6 @@ function mlirGetDialectHandle__tensor__()
     @ccall (MLIR_C_PATH[]).mlirGetDialectHandle__tensor__()::MlirDialectHandle
 end
 
-struct MlirExecutionEngine
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
 
@@ -5079,10 +4933,6 @@ Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
     @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
-end
-
-struct MlirIntegerSet
-    ptr::Ptr{Cvoid}
 end
 
 """

--- a/src/API/14/libMLIR_h.jl
+++ b/src/API/14/libMLIR_h.jl
@@ -2,13 +2,8 @@ using CEnum
 
 const intptr_t = Clong
 
-"""
-    mlirStringRefCreate(str, length)
-
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
-"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -26,9 +21,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -117,9 +110,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -128,9 +119,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -139,9 +128,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -150,9 +137,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -170,9 +155,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -181,9 +164,7 @@ end
 Set threading mode (must be set to false to print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -192,9 +173,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -221,9 +200,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -268,9 +245,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -279,9 +254,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -290,12 +263,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -304,9 +272,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -351,9 +317,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -371,9 +335,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -436,9 +398,7 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -447,33 +407,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -482,9 +432,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -511,9 +459,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -522,9 +468,7 @@ end
 Enable printing of debug information. If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -533,9 +477,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -544,9 +486,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -557,9 +497,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -676,9 +614,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -705,9 +641,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -716,9 +650,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -736,9 +668,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -756,9 +686,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -776,9 +704,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -787,9 +713,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -798,9 +722,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -809,9 +731,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -820,9 +740,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -831,12 +749,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -863,9 +776,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -874,9 +785,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -930,9 +839,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -941,9 +848,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -952,9 +857,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -963,9 +866,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -992,9 +893,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1075,9 +974,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1086,9 +983,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1097,9 +992,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1108,9 +1001,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1128,9 +1019,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1148,9 +1037,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1258,9 +1145,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1269,9 +1154,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1316,9 +1199,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1336,9 +1217,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1392,9 +1271,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1412,9 +1289,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1423,9 +1298,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1443,9 +1316,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1475,13 +1346,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -1535,9 +1401,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1546,9 +1410,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1557,9 +1419,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1568,9 +1428,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1579,12 +1437,7 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1602,9 +1455,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1622,9 +1473,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1642,9 +1491,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -1662,9 +1509,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -1673,9 +1518,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -1684,9 +1527,7 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
 end
 
 """
@@ -1695,9 +1536,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -1715,9 +1554,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1726,9 +1563,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1746,9 +1581,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1757,9 +1590,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1777,9 +1608,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -1806,9 +1635,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1826,9 +1653,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1846,9 +1671,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1866,9 +1689,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1886,9 +1707,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1906,9 +1725,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1917,9 +1734,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1955,9 +1770,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1984,9 +1797,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -1995,13 +1806,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2010,9 +1815,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2021,9 +1824,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2032,9 +1833,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2043,9 +1842,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2090,9 +1887,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2128,9 +1923,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2148,9 +1941,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2168,9 +1959,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2179,9 +1968,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2190,9 +1977,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2200,16 +1985,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2218,12 +1995,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2277,9 +2049,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2297,9 +2067,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2317,9 +2085,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2337,9 +2103,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2348,9 +2112,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2368,9 +2130,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2379,9 +2139,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2471,13 +2229,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2486,9 +2238,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2515,9 +2265,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2526,9 +2274,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2555,12 +2301,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2569,9 +2310,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2580,9 +2319,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2591,9 +2328,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -2602,9 +2337,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2622,9 +2355,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2696,9 +2427,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -2707,9 +2436,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -2744,24 +2471,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -2770,63 +2484,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -2835,69 +2529,47 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -2906,9 +2578,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -2917,9 +2587,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -2937,9 +2605,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -2951,51 +2617,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3004,75 +2654,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3108,9 +2734,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3119,9 +2743,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3130,9 +2752,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3159,9 +2779,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3170,9 +2788,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3442,9 +3058,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3453,9 +3067,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3491,9 +3103,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3502,13 +3112,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3535,9 +3139,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -3564,13 +3166,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3579,14 +3175,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3595,9 +3184,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3606,13 +3193,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3621,9 +3202,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3632,9 +3211,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3688,9 +3265,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3726,13 +3301,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3768,9 +3337,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -3806,9 +3373,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -3817,9 +3382,7 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
-        passManager::MlirPassManager, _module::MlirModule
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
 end
 
 """
@@ -3828,9 +3391,7 @@ end
 Enable print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -3839,9 +3400,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -3850,9 +3409,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -3861,9 +3418,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -3872,9 +3427,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -3883,9 +3436,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -3894,9 +3445,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -3905,9 +3454,7 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager, pipeline::MlirStringRef
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
 end
 
 function mlirRegisterConversionPasses()
@@ -4337,9 +3884,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4348,9 +3893,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -4359,9 +3902,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -4379,9 +3920,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -4390,12 +3929,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -4404,9 +3938,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -4424,9 +3956,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -4435,9 +3965,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -4446,9 +3974,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -4457,9 +3983,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -4571,9 +4095,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -4591,9 +4113,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -4602,12 +4122,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -4616,9 +4131,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -4934,9 +4447,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -4945,9 +4456,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5010,9 +4519,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -5021,9 +4528,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -5032,9 +4537,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -5043,9 +4546,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5063,9 +4564,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5083,9 +4582,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5102,16 +4599,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5128,18 +4617,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5183,28 +4662,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5213,9 +4672,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -5224,9 +4681,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -5235,9 +4690,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -5246,9 +4699,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -5275,9 +4726,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -5329,9 +4778,7 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -5339,17 +4786,8 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        numDimLevelTypes::intptr_t,
-        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimOrdering::MlirAffineMap,
-        pointerBitWidth::Cint,
-        indexBitWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
 end
 
 """
@@ -5358,9 +4796,7 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -5369,9 +4805,7 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5380,9 +4814,7 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -5391,9 +4823,7 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -5402,9 +4832,7 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -5441,9 +4869,7 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef})::MlirExecutionEngine
 end
 
 """
@@ -5470,9 +4896,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -5481,9 +4905,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5492,9 +4914,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5503,9 +4923,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5514,9 +4932,7 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
 end
 
 """
@@ -5552,9 +4968,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5572,9 +4986,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5582,17 +4994,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -5600,16 +5003,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5681,9 +5076,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -5692,9 +5085,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -5703,9 +5094,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5714,9 +5103,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5739,30 +5126,8 @@ const MlirTypesCallback = Ptr{Nothing}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 function mlirRegisterTransformsPasses()
@@ -5856,3 +5221,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/14/libMLIR_h.jl
+++ b/src/API/14/libMLIR_h.jl
@@ -1,16 +1,21 @@
 using CEnum
 
-const __darwin_intptr_t = Clong
-
-const intptr_t = __darwin_intptr_t
+const intptr_t = Clong
 
 """
-    mlirStringRefCreate(str, length)
+    MlirStringRef
 
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+| Field | Note                          |
+| :---- | :---------------------------- |
+| data  | Pointer to the first symbol.  |
 """
+struct MlirStringRef
+    data::Cstring
+    length::Cint
+end
+
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -28,9 +33,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -40,6 +43,15 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
+
+"""
+    MlirLogicalResult
+
+A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
+"""
+struct MlirLogicalResult
+    value::Int8
+end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -75,6 +87,78 @@ Creates a logical result representing a failure.
 """
 function mlirLogicalResultFailure()
     @ccall (MLIR_C_PATH[]).mlirLogicalResultFailure()::MlirLogicalResult
+end
+
+struct MlirContext
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialect
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialectRegistry
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOperation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPrintingFlags
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirBlock
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirRegion
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirSymbolTable
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirAttribute
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirIdentifier
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirLocation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirModule
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirType
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeID
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirValue
+    ptr::Ptr{Cvoid}
+end
+
+"""
+    MlirNamedAttribute
+
+Named MLIR attribute.
+
+A named attribute is essentially a (name, attribute) pair where the name is a string.
+"""
+struct MlirNamedAttribute
+    name::MlirIdentifier
+    attribute::MlirAttribute
 end
 
 """
@@ -119,9 +203,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -130,9 +212,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -141,9 +221,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -152,9 +230,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -172,9 +248,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -183,9 +257,7 @@ end
 Set threading mode (must be set to false to print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -194,9 +266,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -223,9 +293,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -270,9 +338,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -281,9 +347,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -292,12 +356,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -306,9 +365,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -353,9 +410,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -373,9 +428,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -432,15 +485,29 @@ function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
 end
 
+struct MlirOperationState
+    name::MlirStringRef
+    location::MlirLocation
+    nResults::intptr_t
+    results::Ptr{MlirType}
+    nOperands::intptr_t
+    operands::Ptr{MlirValue}
+    nRegions::intptr_t
+    regions::Ptr{MlirRegion}
+    nSuccessors::intptr_t
+    successors::Ptr{MlirBlock}
+    nAttributes::intptr_t
+    attributes::Ptr{MlirNamedAttribute}
+    enableResultTypeInference::Bool
+end
+
 """
     mlirOperationStateGet(name, loc)
 
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -449,33 +516,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -484,9 +541,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -513,9 +568,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -524,9 +577,7 @@ end
 Enable printing of debug information. If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -535,9 +586,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -546,9 +595,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -559,9 +606,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -678,9 +723,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -707,9 +750,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -718,9 +759,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -738,9 +777,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -758,9 +795,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -778,9 +813,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -789,9 +822,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -800,9 +831,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -811,9 +840,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -822,9 +849,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -833,12 +858,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -865,9 +885,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -876,9 +894,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -932,9 +948,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -943,9 +957,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -954,9 +966,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -965,9 +975,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -994,9 +1002,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1077,9 +1083,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1088,9 +1092,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1099,9 +1101,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1110,9 +1110,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1130,9 +1128,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1150,9 +1146,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1260,9 +1254,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1271,9 +1263,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1318,9 +1308,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1338,9 +1326,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1394,9 +1380,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1414,9 +1398,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1425,9 +1407,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1445,9 +1425,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1477,13 +1455,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -1537,9 +1510,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1548,9 +1519,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1559,9 +1528,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1570,9 +1537,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1581,12 +1546,11 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+end
+
+struct MlirAffineExpr
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1604,9 +1568,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1624,9 +1586,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1644,9 +1604,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -1664,9 +1622,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -1675,9 +1631,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -1686,9 +1640,11 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+end
+
+struct MlirAffineMap
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1697,9 +1653,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -1717,9 +1671,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1728,9 +1680,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1748,9 +1698,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1759,9 +1707,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1779,9 +1725,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -1808,9 +1752,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1828,9 +1770,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1848,9 +1788,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1868,9 +1806,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1888,9 +1824,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1908,9 +1842,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1919,9 +1851,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1957,9 +1887,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1986,9 +1914,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -1997,13 +1923,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2012,9 +1932,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2023,9 +1941,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2034,9 +1950,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2045,9 +1959,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2092,9 +2004,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2130,9 +2040,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2150,9 +2058,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2170,9 +2076,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2181,9 +2085,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2192,9 +2094,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2202,16 +2102,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2220,12 +2112,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2279,9 +2166,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2299,9 +2184,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2319,9 +2202,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2339,9 +2220,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2350,9 +2229,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2370,9 +2247,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2381,9 +2256,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2473,13 +2346,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2488,9 +2355,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2517,9 +2382,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2528,9 +2391,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2557,12 +2418,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2571,9 +2427,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2582,9 +2436,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2593,9 +2445,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -2604,9 +2454,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2624,9 +2472,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2698,9 +2544,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -2709,9 +2553,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -2746,24 +2588,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -2772,63 +2601,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -2837,69 +2646,47 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -2908,9 +2695,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -2919,9 +2704,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -2939,9 +2722,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -2953,51 +2734,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3006,75 +2771,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3110,9 +2851,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3121,9 +2860,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3132,9 +2869,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3161,9 +2896,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3172,9 +2905,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3444,9 +3175,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3455,9 +3184,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3493,9 +3220,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3504,13 +3229,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3537,9 +3256,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -3566,13 +3283,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3581,14 +3292,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3597,9 +3301,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3608,13 +3310,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3623,9 +3319,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3634,9 +3328,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3690,9 +3382,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3728,13 +3418,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3770,9 +3454,19 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
+end
+
+struct MlirPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirPassManager
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPassManager
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -3808,9 +3502,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -3819,9 +3511,7 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
-        passManager::MlirPassManager, _module::MlirModule
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
 end
 
 """
@@ -3830,9 +3520,7 @@ end
 Enable print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -3841,9 +3529,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -3852,9 +3538,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -3863,9 +3547,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -3874,9 +3556,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -3885,9 +3565,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -3896,9 +3574,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -3907,9 +3583,7 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager, pipeline::MlirStringRef
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
 end
 
 function mlirRegisterConversionPasses()
@@ -4311,6 +3985,15 @@ function mlirIsGlobalDebugEnabled()
 end
 
 """
+    MlirDiagnostic
+
+An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
+"""
+struct MlirDiagnostic
+    ptr::Ptr{Cvoid}
+end
+
+"""
     MlirDiagnosticSeverity
 
 Severity of a diagnostic.
@@ -4339,9 +4022,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4350,9 +4031,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -4361,9 +4040,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -4381,9 +4058,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -4392,12 +4067,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -4406,9 +4076,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -4420,15 +4088,17 @@ function mlirEmitError(location, message)
     @ccall (MLIR_C_PATH[]).mlirEmitError(location::MlirLocation, message::Cstring)::Cvoid
 end
 
+struct MlirDialectHandle
+    ptr::Ptr{Cvoid}
+end
+
 """
     mlirDialectHandleGetNamespace(arg1)
 
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -4437,9 +4107,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -4448,9 +4116,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -4459,9 +4125,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -4573,9 +4237,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -4593,9 +4255,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -4604,12 +4264,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -4618,9 +4273,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -4936,9 +4589,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -4947,9 +4598,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5012,9 +4661,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -5023,9 +4670,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -5034,9 +4679,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -5045,9 +4688,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5065,9 +4706,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5085,9 +4724,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5104,16 +4741,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5130,18 +4759,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5185,28 +4804,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5215,9 +4814,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -5226,9 +4823,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -5237,9 +4832,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -5248,9 +4841,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -5277,9 +4868,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -5331,9 +4920,7 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -5341,17 +4928,8 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        numDimLevelTypes::intptr_t,
-        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimOrdering::MlirAffineMap,
-        pointerBitWidth::Cint,
-        indexBitWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
 end
 
 """
@@ -5360,9 +4938,7 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -5371,9 +4947,7 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5382,9 +4956,7 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -5393,9 +4965,7 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -5404,9 +4974,7 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -5437,15 +5005,17 @@ function mlirGetDialectHandle__tensor__()
     @ccall (MLIR_C_PATH[]).mlirGetDialectHandle__tensor__()::MlirDialectHandle
 end
 
+struct MlirExecutionEngine
+    ptr::Ptr{Cvoid}
+end
+
 """
     mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
 
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef})::MlirExecutionEngine
 end
 
 """
@@ -5472,9 +5042,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -5483,9 +5051,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5494,9 +5060,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5505,9 +5069,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5516,9 +5078,11 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+end
+
+struct MlirIntegerSet
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -5554,9 +5118,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5574,9 +5136,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5584,17 +5144,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -5602,16 +5153,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5683,9 +5226,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -5694,9 +5235,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -5705,9 +5244,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5716,9 +5253,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5741,30 +5276,8 @@ const MlirTypesCallback = Ptr{Nothing}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 function mlirRegisterTransformsPasses()
@@ -5858,3 +5371,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/15/libMLIR_h.jl
+++ b/src/API/15/libMLIR_h.jl
@@ -1,16 +1,33 @@
 using CEnum
 
-const __darwin_intptr_t = Clong
+const intptr_t = Clong
 
-const intptr_t = __darwin_intptr_t
+struct MlirDialectHandle
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeID
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeIDAllocator
+    ptr::Ptr{Cvoid}
+end
 
 """
-    mlirStringRefCreate(str, length)
+    MlirStringRef
 
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+| Field | Note                          |
+| :---- | :---------------------------- |
+| data  | Pointer to the first symbol.  |
 """
+struct MlirStringRef
+    data::Cstring
+    length::Cint
+end
+
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -28,9 +45,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -40,6 +55,15 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
+
+"""
+    MlirLogicalResult
+
+A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
+"""
+struct MlirLogicalResult
+    value::Int8
+end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -104,13 +128,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -137,9 +156,75 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
-        allocator::MlirTypeIDAllocator
-    )::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
+end
+
+struct MlirContext
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialect
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialectRegistry
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOperation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPrintingFlags
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirBlock
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirRegion
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirSymbolTable
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirAttribute
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirIdentifier
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirLocation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirModule
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirType
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirValue
+    ptr::Ptr{Cvoid}
+end
+
+"""
+    MlirNamedAttribute
+
+Named MLIR attribute.
+
+A named attribute is essentially a (name, attribute) pair where the name is a string.
+"""
+struct MlirNamedAttribute
+    name::MlirIdentifier
+    attribute::MlirAttribute
 end
 
 """
@@ -184,9 +269,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -195,9 +278,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -206,9 +287,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -217,9 +296,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -237,9 +314,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -248,9 +323,7 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -268,9 +341,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -297,9 +368,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -317,9 +386,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -328,9 +395,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -339,9 +404,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -350,9 +413,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -388,9 +449,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -399,9 +458,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -410,12 +467,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -424,9 +476,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -471,9 +521,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -491,9 +539,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -550,15 +596,29 @@ function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
 end
 
+struct MlirOperationState
+    name::MlirStringRef
+    location::MlirLocation
+    nResults::intptr_t
+    results::Ptr{MlirType}
+    nOperands::intptr_t
+    operands::Ptr{MlirValue}
+    nRegions::intptr_t
+    regions::Ptr{MlirRegion}
+    nSuccessors::intptr_t
+    successors::Ptr{MlirBlock}
+    nAttributes::intptr_t
+    attributes::Ptr{MlirNamedAttribute}
+    enableResultTypeInference::Bool
+end
+
 """
     mlirOperationStateGet(name, loc)
 
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -567,33 +627,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -602,9 +652,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -631,9 +679,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -642,9 +688,7 @@ end
 Enable printing of debug information. If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -653,9 +697,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -664,9 +706,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -677,9 +717,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -796,9 +834,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -825,9 +861,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -836,9 +870,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -856,9 +888,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -876,9 +906,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -896,9 +924,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -907,9 +933,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -918,9 +942,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -929,9 +951,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -940,9 +960,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -951,12 +969,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -983,9 +996,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -994,9 +1005,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1050,9 +1059,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1061,9 +1068,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1072,9 +1077,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1083,9 +1086,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1112,9 +1113,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1204,9 +1203,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1215,9 +1212,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1226,9 +1221,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1237,9 +1230,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1257,9 +1248,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1277,9 +1266,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1387,9 +1374,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1398,9 +1383,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1445,9 +1428,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1465,9 +1446,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1521,9 +1500,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1541,9 +1518,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1552,9 +1527,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1572,9 +1545,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1637,9 +1608,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1648,9 +1617,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1659,9 +1626,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1670,9 +1635,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1681,12 +1644,11 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+end
+
+struct MlirAffineExpr
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1704,9 +1666,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1724,9 +1684,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1744,9 +1702,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -1764,9 +1720,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -1775,9 +1729,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -1786,9 +1738,11 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+end
+
+struct MlirAffineMap
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1797,9 +1751,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -1817,9 +1769,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1828,9 +1778,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1848,9 +1796,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1859,9 +1805,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1879,9 +1823,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -1908,9 +1850,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1928,9 +1868,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1948,9 +1886,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1968,9 +1904,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1988,9 +1922,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2008,9 +1940,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2019,9 +1949,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2057,9 +1985,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2086,9 +2012,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2097,13 +2021,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2112,9 +2030,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2123,9 +2039,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2134,9 +2048,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2145,9 +2057,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2192,9 +2102,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2230,9 +2138,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2250,9 +2156,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2270,9 +2174,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2281,9 +2183,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2292,9 +2192,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2302,16 +2200,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2320,12 +2210,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2379,9 +2264,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2399,9 +2282,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2419,9 +2300,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2439,9 +2318,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2450,9 +2327,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2470,9 +2345,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2481,9 +2354,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2591,13 +2462,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2606,9 +2471,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2635,9 +2498,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2646,9 +2507,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2675,12 +2534,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2689,9 +2543,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2700,9 +2552,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2711,9 +2561,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -2722,9 +2570,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2742,9 +2588,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2816,9 +2660,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -2827,9 +2669,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -2864,24 +2704,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -2890,63 +2717,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -2955,81 +2762,55 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 """
@@ -3038,9 +2819,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -3049,9 +2828,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -3069,9 +2846,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3083,51 +2858,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3136,75 +2895,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3240,9 +2975,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3251,9 +2984,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3262,9 +2993,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3291,9 +3020,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3302,9 +3029,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3592,9 +3317,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3603,9 +3326,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3641,9 +3362,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3652,13 +3371,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3685,9 +3398,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -3714,13 +3425,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3729,14 +3434,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3745,9 +3443,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3756,13 +3452,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3771,9 +3461,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3782,9 +3470,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3838,9 +3524,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3876,13 +3560,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3918,9 +3596,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -3938,9 +3614,7 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
-        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
 end
 
 """
@@ -3959,6 +3633,22 @@ Returns the raw data as a string reference. The data remains live as long as the
 """
 function mlirOpaqueTypeGetData(type)
     @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGetData(type::MlirType)::MlirStringRef
+end
+
+struct MlirPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirExternalPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirPassManager
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPassManager
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -3994,9 +3684,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -4005,9 +3693,7 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
-        passManager::MlirPassManager, _module::MlirModule
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
 end
 
 """
@@ -4016,9 +3702,7 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -4027,9 +3711,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -4038,9 +3720,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4049,9 +3729,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4060,9 +3738,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4071,9 +3747,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4082,9 +3756,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4093,9 +3765,28 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager, pipeline::MlirStringRef
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
+end
+
+"""
+    MlirExternalPassCallbacks
+
+Structure of external [`MlirPass`](@ref) callbacks. All callbacks are required to be set unless otherwise specified.
+
+| Field      | Note                                                                                                                                                                                              |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| construct  | This callback is called from the pass is created. This is analogous to a C++ pass constructor.                                                                                                    |
+| destruct   | This callback is called when the pass is destroyed This is analogous to a C++ pass destructor.                                                                                                    |
+| initialize | This callback is optional. The callback is called before the pass is run, allowing a chance to initialize any complex state necessary for running the pass. See Pass::initialize(MLIRContext *).  |
+| clone      | This callback is called when the pass is cloned. See Pass::clonePass().                                                                                                                           |
+| run        | This callback is called when the pass is run. See Pass::runOnOperation().                                                                                                                         |
+"""
+struct MlirExternalPassCallbacks
+    construct::Ptr{Cvoid}
+    destruct::Ptr{Cvoid}
+    initialize::Ptr{Cvoid}
+    clone::Ptr{Cvoid}
+    run::Ptr{Cvoid}
 end
 
 """
@@ -4103,28 +3794,8 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(
-    passID,
-    name,
-    argument,
-    description,
-    opName,
-    nDependentDialects,
-    dependentDialects,
-    callbacks,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
-        passID::MlirTypeID,
-        name::MlirStringRef,
-        argument::MlirStringRef,
-        description::MlirStringRef,
-        opName::MlirStringRef,
-        nDependentDialects::intptr_t,
-        dependentDialects::Ptr{MlirDialectHandle},
-        callbacks::MlirExternalPassCallbacks,
-        userData::Ptr{Cvoid},
-    )::MlirPass
+function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
 end
 
 """
@@ -4591,6 +4262,15 @@ function mlirIsGlobalDebugEnabled()
 end
 
 """
+    MlirDiagnostic
+
+An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
+"""
+struct MlirDiagnostic
+    ptr::Ptr{Cvoid}
+end
+
+"""
     MlirDiagnosticSeverity
 
 Severity of a diagnostic.
@@ -4619,9 +4299,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4630,9 +4308,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -4641,9 +4317,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -4661,9 +4335,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -4672,12 +4344,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -4686,9 +4353,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -4806,9 +4471,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -4826,9 +4489,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -4837,12 +4498,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -4851,9 +4507,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -5145,9 +4799,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5156,9 +4808,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5221,9 +4871,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -5232,9 +4880,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -5243,9 +4889,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -5254,9 +4898,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5274,9 +4916,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5294,9 +4934,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5313,16 +4951,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5339,18 +4969,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5394,28 +5014,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5424,9 +5024,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -5435,9 +5033,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -5446,9 +5042,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -5457,9 +5051,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -5486,9 +5078,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -5540,9 +5130,7 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -5550,17 +5138,8 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        numDimLevelTypes::intptr_t,
-        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimOrdering::MlirAffineMap,
-        pointerBitWidth::Cint,
-        indexBitWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
 end
 
 """
@@ -5569,9 +5148,7 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -5580,9 +5157,7 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5591,9 +5166,7 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -5602,9 +5175,7 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -5613,9 +5184,7 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -5642,15 +5211,17 @@ function mlirGetDialectHandle__tensor__()
     @ccall (MLIR_C_PATH[]).mlirGetDialectHandle__tensor__()::MlirDialectHandle
 end
 
+struct MlirExecutionEngine
+    ptr::Ptr{Cvoid}
+end
+
 """
     mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
 
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef})::MlirExecutionEngine
 end
 
 """
@@ -5677,9 +5248,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -5688,9 +5257,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5699,9 +5266,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5710,9 +5275,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5721,9 +5284,11 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+end
+
+struct MlirIntegerSet
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -5759,9 +5324,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5779,9 +5342,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5789,17 +5350,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -5807,16 +5359,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5888,9 +5432,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -5899,9 +5441,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -5910,9 +5450,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5921,9 +5459,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5946,30 +5482,8 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -6106,3 +5620,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/15/libMLIR_h.jl
+++ b/src/API/15/libMLIR_h.jl
@@ -2,8 +2,13 @@ using CEnum
 
 const intptr_t = Clong
 
+"""
+    mlirStringRefCreate(str, length)
+
+Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
 end
 
 """
@@ -21,7 +26,9 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
+        string::MlirStringRef, other::MlirStringRef
+    )::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -95,8 +102,13 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
+"""
+    mlirTypeIDHashValue(typeID)
+
+Returns the hash value of the type id.
+"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
 end
 
 """
@@ -123,7 +135,9 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
+        allocator::MlirTypeIDAllocator
+    )::MlirTypeID
 end
 
 """
@@ -168,7 +182,9 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
+        context::MlirContext, allow::Bool
+    )::Cvoid
 end
 
 """
@@ -177,7 +193,9 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
+        context::MlirContext
+    )::Bool
 end
 
 """
@@ -186,7 +204,9 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
+        context::MlirContext
+    )::intptr_t
 end
 
 """
@@ -195,7 +215,9 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
+        ctx::MlirContext, registry::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -213,7 +235,9 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
+        context::MlirContext, name::MlirStringRef
+    )::MlirDialect
 end
 
 """
@@ -222,7 +246,9 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
+        context::MlirContext, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -240,7 +266,9 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
+        context::MlirContext, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -267,7 +295,9 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
+        dialect1::MlirDialect, dialect2::MlirDialect
+    )::Bool
 end
 
 """
@@ -285,7 +315,9 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
+        arg1::MlirDialectHandle
+    )::MlirStringRef
 end
 
 """
@@ -294,7 +326,9 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
+        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -303,7 +337,9 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::Cvoid
 end
 
 """
@@ -312,7 +348,9 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::MlirDialect
 end
 
 """
@@ -348,7 +386,9 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
+        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
+    )::MlirLocation
 end
 
 """
@@ -357,7 +397,9 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
+        callee::MlirLocation, caller::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -366,7 +408,12 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
+        ctx::MlirContext,
+        nLocations::intptr_t,
+        locations::Ptr{MlirLocation},
+        metadata::MlirAttribute,
+    )::MlirLocation
 end
 
 """
@@ -375,7 +422,9 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
+        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -420,7 +469,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
+        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -438,7 +489,9 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
+        context::MlirContext, _module::MlirStringRef
+    )::MlirModule
 end
 
 """
@@ -501,7 +554,9 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
+        name::MlirStringRef, loc::MlirLocation
+    )::MlirOperationState
 end
 
 """
@@ -510,23 +565,33 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
+        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
+        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
+        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
+    )::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
+        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
+    )::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
+        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
+    )::Cvoid
 end
 
 """
@@ -535,7 +600,9 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
+        state::Ptr{MlirOperationState}
+    )::Cvoid
 end
 
 """
@@ -562,7 +629,9 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
+        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
+    )::Cvoid
 end
 
 """
@@ -571,7 +640,9 @@ end
 Enable printing of debug information. If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, prettyForm::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
+        flags::MlirOpPrintingFlags, prettyForm::Bool
+    )::Cvoid
 end
 
 """
@@ -580,7 +651,9 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -589,7 +662,9 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -600,7 +675,9 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
+        state::Ptr{MlirOperationState}
+    )::MlirOperation
 end
 
 """
@@ -717,7 +794,9 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
+        op::MlirOperation, pos::intptr_t
+    )::MlirRegion
 end
 
 """
@@ -744,7 +823,9 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -753,7 +834,9 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
+        op::MlirOperation, pos::intptr_t, newValue::MlirValue
+    )::Cvoid
 end
 
 """
@@ -771,7 +854,9 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -789,7 +874,9 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
+        op::MlirOperation, pos::intptr_t
+    )::MlirBlock
 end
 
 """
@@ -807,7 +894,9 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
+        op::MlirOperation, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -816,7 +905,9 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -825,7 +916,9 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
+        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
+    )::Cvoid
 end
 
 """
@@ -834,7 +927,9 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -843,7 +938,9 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
+        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -852,7 +949,12 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
+        op::MlirOperation,
+        flags::MlirOpPrintingFlags,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -879,7 +981,9 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -888,7 +992,9 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -942,7 +1048,9 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
+        region::MlirRegion, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -951,7 +1059,9 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
+        region::MlirRegion, pos::intptr_t, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -960,7 +1070,9 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -969,7 +1081,9 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -996,7 +1110,9 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
+        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
+    )::MlirBlock
 end
 
 """
@@ -1086,7 +1202,9 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
+        block::MlirBlock, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1095,7 +1213,9 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
+        block::MlirBlock, pos::intptr_t, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1104,7 +1224,9 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1113,7 +1235,9 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1131,7 +1255,9 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
+        block::MlirBlock, type::MlirType, loc::MlirLocation
+    )::MlirValue
 end
 
 """
@@ -1149,7 +1275,9 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
+        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1257,7 +1385,9 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(
+        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1266,7 +1396,9 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
+        context::MlirContext, type::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -1311,7 +1443,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(
+        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1329,7 +1463,9 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
+        context::MlirContext, attr::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -1383,7 +1519,9 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
+        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1401,7 +1539,9 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
+        name::MlirIdentifier, attr::MlirAttribute
+    )::MlirNamedAttribute
 end
 
 """
@@ -1410,7 +1550,9 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
+        context::MlirContext, str::MlirStringRef
+    )::MlirIdentifier
 end
 
 """
@@ -1428,7 +1570,9 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
+        ident::MlirIdentifier, other::MlirIdentifier
+    )::Bool
 end
 
 """
@@ -1491,7 +1635,9 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
+        symbolTable::MlirSymbolTable, name::MlirStringRef
+    )::MlirOperation
 end
 
 """
@@ -1500,7 +1646,9 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::MlirAttribute
 end
 
 """
@@ -1509,7 +1657,9 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1518,7 +1668,9 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
+        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
+    )::MlirLogicalResult
 end
 
 """
@@ -1527,7 +1679,12 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
+        from::MlirOperation,
+        allSymUsesVisible::Bool,
+        callback::Ptr{Cvoid},
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -1545,7 +1702,9 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1563,7 +1722,9 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
+        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1581,7 +1742,9 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
+        affineExpr::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1599,7 +1762,9 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
+        affineExpr::MlirAffineExpr
+    )::Int64
 end
 
 """
@@ -1608,7 +1773,9 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
+        affineExpr::MlirAffineExpr, factor::Int64
+    )::Bool
 end
 
 """
@@ -1617,7 +1784,9 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
+        affineExpr::MlirAffineExpr, position::intptr_t
+    )::Bool
 end
 
 """
@@ -1626,7 +1795,9 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
+        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
+    )::MlirAffineExpr
 end
 
 """
@@ -1644,7 +1815,9 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1653,7 +1826,9 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1671,7 +1846,9 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1680,7 +1857,9 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1698,7 +1877,9 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
+        ctx::MlirContext, constant::Int64
+    )::MlirAffineExpr
 end
 
 """
@@ -1725,7 +1906,9 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1743,7 +1926,9 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1761,7 +1946,9 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1779,7 +1966,9 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1797,7 +1986,9 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1815,7 +2006,9 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1824,7 +2017,9 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1860,7 +2055,9 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
+        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1887,7 +2084,9 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
+        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1896,7 +2095,13 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
+        ctx::MlirContext,
+        dimCount::intptr_t,
+        symbolCount::intptr_t,
+        nAffineExprs::intptr_t,
+        affineExprs::Ptr{MlirAffineExpr},
+    )::MlirAffineMap
 end
 
 """
@@ -1905,7 +2110,9 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
+        ctx::MlirContext, val::Int64
+    )::MlirAffineMap
 end
 
 """
@@ -1914,7 +2121,9 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
+        ctx::MlirContext, numDims::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1923,7 +2132,9 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
+        ctx::MlirContext, dims::intptr_t, results::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1932,7 +2143,9 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
+        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
+    )::MlirAffineMap
 end
 
 """
@@ -1977,7 +2190,9 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
+        affineMap::MlirAffineMap
+    )::Int64
 end
 
 """
@@ -2013,7 +2228,9 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
+        affineMap::MlirAffineMap, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -2031,7 +2248,9 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
+        affineMap::MlirAffineMap
+    )::Bool
 end
 
 """
@@ -2049,7 +2268,9 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
+        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
+    )::MlirAffineMap
 end
 
 """
@@ -2058,7 +2279,9 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2067,7 +2290,9 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2075,8 +2300,16 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
+function mlirAffineMapReplace(
+    affineMap, expression, replacement, numResultDims, numResultSyms
+)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
+        affineMap::MlirAffineMap,
+        expression::MlirAffineExpr,
+        replacement::MlirAffineExpr,
+        numResultDims::intptr_t,
+        numResultSyms::intptr_t,
+    )::MlirAffineMap
 end
 
 """
@@ -2085,7 +2318,12 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
+        affineMaps::Ptr{MlirAffineMap},
+        size::intptr_t,
+        result::Ptr{Cvoid},
+        populateResult::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -2139,7 +2377,9 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2157,7 +2397,9 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2175,7 +2417,9 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2193,7 +2437,9 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -2202,7 +2448,9 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
+        attr::MlirAttribute, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2220,7 +2468,9 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
+        ctx::MlirContext, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2229,7 +2479,9 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
+        loc::MlirLocation, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2337,7 +2589,13 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
+        ctx::MlirContext,
+        dialectNamespace::MlirStringRef,
+        dataLength::intptr_t,
+        data::Cstring,
+        type::MlirType,
+    )::MlirAttribute
 end
 
 """
@@ -2346,7 +2604,9 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2373,7 +2633,9 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
+        ctx::MlirContext, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2382,7 +2644,9 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
+        type::MlirType, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2409,7 +2673,12 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
+        ctx::MlirContext,
+        symbol::MlirStringRef,
+        numReferences::intptr_t,
+        references::Ptr{MlirAttribute},
+    )::MlirAttribute
 end
 
 """
@@ -2418,7 +2687,9 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2427,7 +2698,9 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2436,7 +2709,9 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -2445,7 +2720,9 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2463,7 +2740,9 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
+        ctx::MlirContext, symbol::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2535,7 +2814,9 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 """
@@ -2544,7 +2825,9 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::Bool
 end
 
 """
@@ -2579,11 +2862,24 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
+"""
+    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
+
+Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
+
+The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
+
+A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
+"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
+        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
+    )::MlirAttribute
 end
 
 """
@@ -2592,43 +2888,63 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
+        shapedType::MlirType, element::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
+        shapedType::MlirType, element::Bool
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
+        shapedType::MlirType, element::UInt8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
+        shapedType::MlirType, element::Int8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
+        shapedType::MlirType, element::UInt32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
+        shapedType::MlirType, element::Int32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
+        shapedType::MlirType, element::UInt64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
+        shapedType::MlirType, element::Int64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
+        shapedType::MlirType, element::Cfloat
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
+        shapedType::MlirType, element::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2637,55 +2953,81 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 """
@@ -2694,7 +3036,9 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
+        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
+    )::MlirAttribute
 end
 
 """
@@ -2703,7 +3047,9 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
+        attr::MlirAttribute, shapedType::MlirType
+    )::MlirAttribute
 end
 
 """
@@ -2721,7 +3067,9 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -2733,35 +3081,51 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
+        attr::MlirAttribute
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
+        attr::MlirAttribute
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
+        attr::MlirAttribute
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
+        attr::MlirAttribute
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
+        attr::MlirAttribute
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
+        attr::MlirAttribute
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
+        attr::MlirAttribute
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2770,51 +3134,75 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirStringRef
 end
 
 """
@@ -2850,7 +3238,9 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
+        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -2859,7 +3249,9 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -2868,7 +3260,9 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -2895,7 +3289,9 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -2904,7 +3300,9 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -3192,7 +3590,9 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3201,7 +3601,9 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
+        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3237,7 +3639,9 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3246,7 +3650,13 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
+        loc::MlirLocation,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        elementType::MlirType,
+        encoding::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3273,7 +3683,9 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3300,7 +3712,13 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3309,7 +3727,14 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3318,7 +3743,9 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
+        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3327,7 +3754,13 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3336,7 +3769,9 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
+        elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3345,7 +3780,9 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3399,7 +3836,9 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
+    )::MlirType
 end
 
 """
@@ -3435,7 +3874,13 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
+        ctx::MlirContext,
+        numInputs::intptr_t,
+        inputs::Ptr{MlirType},
+        numResults::intptr_t,
+        results::Ptr{MlirType},
+    )::MlirType
 end
 
 """
@@ -3471,7 +3916,9 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
+        type::MlirType, pos::intptr_t
+    )::MlirType
 end
 
 """
@@ -3489,7 +3936,9 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
+        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -3543,7 +3992,9 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
+        passManager::MlirPassManager
+    )::MlirOpPassManager
 end
 
 """
@@ -3552,7 +4003,9 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
+        passManager::MlirPassManager, _module::MlirModule
+    )::MlirLogicalResult
 end
 
 """
@@ -3561,7 +4014,9 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
+        passManager::MlirPassManager
+    )::Cvoid
 end
 
 """
@@ -3570,7 +4025,9 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
+        passManager::MlirPassManager, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -3579,7 +4036,9 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
+        passManager::MlirPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -3588,7 +4047,9 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
+        passManager::MlirOpPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -3597,7 +4058,9 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
+        passManager::MlirPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -3606,7 +4069,9 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
+        passManager::MlirOpPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -3615,7 +4080,9 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
+        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -3624,7 +4091,9 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
+        passManager::MlirOpPassManager, pipeline::MlirStringRef
+    )::MlirLogicalResult
 end
 
 """
@@ -3632,8 +4101,28 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
+function mlirCreateExternalPass(
+    passID,
+    name,
+    argument,
+    description,
+    opName,
+    nDependentDialects,
+    dependentDialects,
+    callbacks,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
+        passID::MlirTypeID,
+        name::MlirStringRef,
+        argument::MlirStringRef,
+        description::MlirStringRef,
+        opName::MlirStringRef,
+        nDependentDialects::intptr_t,
+        dependentDialects::Ptr{MlirDialectHandle},
+        callbacks::MlirExternalPassCallbacks,
+        userData::Ptr{Cvoid},
+    )::MlirPass
 end
 
 """
@@ -4128,7 +4617,9 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
+        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -4137,7 +4628,9 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
+        diagnostic::MlirDiagnostic
+    )::MlirLocation
 end
 
 """
@@ -4146,7 +4639,9 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
+        diagnostic::MlirDiagnostic
+    )::MlirDiagnosticSeverity
 end
 
 """
@@ -4164,7 +4659,9 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
+        diagnostic::MlirDiagnostic, pos::intptr_t
+    )::MlirDiagnostic
 end
 
 """
@@ -4173,7 +4670,12 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
+        context::MlirContext,
+        handler::MlirDiagnosticHandler,
+        userData::Ptr{Cvoid},
+        deleteUserData::Ptr{Cvoid},
+    )::MlirDiagnosticHandlerID
 end
 
 """
@@ -4182,7 +4684,9 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
+        context::MlirContext, id::MlirDiagnosticHandlerID
+    )::Cvoid
 end
 
 """
@@ -4300,7 +4804,9 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
+        pointee::MlirType, addressSpace::Cuint
+    )::MlirType
 end
 
 """
@@ -4318,7 +4824,9 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
+        elementType::MlirType, numElements::Cuint
+    )::MlirType
 end
 
 """
@@ -4327,7 +4835,12 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
+        resultType::MlirType,
+        nArgumentTypes::intptr_t,
+        argumentTypes::Ptr{MlirType},
+        isVarArg::Bool,
+    )::MlirType
 end
 
 """
@@ -4336,7 +4849,9 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
+        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
+    )::MlirType
 end
 
 """
@@ -4628,7 +5143,9 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -4637,7 +5154,9 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -4700,7 +5219,9 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
+        type::MlirType
+    )::Cuint
 end
 
 """
@@ -4709,7 +5230,9 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
+        type::MlirType, candidate::MlirType
+    )::Bool
 end
 
 """
@@ -4718,7 +5241,9 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
+        type::MlirType
+    )::MlirType
 end
 
 """
@@ -4727,7 +5252,9 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4745,7 +5272,9 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4763,7 +5292,9 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4780,8 +5311,16 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirAnyQuantizedTypeGet(
+    flags, storageType, expressedType, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -4798,8 +5337,18 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedTypeGet(
+    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        scale::Cdouble,
+        zeroPoint::Int64,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -4843,8 +5392,28 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(
+    flags,
+    storageType,
+    expressedType,
+    nDims,
+    scales,
+    zeroPoints,
+    quantizedDimension,
+    storageTypeMin,
+    storageTypeMax,
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        nDims::intptr_t,
+        scales::Ptr{Cdouble},
+        zeroPoints::Ptr{Int64},
+        quantizedDimension::Int32,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -4853,7 +5422,9 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
+        type::MlirType
+    )::intptr_t
 end
 
 """
@@ -4862,7 +5433,9 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
+        type::MlirType, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -4871,7 +5444,9 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
+        type::MlirType, pos::intptr_t
+    )::Int64
 end
 
 """
@@ -4880,7 +5455,9 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
+        type::MlirType
+    )::Int32
 end
 
 """
@@ -4907,7 +5484,9 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
+        expressedType::MlirType, min::Cdouble, max::Cdouble
+    )::MlirType
 end
 
 """
@@ -4959,7 +5538,9 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
+        attr::MlirAttribute
+    )::Bool
 end
 
 """
@@ -4967,8 +5548,17 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(
+    ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth
+)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
+        ctx::MlirContext,
+        numDimLevelTypes::intptr_t,
+        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
+        dimOrdering::MlirAffineMap,
+        pointerBitWidth::Cint,
+        indexBitWidth::Cint,
+    )::MlirAttribute
 end
 
 """
@@ -4977,7 +5567,9 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -4986,7 +5578,9 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirSparseTensorDimLevelType
 end
 
 """
@@ -4995,7 +5589,9 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
+        attr::MlirAttribute
+    )::MlirAffineMap
 end
 
 """
@@ -5004,7 +5600,9 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 """
@@ -5013,7 +5611,9 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -5046,7 +5646,9 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef})::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
+        op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}
+    )::MlirExecutionEngine
 end
 
 """
@@ -5073,7 +5675,9 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
+        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
+    )::MlirLogicalResult
 end
 
 """
@@ -5082,7 +5686,9 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -5091,7 +5697,9 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -5100,7 +5708,9 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
+        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -5109,7 +5719,9 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
+        jit::MlirExecutionEngine, fileName::MlirStringRef
+    )::Cvoid
 end
 
 """
@@ -5145,7 +5757,9 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
+        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -5163,7 +5777,9 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
+        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
+    )::MlirIntegerSet
 end
 
 """
@@ -5171,8 +5787,17 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
+function mlirIntegerSetGet(
+    context, numDims, numSymbols, numConstraints, constraints, eqFlags
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
+        context::MlirContext,
+        numDims::intptr_t,
+        numSymbols::intptr_t,
+        numConstraints::intptr_t,
+        constraints::Ptr{MlirAffineExpr},
+        eqFlags::Ptr{Bool},
+    )::MlirIntegerSet
 end
 
 """
@@ -5180,8 +5805,16 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
+function mlirIntegerSetReplaceGet(
+    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
+        set::MlirIntegerSet,
+        dimReplacements::Ptr{MlirAffineExpr},
+        symbolReplacements::Ptr{MlirAffineExpr},
+        numResultDims::intptr_t,
+        numResultSymbols::intptr_t,
+    )::MlirIntegerSet
 end
 
 """
@@ -5253,7 +5886,9 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
+        set::MlirIntegerSet, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -5262,7 +5897,9 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
+        set::MlirIntegerSet, pos::intptr_t
+    )::Bool
 end
 
 """
@@ -5271,7 +5908,9 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
+        operation::MlirOperation, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -5280,7 +5919,9 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
+        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -5303,8 +5944,30 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(
+    opName,
+    context,
+    location,
+    nOperands,
+    operands,
+    attributes,
+    nRegions,
+    regions,
+    callback,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
+        opName::MlirStringRef,
+        context::MlirContext,
+        location::MlirLocation,
+        nOperands::intptr_t,
+        operands::Ptr{MlirValue},
+        attributes::MlirAttribute,
+        nRegions::intptr_t,
+        regions::Ptr{MlirRegion},
+        callback::MlirTypesCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -5441,4 +6104,3 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
-

--- a/src/API/15/libMLIR_h.jl
+++ b/src/API/15/libMLIR_h.jl
@@ -2,13 +2,8 @@ using CEnum
 
 const intptr_t = Clong
 
-"""
-    mlirStringRefCreate(str, length)
-
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
-"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -26,9 +21,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -102,13 +95,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -135,9 +123,7 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
-        allocator::MlirTypeIDAllocator
-    )::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
 end
 
 """
@@ -182,9 +168,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -193,9 +177,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -204,9 +186,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -215,9 +195,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -235,9 +213,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -246,9 +222,7 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -266,9 +240,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -295,9 +267,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -315,9 +285,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -326,9 +294,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -337,9 +303,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -348,9 +312,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -386,9 +348,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -397,9 +357,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -408,12 +366,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -422,9 +375,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -469,9 +420,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -489,9 +438,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -554,9 +501,7 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -565,33 +510,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -600,9 +535,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -629,9 +562,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -640,9 +571,7 @@ end
 Enable printing of debug information. If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -651,9 +580,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -662,9 +589,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -675,9 +600,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -794,9 +717,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -823,9 +744,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -834,9 +753,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -854,9 +771,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -874,9 +789,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -894,9 +807,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -905,9 +816,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -916,9 +825,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -927,9 +834,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -938,9 +843,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -949,12 +852,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -981,9 +879,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -992,9 +888,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1048,9 +942,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1059,9 +951,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1070,9 +960,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1081,9 +969,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1110,9 +996,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1202,9 +1086,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1213,9 +1095,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1224,9 +1104,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1235,9 +1113,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1255,9 +1131,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1275,9 +1149,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1385,9 +1257,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1396,9 +1266,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1443,9 +1311,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1463,9 +1329,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1519,9 +1383,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1539,9 +1401,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1550,9 +1410,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1570,9 +1428,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1635,9 +1491,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1646,9 +1500,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1657,9 +1509,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1668,9 +1518,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1679,12 +1527,7 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1702,9 +1545,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1722,9 +1563,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1742,9 +1581,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -1762,9 +1599,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -1773,9 +1608,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -1784,9 +1617,7 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
 end
 
 """
@@ -1795,9 +1626,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -1815,9 +1644,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1826,9 +1653,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1846,9 +1671,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1857,9 +1680,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1877,9 +1698,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -1906,9 +1725,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1926,9 +1743,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1946,9 +1761,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1966,9 +1779,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1986,9 +1797,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2006,9 +1815,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2017,9 +1824,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2055,9 +1860,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2084,9 +1887,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2095,13 +1896,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2110,9 +1905,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2121,9 +1914,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2132,9 +1923,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2143,9 +1932,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2190,9 +1977,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2228,9 +2013,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2248,9 +2031,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2268,9 +2049,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2279,9 +2058,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2290,9 +2067,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2300,16 +2075,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2318,12 +2085,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2377,9 +2139,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2397,9 +2157,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2417,9 +2175,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2437,9 +2193,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2448,9 +2202,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2468,9 +2220,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2479,9 +2229,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2589,13 +2337,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2604,9 +2346,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2633,9 +2373,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2644,9 +2382,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2673,12 +2409,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2687,9 +2418,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2698,9 +2427,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2709,9 +2436,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -2720,9 +2445,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2740,9 +2463,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2814,9 +2535,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -2825,9 +2544,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -2862,24 +2579,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -2888,63 +2592,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -2953,81 +2637,55 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 """
@@ -3036,9 +2694,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -3047,9 +2703,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -3067,9 +2721,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3081,51 +2733,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3134,75 +2770,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3238,9 +2850,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3249,9 +2859,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3260,9 +2868,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3289,9 +2895,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3300,9 +2904,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3590,9 +3192,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3601,9 +3201,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -3639,9 +3237,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3650,13 +3246,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -3683,9 +3273,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -3712,13 +3300,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3727,14 +3309,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3743,9 +3318,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3754,13 +3327,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3769,9 +3336,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3780,9 +3345,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -3836,9 +3399,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3874,13 +3435,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -3916,9 +3471,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -3936,9 +3489,7 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
-        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
 end
 
 """
@@ -3992,9 +3543,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -4003,9 +3552,7 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
-        passManager::MlirPassManager, _module::MlirModule
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
 end
 
 """
@@ -4014,9 +3561,7 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -4025,9 +3570,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -4036,9 +3579,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4047,9 +3588,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4058,9 +3597,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4069,9 +3606,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4080,9 +3615,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4091,9 +3624,7 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager, pipeline::MlirStringRef
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
 end
 
 """
@@ -4101,28 +3632,8 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(
-    passID,
-    name,
-    argument,
-    description,
-    opName,
-    nDependentDialects,
-    dependentDialects,
-    callbacks,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
-        passID::MlirTypeID,
-        name::MlirStringRef,
-        argument::MlirStringRef,
-        description::MlirStringRef,
-        opName::MlirStringRef,
-        nDependentDialects::intptr_t,
-        dependentDialects::Ptr{MlirDialectHandle},
-        callbacks::MlirExternalPassCallbacks,
-        userData::Ptr{Cvoid},
-    )::MlirPass
+function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
 end
 
 """
@@ -4617,9 +4128,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4628,9 +4137,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -4639,9 +4146,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -4659,9 +4164,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -4670,12 +4173,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -4684,9 +4182,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -4804,9 +4300,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -4824,9 +4318,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -4835,12 +4327,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -4849,9 +4336,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -5143,9 +4628,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5154,9 +4637,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5219,9 +4700,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -5230,9 +4709,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -5241,9 +4718,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -5252,9 +4727,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5272,9 +4745,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5292,9 +4763,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5311,16 +4780,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5337,18 +4798,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5392,28 +4843,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5422,9 +4853,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -5433,9 +4862,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -5444,9 +4871,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -5455,9 +4880,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -5484,9 +4907,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -5538,9 +4959,7 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -5548,17 +4967,8 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        numDimLevelTypes::intptr_t,
-        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimOrdering::MlirAffineMap,
-        pointerBitWidth::Cint,
-        indexBitWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, pointerBitWidth, indexBitWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
 end
 
 """
@@ -5567,9 +4977,7 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -5578,9 +4986,7 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5589,9 +4995,7 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -5600,9 +5004,7 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -5611,9 +5013,7 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -5646,9 +5046,7 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef})::MlirExecutionEngine
 end
 
 """
@@ -5675,9 +5073,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -5686,9 +5082,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5697,9 +5091,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -5708,9 +5100,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5719,9 +5109,7 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
 end
 
 """
@@ -5757,9 +5145,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5777,9 +5163,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5787,17 +5171,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -5805,16 +5180,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -5886,9 +5253,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -5897,9 +5262,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -5908,9 +5271,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5919,9 +5280,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -5944,30 +5303,8 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -6104,3 +5441,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/15/libMLIR_h.jl
+++ b/src/API/15/libMLIR_h.jl
@@ -2,30 +2,6 @@ using CEnum
 
 const intptr_t = Clong
 
-struct MlirDialectHandle
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeID
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeIDAllocator
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirStringRef
-
-| Field | Note                          |
-| :---- | :---------------------------- |
-| data  | Pointer to the first symbol.  |
-"""
-struct MlirStringRef
-    data::Cstring
-    length::Cint
-end
-
 function mlirStringRefCreate(str, length)
     @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
@@ -55,15 +31,6 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
-
-"""
-    MlirLogicalResult
-
-A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
-"""
-struct MlirLogicalResult
-    value::Int8
-end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -157,74 +124,6 @@ Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
     @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
-end
-
-struct MlirContext
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialect
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialectRegistry
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOperation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPrintingFlags
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirBlock
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirRegion
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirSymbolTable
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirAttribute
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirIdentifier
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirLocation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirModule
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirType
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirValue
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirNamedAttribute
-
-Named MLIR attribute.
-
-A named attribute is essentially a (name, attribute) pair where the name is a string.
-"""
-struct MlirNamedAttribute
-    name::MlirIdentifier
-    attribute::MlirAttribute
 end
 
 """
@@ -594,22 +493,6 @@ Views the generic operation as a module. The returned module is null when the in
 """
 function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
-end
-
-struct MlirOperationState
-    name::MlirStringRef
-    location::MlirLocation
-    nResults::intptr_t
-    results::Ptr{MlirType}
-    nOperands::intptr_t
-    operands::Ptr{MlirValue}
-    nRegions::intptr_t
-    regions::Ptr{MlirRegion}
-    nSuccessors::intptr_t
-    successors::Ptr{MlirBlock}
-    nAttributes::intptr_t
-    attributes::Ptr{MlirNamedAttribute}
-    enableResultTypeInference::Bool
 end
 
 """
@@ -1647,10 +1530,6 @@ function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, user
     @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
-struct MlirAffineExpr
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirAffineExprGetContext(affineExpr)
 
@@ -1739,10 +1618,6 @@ Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
     @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
-end
-
-struct MlirAffineMap
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -3635,22 +3510,6 @@ function mlirOpaqueTypeGetData(type)
     @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGetData(type::MlirType)::MlirStringRef
 end
 
-struct MlirPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirExternalPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirPassManager
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPassManager
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirPassManagerCreate(ctx)
 
@@ -3766,27 +3625,6 @@ Parse a textual MLIR pass pipeline and add it to the provided OpPassManager.
 """
 function mlirParsePassPipeline(passManager, pipeline)
     @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef)::MlirLogicalResult
-end
-
-"""
-    MlirExternalPassCallbacks
-
-Structure of external [`MlirPass`](@ref) callbacks. All callbacks are required to be set unless otherwise specified.
-
-| Field      | Note                                                                                                                                                                                              |
-| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| construct  | This callback is called from the pass is created. This is analogous to a C++ pass constructor.                                                                                                    |
-| destruct   | This callback is called when the pass is destroyed This is analogous to a C++ pass destructor.                                                                                                    |
-| initialize | This callback is optional. The callback is called before the pass is run, allowing a chance to initialize any complex state necessary for running the pass. See Pass::initialize(MLIRContext *).  |
-| clone      | This callback is called when the pass is cloned. See Pass::clonePass().                                                                                                                           |
-| run        | This callback is called when the pass is run. See Pass::runOnOperation().                                                                                                                         |
-"""
-struct MlirExternalPassCallbacks
-    construct::Ptr{Cvoid}
-    destruct::Ptr{Cvoid}
-    initialize::Ptr{Cvoid}
-    clone::Ptr{Cvoid}
-    run::Ptr{Cvoid}
 end
 
 """
@@ -4259,15 +4097,6 @@ Retuns `true` if the global debugging flag is set, false otherwise.
 """
 function mlirIsGlobalDebugEnabled()
     @ccall (MLIR_C_PATH[]).mlirIsGlobalDebugEnabled()::Bool
-end
-
-"""
-    MlirDiagnostic
-
-An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
-"""
-struct MlirDiagnostic
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -5211,10 +5040,6 @@ function mlirGetDialectHandle__tensor__()
     @ccall (MLIR_C_PATH[]).mlirGetDialectHandle__tensor__()::MlirDialectHandle
 end
 
-struct MlirExecutionEngine
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths)
 
@@ -5285,10 +5110,6 @@ Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
     @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
-end
-
-struct MlirIntegerSet
-    ptr::Ptr{Cvoid}
 end
 
 """

--- a/src/API/16/libMLIR_h.jl
+++ b/src/API/16/libMLIR_h.jl
@@ -2,13 +2,8 @@ using CEnum
 
 const intptr_t = Clong
 
-"""
-    mlirStringRefCreate(str, length)
-
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
-"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -26,9 +21,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -102,13 +95,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -135,9 +123,7 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
-        allocator::MlirTypeIDAllocator
-    )::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
 end
 
 """
@@ -182,9 +168,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -193,9 +177,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -204,9 +186,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -215,9 +195,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -235,9 +213,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -246,9 +222,7 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -266,9 +240,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -295,9 +267,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -315,9 +285,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -326,9 +294,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -337,9 +303,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -348,9 +312,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -386,9 +348,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -397,9 +357,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -408,12 +366,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -422,9 +375,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -469,9 +420,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -489,9 +438,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -554,9 +501,7 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -565,33 +510,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -600,9 +535,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -629,9 +562,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -640,9 +571,7 @@ end
 Enable or disable printing of debug information (based on `enable`). If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, enable, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -651,9 +580,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -662,9 +589,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -675,9 +600,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -794,9 +717,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -823,9 +744,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -834,9 +753,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -854,9 +771,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -874,9 +789,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -894,9 +807,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -905,9 +816,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -916,9 +825,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -927,9 +834,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -938,9 +843,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -949,12 +852,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -963,9 +861,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but writing the bytecode format out.
 """
 function mlirOperationWriteBytecode(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -992,9 +888,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1003,9 +897,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1059,9 +951,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1070,9 +960,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1081,9 +969,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1092,9 +978,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1121,9 +1005,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1213,9 +1095,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1224,9 +1104,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1235,9 +1113,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1246,9 +1122,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1266,9 +1140,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1286,9 +1158,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1396,9 +1266,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1452,9 +1320,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1499,9 +1365,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1519,9 +1383,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1575,9 +1437,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1595,9 +1455,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1606,9 +1464,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1626,9 +1482,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1691,9 +1545,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1702,9 +1554,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1713,9 +1563,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1724,9 +1572,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1735,12 +1581,7 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1758,9 +1599,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1778,9 +1617,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1798,9 +1635,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -1818,9 +1653,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -1829,9 +1662,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -1840,9 +1671,7 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
 end
 
 """
@@ -1851,9 +1680,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -1871,9 +1698,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1882,9 +1707,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1902,9 +1725,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1913,9 +1734,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1933,9 +1752,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -1962,9 +1779,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1982,9 +1797,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2002,9 +1815,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2022,9 +1833,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2042,9 +1851,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2062,9 +1869,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2073,9 +1878,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2111,9 +1914,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2140,9 +1941,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2151,13 +1950,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2166,9 +1959,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2177,9 +1968,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2188,9 +1977,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2199,9 +1986,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2246,9 +2031,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2284,9 +2067,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2304,9 +2085,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2324,9 +2103,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2335,9 +2112,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2346,9 +2121,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2356,16 +2129,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2374,12 +2139,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2433,9 +2193,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2453,9 +2211,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2473,9 +2229,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2493,9 +2247,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2504,9 +2256,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2524,9 +2274,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2535,9 +2283,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2645,13 +2391,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2660,9 +2400,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2689,9 +2427,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2700,9 +2436,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2729,12 +2463,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2743,9 +2472,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2754,9 +2481,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2765,9 +2490,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -2776,9 +2499,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2796,9 +2517,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2870,9 +2589,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -2881,9 +2598,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -2934,45 +2649,31 @@ end
 Create a dense array attribute with the given elements.
 """
 function mlirDenseBoolArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseI8ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseI16ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseI32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseI64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseF32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseF64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -2990,45 +2691,31 @@ end
 Get an element of a dense array.
 """
 function mlirDenseBoolArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseI8ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseI16ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseI32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseI64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseF32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseF64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3054,24 +2741,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -3080,63 +2754,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -3145,81 +2799,55 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 """
@@ -3228,9 +2856,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -3239,9 +2865,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -3259,9 +2883,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3273,51 +2895,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3326,75 +2932,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3406,125 +2988,48 @@ function mlirDenseElementsAttrGetRawData(attr)
     @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetRawData(attr::MlirAttribute)::Ptr{Cvoid}
 end
 
-function mlirUnmanagedDenseBoolResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cint},
-    )::MlirAttribute
+function mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt8},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int8},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt16},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int16},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt32},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int32},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt64},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int64},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseFloatResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cfloat},
-    )::MlirAttribute
+function mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
-function mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cdouble},
-    )::MlirAttribute
+function mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -3533,69 +3038,47 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense resource elements attribute.
 """
 function mlirDenseBoolResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseUInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseUInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseUInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseUInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseFloatResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseDoubleResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3613,9 +3096,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3624,9 +3105,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3635,9 +3114,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirAttributeIsAStridedLayout(attr)
@@ -3645,9 +3122,7 @@ function mlirAttributeIsAStridedLayout(attr)
 end
 
 function mlirStridedLayoutAttrGet(ctx, offset, numStrides, strides)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(
-        ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64})::MlirAttribute
 end
 
 function mlirStridedLayoutAttrGetOffset(attr)
@@ -3659,9 +3134,7 @@ function mlirStridedLayoutAttrGetNumStrides(attr)
 end
 
 function mlirStridedLayoutAttrGetStride(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 """
@@ -3688,9 +3161,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3699,9 +3170,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -4025,9 +3494,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4036,9 +3503,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4074,9 +3539,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4085,13 +3548,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4118,9 +3575,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -4147,13 +3602,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4162,14 +3611,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4178,9 +3620,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4189,13 +3629,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4204,9 +3638,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4215,9 +3647,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4271,9 +3701,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4309,13 +3737,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4351,9 +3773,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -4371,9 +3791,7 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
-        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
 end
 
 """
@@ -4409,9 +3827,7 @@ end
 Create a new top-level PassManager anchored on `anchorOp`.
 """
 function mlirPassManagerCreateOnOperation(ctx, anchorOp)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(
-        ctx::MlirContext, anchorOp::MlirStringRef
-    )::MlirPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(ctx::MlirContext, anchorOp::MlirStringRef)::MlirPassManager
 end
 
 """
@@ -4438,9 +3854,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -4449,9 +3863,7 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
-        passManager::MlirPassManager, _module::MlirModule
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
 end
 
 """
@@ -4460,9 +3872,7 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -4471,9 +3881,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -4482,9 +3890,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4493,9 +3899,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4504,9 +3908,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4515,9 +3917,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4526,12 +3926,7 @@ end
 Parse a sequence of textual MLIR pass pipeline elements and add them to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirOpPassManagerAddPipeline(passManager, pipelineElements, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(
-        passManager::MlirOpPassManager,
-        pipelineElements::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(passManager::MlirOpPassManager, pipelineElements::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -4540,9 +3935,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4551,12 +3944,7 @@ end
 Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager,
-        pipeline::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -4564,28 +3952,8 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(
-    passID,
-    name,
-    argument,
-    description,
-    opName,
-    nDependentDialects,
-    dependentDialects,
-    callbacks,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
-        passID::MlirTypeID,
-        name::MlirStringRef,
-        argument::MlirStringRef,
-        description::MlirStringRef,
-        opName::MlirStringRef,
-        nDependentDialects::intptr_t,
-        dependentDialects::Ptr{MlirDialectHandle},
-        callbacks::MlirExternalPassCallbacks,
-        userData::Ptr{Cvoid},
-    )::MlirPass
+function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
 end
 
 """
@@ -5096,9 +4464,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5107,9 +4473,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -5118,9 +4482,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -5138,9 +4500,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -5149,12 +4509,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -5163,9 +4518,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -5299,9 +4652,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -5319,9 +4670,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -5330,12 +4679,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -5344,9 +4688,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -5538,9 +4880,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5549,9 +4889,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5614,9 +4952,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -5625,9 +4961,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -5636,9 +4970,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -5647,9 +4979,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5667,9 +4997,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5687,9 +5015,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5706,16 +5032,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5732,18 +5050,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5787,28 +5095,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5817,9 +5105,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -5828,9 +5114,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -5839,9 +5123,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -5850,9 +5132,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -5879,9 +5159,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -5939,9 +5217,7 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -5949,24 +5225,8 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx,
-    numDimLevelTypes,
-    dimLevelTypes,
-    dimOrdering,
-    higherOrdering,
-    pointerBitWidth,
-    indexBitWidth,
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        numDimLevelTypes::intptr_t,
-        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimOrdering::MlirAffineMap,
-        higherOrdering::MlirAffineMap,
-        pointerBitWidth::Cint,
-        indexBitWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, higherOrdering, pointerBitWidth, indexBitWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, higherOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
 end
 
 """
@@ -5975,9 +5235,7 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -5986,9 +5244,7 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5997,9 +5253,7 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -6008,9 +5262,7 @@ end
 Returns the higher ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetHigherOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetHigherOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetHigherOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -6019,9 +5271,7 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -6030,9 +5280,7 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -6124,15 +5372,11 @@ function mlirTypeIsATransformOperationType(type)
 end
 
 function mlirTransformOperationTypeGet(ctx, operationName)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(
-        ctx::MlirContext, operationName::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(ctx::MlirContext, operationName::MlirStringRef)::MlirType
 end
 
 function mlirTransformOperationTypeGetOperationName(type)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(
-        type::MlirType
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
 end
 
 """
@@ -6141,13 +5385,7 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule,
-        optLevel::Cint,
-        numPaths::Cint,
-        sharedLibPaths::Ptr{MlirStringRef},
-        enableObjectDump::Bool,
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}, enableObjectDump::Bool)::MlirExecutionEngine
 end
 
 """
@@ -6174,9 +5412,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -6185,9 +5421,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6196,9 +5430,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6207,9 +5439,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6218,9 +5448,7 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
 end
 
 """
@@ -6256,9 +5484,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6276,9 +5502,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -6286,17 +5510,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -6304,16 +5519,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -6385,9 +5592,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -6396,9 +5601,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -6407,9 +5610,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -6418,9 +5619,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -6443,30 +5642,8 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -6611,3 +5788,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/16/libMLIR_h.jl
+++ b/src/API/16/libMLIR_h.jl
@@ -1,16 +1,33 @@
 using CEnum
 
-const __darwin_intptr_t = Clong
+const intptr_t = Clong
 
-const intptr_t = __darwin_intptr_t
+struct MlirDialectHandle
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeID
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeIDAllocator
+    ptr::Ptr{Cvoid}
+end
 
 """
-    mlirStringRefCreate(str, length)
+    MlirStringRef
 
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+| Field | Note                          |
+| :---- | :---------------------------- |
+| data  | Pointer to the first symbol.  |
 """
+struct MlirStringRef
+    data::Cstring
+    length::Cint
+end
+
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -28,9 +45,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -40,6 +55,15 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
+
+"""
+    MlirLogicalResult
+
+A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
+"""
+struct MlirLogicalResult
+    value::Int8
+end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -104,13 +128,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -137,9 +156,79 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
-        allocator::MlirTypeIDAllocator
-    )::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
+end
+
+struct MlirContext
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialect
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialectRegistry
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOperation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpOperand
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPrintingFlags
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirBlock
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirRegion
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirSymbolTable
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirAttribute
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirIdentifier
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirLocation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirModule
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirType
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirValue
+    ptr::Ptr{Cvoid}
+end
+
+"""
+    MlirNamedAttribute
+
+Named MLIR attribute.
+
+A named attribute is essentially a (name, attribute) pair where the name is a string.
+"""
+struct MlirNamedAttribute
+    name::MlirIdentifier
+    attribute::MlirAttribute
 end
 
 """
@@ -184,9 +273,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -195,9 +282,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -206,9 +291,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -217,9 +300,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -237,9 +318,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -248,9 +327,7 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -268,9 +345,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -297,9 +372,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -317,9 +390,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -328,9 +399,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -339,9 +408,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -350,9 +417,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -388,9 +453,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -399,9 +462,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -410,12 +471,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -424,9 +480,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -471,9 +525,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -491,9 +543,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -550,15 +600,29 @@ function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
 end
 
+struct MlirOperationState
+    name::MlirStringRef
+    location::MlirLocation
+    nResults::intptr_t
+    results::Ptr{MlirType}
+    nOperands::intptr_t
+    operands::Ptr{MlirValue}
+    nRegions::intptr_t
+    regions::Ptr{MlirRegion}
+    nSuccessors::intptr_t
+    successors::Ptr{MlirBlock}
+    nAttributes::intptr_t
+    attributes::Ptr{MlirNamedAttribute}
+    enableResultTypeInference::Bool
+end
+
 """
     mlirOperationStateGet(name, loc)
 
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -567,33 +631,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -602,9 +656,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -631,9 +683,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -642,9 +692,7 @@ end
 Enable or disable printing of debug information (based on `enable`). If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, enable, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -653,9 +701,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -664,9 +710,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -677,9 +721,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -796,9 +838,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -825,9 +865,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -836,9 +874,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -856,9 +892,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -876,9 +910,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -896,9 +928,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -907,9 +937,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -918,9 +946,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -929,9 +955,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -940,9 +964,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -951,12 +973,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -965,9 +982,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but writing the bytecode format out.
 """
 function mlirOperationWriteBytecode(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -994,9 +1009,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1005,9 +1018,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1061,9 +1072,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1072,9 +1081,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1083,9 +1090,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1094,9 +1099,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1123,9 +1126,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1215,9 +1216,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1226,9 +1225,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1237,9 +1234,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1248,9 +1243,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1268,9 +1261,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1288,9 +1279,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1398,9 +1387,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1454,9 +1441,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1501,9 +1486,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1521,9 +1504,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1577,9 +1558,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1597,9 +1576,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1608,9 +1585,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1628,9 +1603,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1693,9 +1666,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1704,9 +1675,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1715,9 +1684,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1726,9 +1693,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1737,12 +1702,11 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+end
+
+struct MlirAffineExpr
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1760,9 +1724,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1780,9 +1742,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1800,9 +1760,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -1820,9 +1778,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -1831,9 +1787,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -1842,9 +1796,11 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+end
+
+struct MlirAffineMap
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1853,9 +1809,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -1873,9 +1827,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1884,9 +1836,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1904,9 +1854,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -1915,9 +1863,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -1935,9 +1881,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -1964,9 +1908,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -1984,9 +1926,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2004,9 +1944,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2024,9 +1962,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2044,9 +1980,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2064,9 +1998,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2075,9 +2007,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2113,9 +2043,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2142,9 +2070,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2153,13 +2079,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2168,9 +2088,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2179,9 +2097,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2190,9 +2106,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2201,9 +2115,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2248,9 +2160,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2286,9 +2196,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2306,9 +2214,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2326,9 +2232,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2337,9 +2241,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2348,9 +2250,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2358,16 +2258,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2376,12 +2268,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2435,9 +2322,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2455,9 +2340,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2475,9 +2358,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2495,9 +2376,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2506,9 +2385,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2526,9 +2403,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2537,9 +2412,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2647,13 +2520,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2662,9 +2529,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2691,9 +2556,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2702,9 +2565,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2731,12 +2592,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2745,9 +2601,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2756,9 +2610,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2767,9 +2619,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -2778,9 +2628,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2798,9 +2646,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2872,9 +2718,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -2883,9 +2727,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -2936,45 +2778,31 @@ end
 Create a dense array attribute with the given elements.
 """
 function mlirDenseBoolArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseI8ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseI16ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseI32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseI64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseF32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseF64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -2992,45 +2820,31 @@ end
 Get an element of a dense array.
 """
 function mlirDenseBoolArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseI8ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseI16ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseI32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseI64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseF32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseF64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3056,24 +2870,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -3082,63 +2883,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -3147,81 +2928,55 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 """
@@ -3230,9 +2985,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -3241,9 +2994,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -3261,9 +3012,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3275,51 +3024,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3328,75 +3061,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3408,125 +3117,48 @@ function mlirDenseElementsAttrGetRawData(attr)
     @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetRawData(attr::MlirAttribute)::Ptr{Cvoid}
 end
 
-function mlirUnmanagedDenseBoolResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cint},
-    )::MlirAttribute
+function mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt8},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int8},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt16},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int16},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt32},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int32},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt64},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int64},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseFloatResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cfloat},
-    )::MlirAttribute
+function mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
-function mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cdouble},
-    )::MlirAttribute
+function mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -3535,69 +3167,47 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense resource elements attribute.
 """
 function mlirDenseBoolResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseUInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseUInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseUInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseUInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseFloatResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseDoubleResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3615,9 +3225,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3626,9 +3234,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3637,9 +3243,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirAttributeIsAStridedLayout(attr)
@@ -3647,9 +3251,7 @@ function mlirAttributeIsAStridedLayout(attr)
 end
 
 function mlirStridedLayoutAttrGet(ctx, offset, numStrides, strides)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(
-        ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64})::MlirAttribute
 end
 
 function mlirStridedLayoutAttrGetOffset(attr)
@@ -3661,9 +3263,7 @@ function mlirStridedLayoutAttrGetNumStrides(attr)
 end
 
 function mlirStridedLayoutAttrGetStride(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 """
@@ -3690,9 +3290,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -3701,9 +3299,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -4027,9 +3623,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4038,9 +3632,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4076,9 +3668,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4087,13 +3677,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4120,9 +3704,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -4149,13 +3731,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4164,14 +3740,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4180,9 +3749,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4191,13 +3758,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4206,9 +3767,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4217,9 +3776,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4273,9 +3830,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4311,13 +3866,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4353,9 +3902,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -4373,9 +3920,7 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
-        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
 end
 
 """
@@ -4396,6 +3941,22 @@ function mlirOpaqueTypeGetData(type)
     @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGetData(type::MlirType)::MlirStringRef
 end
 
+struct MlirPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirExternalPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirPassManager
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPassManager
+    ptr::Ptr{Cvoid}
+end
+
 """
     mlirPassManagerCreate(ctx)
 
@@ -4411,9 +3972,7 @@ end
 Create a new top-level PassManager anchored on `anchorOp`.
 """
 function mlirPassManagerCreateOnOperation(ctx, anchorOp)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(
-        ctx::MlirContext, anchorOp::MlirStringRef
-    )::MlirPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(ctx::MlirContext, anchorOp::MlirStringRef)::MlirPassManager
 end
 
 """
@@ -4440,9 +3999,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -4451,9 +4008,7 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
-        passManager::MlirPassManager, _module::MlirModule
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
 end
 
 """
@@ -4462,9 +4017,7 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -4473,9 +4026,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -4484,9 +4035,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4495,9 +4044,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -4506,9 +4053,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4517,9 +4062,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -4528,12 +4071,7 @@ end
 Parse a sequence of textual MLIR pass pipeline elements and add them to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirOpPassManagerAddPipeline(passManager, pipelineElements, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(
-        passManager::MlirOpPassManager,
-        pipelineElements::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(passManager::MlirOpPassManager, pipelineElements::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -4542,9 +4080,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -4553,12 +4089,28 @@ end
 Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager,
-        pipeline::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+end
+
+"""
+    MlirExternalPassCallbacks
+
+Structure of external [`MlirPass`](@ref) callbacks. All callbacks are required to be set unless otherwise specified.
+
+| Field      | Note                                                                                                                                                                                              |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| construct  | This callback is called from the pass is created. This is analogous to a C++ pass constructor.                                                                                                    |
+| destruct   | This callback is called when the pass is destroyed This is analogous to a C++ pass destructor.                                                                                                    |
+| initialize | This callback is optional. The callback is called before the pass is run, allowing a chance to initialize any complex state necessary for running the pass. See Pass::initialize(MLIRContext *).  |
+| clone      | This callback is called when the pass is cloned. See Pass::clonePass().                                                                                                                           |
+| run        | This callback is called when the pass is run. See Pass::runOnOperation().                                                                                                                         |
+"""
+struct MlirExternalPassCallbacks
+    construct::Ptr{Cvoid}
+    destruct::Ptr{Cvoid}
+    initialize::Ptr{Cvoid}
+    clone::Ptr{Cvoid}
+    run::Ptr{Cvoid}
 end
 
 """
@@ -4566,28 +4118,8 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(
-    passID,
-    name,
-    argument,
-    description,
-    opName,
-    nDependentDialects,
-    dependentDialects,
-    callbacks,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
-        passID::MlirTypeID,
-        name::MlirStringRef,
-        argument::MlirStringRef,
-        description::MlirStringRef,
-        opName::MlirStringRef,
-        nDependentDialects::intptr_t,
-        dependentDialects::Ptr{MlirDialectHandle},
-        callbacks::MlirExternalPassCallbacks,
-        userData::Ptr{Cvoid},
-    )::MlirPass
+function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
 end
 
 """
@@ -5070,6 +4602,15 @@ function mlirIsGlobalDebugEnabled()
 end
 
 """
+    MlirDiagnostic
+
+An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
+"""
+struct MlirDiagnostic
+    ptr::Ptr{Cvoid}
+end
+
+"""
     MlirDiagnosticSeverity
 
 Severity of a diagnostic.
@@ -5098,9 +4639,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5109,9 +4648,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -5120,9 +4657,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -5140,9 +4675,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -5151,12 +4684,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -5165,9 +4693,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -5301,9 +4827,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -5321,9 +4845,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -5332,12 +4854,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -5346,9 +4863,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -5540,9 +5055,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5551,9 +5064,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -5616,9 +5127,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -5627,9 +5136,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -5638,9 +5145,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -5649,9 +5154,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5669,9 +5172,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5689,9 +5190,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -5708,16 +5207,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5734,18 +5225,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5789,28 +5270,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -5819,9 +5280,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -5830,9 +5289,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -5841,9 +5298,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -5852,9 +5307,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -5881,9 +5334,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -5941,9 +5392,7 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -5951,24 +5400,8 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx,
-    numDimLevelTypes,
-    dimLevelTypes,
-    dimOrdering,
-    higherOrdering,
-    pointerBitWidth,
-    indexBitWidth,
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        numDimLevelTypes::intptr_t,
-        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimOrdering::MlirAffineMap,
-        higherOrdering::MlirAffineMap,
-        pointerBitWidth::Cint,
-        indexBitWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, higherOrdering, pointerBitWidth, indexBitWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, higherOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
 end
 
 """
@@ -5977,9 +5410,7 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -5988,9 +5419,7 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5999,9 +5428,7 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -6010,9 +5437,7 @@ end
 Returns the higher ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetHigherOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetHigherOrdering(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetHigherOrdering(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -6021,9 +5446,7 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -6032,9 +5455,7 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -6126,15 +5547,15 @@ function mlirTypeIsATransformOperationType(type)
 end
 
 function mlirTransformOperationTypeGet(ctx, operationName)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(
-        ctx::MlirContext, operationName::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(ctx::MlirContext, operationName::MlirStringRef)::MlirType
 end
 
 function mlirTransformOperationTypeGetOperationName(type)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(
-        type::MlirType
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
+end
+
+struct MlirExecutionEngine
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -6143,13 +5564,7 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule,
-        optLevel::Cint,
-        numPaths::Cint,
-        sharedLibPaths::Ptr{MlirStringRef},
-        enableObjectDump::Bool,
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}, enableObjectDump::Bool)::MlirExecutionEngine
 end
 
 """
@@ -6176,9 +5591,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -6187,9 +5600,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6198,9 +5609,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6209,9 +5618,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6220,9 +5627,11 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+end
+
+struct MlirIntegerSet
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -6258,9 +5667,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6278,9 +5685,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -6288,17 +5693,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -6306,16 +5702,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -6387,9 +5775,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -6398,9 +5784,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -6409,9 +5793,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -6420,9 +5802,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -6445,30 +5825,8 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -6613,3 +5971,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/16/libMLIR_h.jl
+++ b/src/API/16/libMLIR_h.jl
@@ -2,8 +2,13 @@ using CEnum
 
 const intptr_t = Clong
 
+"""
+    mlirStringRefCreate(str, length)
+
+Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
 end
 
 """
@@ -21,7 +26,9 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
+        string::MlirStringRef, other::MlirStringRef
+    )::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -95,8 +102,13 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
+"""
+    mlirTypeIDHashValue(typeID)
+
+Returns the hash value of the type id.
+"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
 end
 
 """
@@ -123,7 +135,9 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
+        allocator::MlirTypeIDAllocator
+    )::MlirTypeID
 end
 
 """
@@ -168,7 +182,9 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
+        context::MlirContext, allow::Bool
+    )::Cvoid
 end
 
 """
@@ -177,7 +193,9 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
+        context::MlirContext
+    )::Bool
 end
 
 """
@@ -186,7 +204,9 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
+        context::MlirContext
+    )::intptr_t
 end
 
 """
@@ -195,7 +215,9 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
+        ctx::MlirContext, registry::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -213,7 +235,9 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
+        context::MlirContext, name::MlirStringRef
+    )::MlirDialect
 end
 
 """
@@ -222,7 +246,9 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
+        context::MlirContext, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -240,7 +266,9 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
+        context::MlirContext, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -267,7 +295,9 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
+        dialect1::MlirDialect, dialect2::MlirDialect
+    )::Bool
 end
 
 """
@@ -285,7 +315,9 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
+        arg1::MlirDialectHandle
+    )::MlirStringRef
 end
 
 """
@@ -294,7 +326,9 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
+        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -303,7 +337,9 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::Cvoid
 end
 
 """
@@ -312,7 +348,9 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::MlirDialect
 end
 
 """
@@ -348,7 +386,9 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
+        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
+    )::MlirLocation
 end
 
 """
@@ -357,7 +397,9 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
+        callee::MlirLocation, caller::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -366,7 +408,12 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
+        ctx::MlirContext,
+        nLocations::intptr_t,
+        locations::Ptr{MlirLocation},
+        metadata::MlirAttribute,
+    )::MlirLocation
 end
 
 """
@@ -375,7 +422,9 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
+        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -420,7 +469,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
+        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -438,7 +489,9 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
+        context::MlirContext, _module::MlirStringRef
+    )::MlirModule
 end
 
 """
@@ -501,7 +554,9 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
+        name::MlirStringRef, loc::MlirLocation
+    )::MlirOperationState
 end
 
 """
@@ -510,23 +565,33 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
+        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
+        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
+        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
+    )::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
+        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
+    )::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
+        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
+    )::Cvoid
 end
 
 """
@@ -535,7 +600,9 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
+        state::Ptr{MlirOperationState}
+    )::Cvoid
 end
 
 """
@@ -562,7 +629,9 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
+        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
+    )::Cvoid
 end
 
 """
@@ -571,7 +640,9 @@ end
 Enable or disable printing of debug information (based on `enable`). If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, enable, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
+        flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool
+    )::Cvoid
 end
 
 """
@@ -580,7 +651,9 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -589,7 +662,9 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -600,7 +675,9 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
+        state::Ptr{MlirOperationState}
+    )::MlirOperation
 end
 
 """
@@ -717,7 +794,9 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
+        op::MlirOperation, pos::intptr_t
+    )::MlirRegion
 end
 
 """
@@ -744,7 +823,9 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -753,7 +834,9 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
+        op::MlirOperation, pos::intptr_t, newValue::MlirValue
+    )::Cvoid
 end
 
 """
@@ -771,7 +854,9 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -789,7 +874,9 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
+        op::MlirOperation, pos::intptr_t
+    )::MlirBlock
 end
 
 """
@@ -807,7 +894,9 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
+        op::MlirOperation, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -816,7 +905,9 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -825,7 +916,9 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
+        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
+    )::Cvoid
 end
 
 """
@@ -834,7 +927,9 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -843,7 +938,9 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
+        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -852,7 +949,12 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
+        op::MlirOperation,
+        flags::MlirOpPrintingFlags,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -861,7 +963,9 @@ end
 Same as [`mlirOperationPrint`](@ref) but writing the bytecode format out.
 """
 function mlirOperationWriteBytecode(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(
+        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -888,7 +992,9 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -897,7 +1003,9 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -951,7 +1059,9 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
+        region::MlirRegion, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -960,7 +1070,9 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
+        region::MlirRegion, pos::intptr_t, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -969,7 +1081,9 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -978,7 +1092,9 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -1005,7 +1121,9 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
+        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
+    )::MlirBlock
 end
 
 """
@@ -1095,7 +1213,9 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
+        block::MlirBlock, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1104,7 +1224,9 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
+        block::MlirBlock, pos::intptr_t, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1113,7 +1235,9 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1122,7 +1246,9 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1140,7 +1266,9 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
+        block::MlirBlock, type::MlirType, loc::MlirLocation
+    )::MlirValue
 end
 
 """
@@ -1158,7 +1286,9 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
+        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1266,7 +1396,9 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(
+        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1320,7 +1452,9 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
+        context::MlirContext, type::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -1365,7 +1499,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(
+        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1383,7 +1519,9 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
+        context::MlirContext, attr::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -1437,7 +1575,9 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
+        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1455,7 +1595,9 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
+        name::MlirIdentifier, attr::MlirAttribute
+    )::MlirNamedAttribute
 end
 
 """
@@ -1464,7 +1606,9 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
+        context::MlirContext, str::MlirStringRef
+    )::MlirIdentifier
 end
 
 """
@@ -1482,7 +1626,9 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
+        ident::MlirIdentifier, other::MlirIdentifier
+    )::Bool
 end
 
 """
@@ -1545,7 +1691,9 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
+        symbolTable::MlirSymbolTable, name::MlirStringRef
+    )::MlirOperation
 end
 
 """
@@ -1554,7 +1702,9 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::MlirAttribute
 end
 
 """
@@ -1563,7 +1713,9 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1572,7 +1724,9 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
+        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
+    )::MlirLogicalResult
 end
 
 """
@@ -1581,7 +1735,12 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
+        from::MlirOperation,
+        allSymUsesVisible::Bool,
+        callback::Ptr{Cvoid},
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -1599,7 +1758,9 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1617,7 +1778,9 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
+        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1635,7 +1798,9 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
+        affineExpr::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1653,7 +1818,9 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
+        affineExpr::MlirAffineExpr
+    )::Int64
 end
 
 """
@@ -1662,7 +1829,9 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
+        affineExpr::MlirAffineExpr, factor::Int64
+    )::Bool
 end
 
 """
@@ -1671,7 +1840,9 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
+        affineExpr::MlirAffineExpr, position::intptr_t
+    )::Bool
 end
 
 """
@@ -1680,7 +1851,9 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
+        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
+    )::MlirAffineExpr
 end
 
 """
@@ -1698,7 +1871,9 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1707,7 +1882,9 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1725,7 +1902,9 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1734,7 +1913,9 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1752,7 +1933,9 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
+        ctx::MlirContext, constant::Int64
+    )::MlirAffineExpr
 end
 
 """
@@ -1779,7 +1962,9 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1797,7 +1982,9 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1815,7 +2002,9 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1833,7 +2022,9 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1851,7 +2042,9 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1869,7 +2062,9 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1878,7 +2073,9 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1914,7 +2111,9 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
+        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1941,7 +2140,9 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
+        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1950,7 +2151,13 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
+        ctx::MlirContext,
+        dimCount::intptr_t,
+        symbolCount::intptr_t,
+        nAffineExprs::intptr_t,
+        affineExprs::Ptr{MlirAffineExpr},
+    )::MlirAffineMap
 end
 
 """
@@ -1959,7 +2166,9 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
+        ctx::MlirContext, val::Int64
+    )::MlirAffineMap
 end
 
 """
@@ -1968,7 +2177,9 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
+        ctx::MlirContext, numDims::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1977,7 +2188,9 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
+        ctx::MlirContext, dims::intptr_t, results::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -1986,7 +2199,9 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
+        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
+    )::MlirAffineMap
 end
 
 """
@@ -2031,7 +2246,9 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
+        affineMap::MlirAffineMap
+    )::Int64
 end
 
 """
@@ -2067,7 +2284,9 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
+        affineMap::MlirAffineMap, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -2085,7 +2304,9 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
+        affineMap::MlirAffineMap
+    )::Bool
 end
 
 """
@@ -2103,7 +2324,9 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
+        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
+    )::MlirAffineMap
 end
 
 """
@@ -2112,7 +2335,9 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2121,7 +2346,9 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2129,8 +2356,16 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
+function mlirAffineMapReplace(
+    affineMap, expression, replacement, numResultDims, numResultSyms
+)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
+        affineMap::MlirAffineMap,
+        expression::MlirAffineExpr,
+        replacement::MlirAffineExpr,
+        numResultDims::intptr_t,
+        numResultSyms::intptr_t,
+    )::MlirAffineMap
 end
 
 """
@@ -2139,7 +2374,12 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
+        affineMaps::Ptr{MlirAffineMap},
+        size::intptr_t,
+        result::Ptr{Cvoid},
+        populateResult::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -2193,7 +2433,9 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2211,7 +2453,9 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2229,7 +2473,9 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2247,7 +2493,9 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -2256,7 +2504,9 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
+        attr::MlirAttribute, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2274,7 +2524,9 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
+        ctx::MlirContext, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2283,7 +2535,9 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
+        loc::MlirLocation, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2391,7 +2645,13 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
+        ctx::MlirContext,
+        dialectNamespace::MlirStringRef,
+        dataLength::intptr_t,
+        data::Cstring,
+        type::MlirType,
+    )::MlirAttribute
 end
 
 """
@@ -2400,7 +2660,9 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2427,7 +2689,9 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
+        ctx::MlirContext, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2436,7 +2700,9 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
+        type::MlirType, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2463,7 +2729,12 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
+        ctx::MlirContext,
+        symbol::MlirStringRef,
+        numReferences::intptr_t,
+        references::Ptr{MlirAttribute},
+    )::MlirAttribute
 end
 
 """
@@ -2472,7 +2743,9 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2481,7 +2754,9 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2490,7 +2765,9 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -2499,7 +2776,9 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2517,7 +2796,9 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
+        ctx::MlirContext, symbol::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2589,7 +2870,9 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 """
@@ -2598,7 +2881,9 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::Bool
 end
 
 """
@@ -2649,31 +2934,45 @@ end
 Create a dense array attribute with the given elements.
 """
 function mlirDenseBoolArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cint})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Cint}
+    )::MlirAttribute
 end
 
 function mlirDenseI8ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int8}
+    )::MlirAttribute
 end
 
 function mlirDenseI16ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int16}
+    )::MlirAttribute
 end
 
 function mlirDenseI32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int32}
+    )::MlirAttribute
 end
 
 function mlirDenseI64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirDenseF32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat}
+    )::MlirAttribute
 end
 
 function mlirDenseF64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble}
+    )::MlirAttribute
 end
 
 """
@@ -2691,31 +2990,45 @@ end
 Get an element of a dense array.
 """
 function mlirDenseBoolArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseI8ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseI16ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseI32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseI64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseF32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseF64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -2741,11 +3054,24 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
+"""
+    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
+
+Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
+
+The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
+
+A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
+"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
+        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
+    )::MlirAttribute
 end
 
 """
@@ -2754,43 +3080,63 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
+        shapedType::MlirType, element::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
+        shapedType::MlirType, element::Bool
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
+        shapedType::MlirType, element::UInt8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
+        shapedType::MlirType, element::Int8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
+        shapedType::MlirType, element::UInt32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
+        shapedType::MlirType, element::Int32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
+        shapedType::MlirType, element::UInt64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
+        shapedType::MlirType, element::Int64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
+        shapedType::MlirType, element::Cfloat
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
+        shapedType::MlirType, element::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2799,55 +3145,81 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 """
@@ -2856,7 +3228,9 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
+        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
+    )::MlirAttribute
 end
 
 """
@@ -2865,7 +3239,9 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
+        attr::MlirAttribute, shapedType::MlirType
+    )::MlirAttribute
 end
 
 """
@@ -2883,7 +3259,9 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -2895,35 +3273,51 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
+        attr::MlirAttribute
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
+        attr::MlirAttribute
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
+        attr::MlirAttribute
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
+        attr::MlirAttribute
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
+        attr::MlirAttribute
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
+        attr::MlirAttribute
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
+        attr::MlirAttribute
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2932,51 +3326,75 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirStringRef
 end
 
 """
@@ -2988,48 +3406,125 @@ function mlirDenseElementsAttrGetRawData(attr)
     @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetRawData(attr::MlirAttribute)::Ptr{Cvoid}
 end
 
-function mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
+function mlirUnmanagedDenseBoolResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Cint},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
+function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt8},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
+function mlirUnmanagedDenseInt8ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int8},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt16},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
+function mlirUnmanagedDenseInt16ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int16},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
+function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt32},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
+function mlirUnmanagedDenseInt32ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int32},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
+function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt64},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
+function mlirUnmanagedDenseInt64ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int64},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
+function mlirUnmanagedDenseFloatResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Cfloat},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
+function mlirUnmanagedDenseDoubleResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Cdouble},
+    )::MlirAttribute
 end
 
 """
@@ -3038,47 +3533,69 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense resource elements attribute.
 """
 function mlirDenseBoolResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseUInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt8
 end
 
 function mlirDenseInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseUInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt16
 end
 
 function mlirDenseInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseUInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt32
 end
 
 function mlirDenseInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseUInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt64
 end
 
 function mlirDenseFloatResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseDoubleResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -3096,7 +3613,9 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
+        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -3105,7 +3624,9 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -3114,7 +3635,9 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirAttributeIsAStridedLayout(attr)
@@ -3122,7 +3645,9 @@ function mlirAttributeIsAStridedLayout(attr)
 end
 
 function mlirStridedLayoutAttrGet(ctx, offset, numStrides, strides)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(
+        ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirStridedLayoutAttrGetOffset(attr)
@@ -3134,7 +3659,9 @@ function mlirStridedLayoutAttrGetNumStrides(attr)
 end
 
 function mlirStridedLayoutAttrGetStride(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 """
@@ -3161,7 +3688,9 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -3170,7 +3699,9 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -3494,7 +4025,9 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3503,7 +4036,9 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
+        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3539,7 +4074,9 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3548,7 +4085,13 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
+        loc::MlirLocation,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        elementType::MlirType,
+        encoding::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3575,7 +4118,9 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -3602,7 +4147,13 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3611,7 +4162,14 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3620,7 +4178,9 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
+        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3629,7 +4189,13 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -3638,7 +4204,9 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
+        elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3647,7 +4215,9 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -3701,7 +4271,9 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
+    )::MlirType
 end
 
 """
@@ -3737,7 +4309,13 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
+        ctx::MlirContext,
+        numInputs::intptr_t,
+        inputs::Ptr{MlirType},
+        numResults::intptr_t,
+        results::Ptr{MlirType},
+    )::MlirType
 end
 
 """
@@ -3773,7 +4351,9 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
+        type::MlirType, pos::intptr_t
+    )::MlirType
 end
 
 """
@@ -3791,7 +4371,9 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
+        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -3827,7 +4409,9 @@ end
 Create a new top-level PassManager anchored on `anchorOp`.
 """
 function mlirPassManagerCreateOnOperation(ctx, anchorOp)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(ctx::MlirContext, anchorOp::MlirStringRef)::MlirPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(
+        ctx::MlirContext, anchorOp::MlirStringRef
+    )::MlirPassManager
 end
 
 """
@@ -3854,7 +4438,9 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
+        passManager::MlirPassManager
+    )::MlirOpPassManager
 end
 
 """
@@ -3863,7 +4449,9 @@ end
 Run the provided `passManager` on the given `module`.
 """
 function mlirPassManagerRun(passManager, _module)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(passManager::MlirPassManager, _module::MlirModule)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRun(
+        passManager::MlirPassManager, _module::MlirModule
+    )::MlirLogicalResult
 end
 
 """
@@ -3872,7 +4460,9 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
+        passManager::MlirPassManager
+    )::Cvoid
 end
 
 """
@@ -3881,7 +4471,9 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
+        passManager::MlirPassManager, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -3890,7 +4482,9 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
+        passManager::MlirPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -3899,7 +4493,9 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
+        passManager::MlirOpPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -3908,7 +4504,9 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
+        passManager::MlirPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -3917,7 +4515,9 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
+        passManager::MlirOpPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -3926,7 +4526,12 @@ end
 Parse a sequence of textual MLIR pass pipeline elements and add them to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirOpPassManagerAddPipeline(passManager, pipelineElements, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(passManager::MlirOpPassManager, pipelineElements::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(
+        passManager::MlirOpPassManager,
+        pipelineElements::MlirStringRef,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -3935,7 +4540,9 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
+        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -3944,7 +4551,12 @@ end
 Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
+        passManager::MlirOpPassManager,
+        pipeline::MlirStringRef,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -3952,8 +4564,28 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
+function mlirCreateExternalPass(
+    passID,
+    name,
+    argument,
+    description,
+    opName,
+    nDependentDialects,
+    dependentDialects,
+    callbacks,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
+        passID::MlirTypeID,
+        name::MlirStringRef,
+        argument::MlirStringRef,
+        description::MlirStringRef,
+        opName::MlirStringRef,
+        nDependentDialects::intptr_t,
+        dependentDialects::Ptr{MlirDialectHandle},
+        callbacks::MlirExternalPassCallbacks,
+        userData::Ptr{Cvoid},
+    )::MlirPass
 end
 
 """
@@ -4464,7 +5096,9 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
+        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -4473,7 +5107,9 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
+        diagnostic::MlirDiagnostic
+    )::MlirLocation
 end
 
 """
@@ -4482,7 +5118,9 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
+        diagnostic::MlirDiagnostic
+    )::MlirDiagnosticSeverity
 end
 
 """
@@ -4500,7 +5138,9 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
+        diagnostic::MlirDiagnostic, pos::intptr_t
+    )::MlirDiagnostic
 end
 
 """
@@ -4509,7 +5149,12 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
+        context::MlirContext,
+        handler::MlirDiagnosticHandler,
+        userData::Ptr{Cvoid},
+        deleteUserData::Ptr{Cvoid},
+    )::MlirDiagnosticHandlerID
 end
 
 """
@@ -4518,7 +5163,9 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
+        context::MlirContext, id::MlirDiagnosticHandlerID
+    )::Cvoid
 end
 
 """
@@ -4652,7 +5299,9 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
+        pointee::MlirType, addressSpace::Cuint
+    )::MlirType
 end
 
 """
@@ -4670,7 +5319,9 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
+        elementType::MlirType, numElements::Cuint
+    )::MlirType
 end
 
 """
@@ -4679,7 +5330,12 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
+        resultType::MlirType,
+        nArgumentTypes::intptr_t,
+        argumentTypes::Ptr{MlirType},
+        isVarArg::Bool,
+    )::MlirType
 end
 
 """
@@ -4688,7 +5344,9 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
+        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
+    )::MlirType
 end
 
 """
@@ -4880,7 +5538,9 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -4889,7 +5549,9 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -4952,7 +5614,9 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
+        type::MlirType
+    )::Cuint
 end
 
 """
@@ -4961,7 +5625,9 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
+        type::MlirType, candidate::MlirType
+    )::Bool
 end
 
 """
@@ -4970,7 +5636,9 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
+        type::MlirType
+    )::MlirType
 end
 
 """
@@ -4979,7 +5647,9 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -4997,7 +5667,9 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -5015,7 +5687,9 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -5032,8 +5706,16 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirAnyQuantizedTypeGet(
+    flags, storageType, expressedType, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -5050,8 +5732,18 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedTypeGet(
+    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        scale::Cdouble,
+        zeroPoint::Int64,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -5095,8 +5787,28 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(
+    flags,
+    storageType,
+    expressedType,
+    nDims,
+    scales,
+    zeroPoints,
+    quantizedDimension,
+    storageTypeMin,
+    storageTypeMax,
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        nDims::intptr_t,
+        scales::Ptr{Cdouble},
+        zeroPoints::Ptr{Int64},
+        quantizedDimension::Int32,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -5105,7 +5817,9 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
+        type::MlirType
+    )::intptr_t
 end
 
 """
@@ -5114,7 +5828,9 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
+        type::MlirType, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -5123,7 +5839,9 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
+        type::MlirType, pos::intptr_t
+    )::Int64
 end
 
 """
@@ -5132,7 +5850,9 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
+        type::MlirType
+    )::Int32
 end
 
 """
@@ -5159,7 +5879,9 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
+        expressedType::MlirType, min::Cdouble, max::Cdouble
+    )::MlirType
 end
 
 """
@@ -5217,7 +5939,9 @@ end
 Checks whether the given attribute is a sparse\\_tensor.encoding attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
+        attr::MlirAttribute
+    )::Bool
 end
 
 """
@@ -5225,8 +5949,24 @@ end
 
 Creates a sparse\\_tensor.encoding attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(ctx, numDimLevelTypes, dimLevelTypes, dimOrdering, higherOrdering, pointerBitWidth, indexBitWidth)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, numDimLevelTypes::intptr_t, dimLevelTypes::Ptr{MlirSparseTensorDimLevelType}, dimOrdering::MlirAffineMap, higherOrdering::MlirAffineMap, pointerBitWidth::Cint, indexBitWidth::Cint)::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(
+    ctx,
+    numDimLevelTypes,
+    dimLevelTypes,
+    dimOrdering,
+    higherOrdering,
+    pointerBitWidth,
+    indexBitWidth,
+)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
+        ctx::MlirContext,
+        numDimLevelTypes::intptr_t,
+        dimLevelTypes::Ptr{MlirSparseTensorDimLevelType},
+        dimOrdering::MlirAffineMap,
+        higherOrdering::MlirAffineMap,
+        pointerBitWidth::Cint,
+        indexBitWidth::Cint,
+    )::MlirAttribute
 end
 
 """
@@ -5235,7 +5975,9 @@ end
 Returns the number of dim level types in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingGetNumDimLevelTypes(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingGetNumDimLevelTypes(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -5244,7 +5986,9 @@ end
 Returns a specified dim level type in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimLevelType(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(attr::MlirAttribute, pos::intptr_t)::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimLevelType(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5253,7 +5997,9 @@ end
 Returns the dimension ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(attr::MlirAttribute)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimOrdering(
+        attr::MlirAttribute
+    )::MlirAffineMap
 end
 
 """
@@ -5262,7 +6008,9 @@ end
 Returns the higher ordering in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetHigherOrdering(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetHigherOrdering(attr::MlirAttribute)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetHigherOrdering(
+        attr::MlirAttribute
+    )::MlirAffineMap
 end
 
 """
@@ -5271,7 +6019,9 @@ end
 Returns the pointer bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetPointerBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPointerBitWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 """
@@ -5280,7 +6030,9 @@ end
 Returns the index bit width in a sparse\\_tensor.encoding attribute.
 """
 function mlirSparseTensorEncodingAttrGetIndexBitWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetIndexBitWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -5372,11 +6124,15 @@ function mlirTypeIsATransformOperationType(type)
 end
 
 function mlirTransformOperationTypeGet(ctx, operationName)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(ctx::MlirContext, operationName::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(
+        ctx::MlirContext, operationName::MlirStringRef
+    )::MlirType
 end
 
 function mlirTransformOperationTypeGetOperationName(type)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(
+        type::MlirType
+    )::MlirStringRef
 end
 
 """
@@ -5385,7 +6141,13 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}, enableObjectDump::Bool)::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
+        op::MlirModule,
+        optLevel::Cint,
+        numPaths::Cint,
+        sharedLibPaths::Ptr{MlirStringRef},
+        enableObjectDump::Bool,
+    )::MlirExecutionEngine
 end
 
 """
@@ -5412,7 +6174,9 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
+        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
+    )::MlirLogicalResult
 end
 
 """
@@ -5421,7 +6185,9 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -5430,7 +6196,9 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -5439,7 +6207,9 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
+        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -5448,7 +6218,9 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
+        jit::MlirExecutionEngine, fileName::MlirStringRef
+    )::Cvoid
 end
 
 """
@@ -5484,7 +6256,9 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
+        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -5502,7 +6276,9 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
+        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
+    )::MlirIntegerSet
 end
 
 """
@@ -5510,8 +6286,17 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
+function mlirIntegerSetGet(
+    context, numDims, numSymbols, numConstraints, constraints, eqFlags
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
+        context::MlirContext,
+        numDims::intptr_t,
+        numSymbols::intptr_t,
+        numConstraints::intptr_t,
+        constraints::Ptr{MlirAffineExpr},
+        eqFlags::Ptr{Bool},
+    )::MlirIntegerSet
 end
 
 """
@@ -5519,8 +6304,16 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
+function mlirIntegerSetReplaceGet(
+    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
+        set::MlirIntegerSet,
+        dimReplacements::Ptr{MlirAffineExpr},
+        symbolReplacements::Ptr{MlirAffineExpr},
+        numResultDims::intptr_t,
+        numResultSymbols::intptr_t,
+    )::MlirIntegerSet
 end
 
 """
@@ -5592,7 +6385,9 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
+        set::MlirIntegerSet, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -5601,7 +6396,9 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
+        set::MlirIntegerSet, pos::intptr_t
+    )::Bool
 end
 
 """
@@ -5610,7 +6407,9 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
+        operation::MlirOperation, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -5619,7 +6418,9 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
+        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -5642,8 +6443,30 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, nRegions, regions, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(
+    opName,
+    context,
+    location,
+    nOperands,
+    operands,
+    attributes,
+    nRegions,
+    regions,
+    callback,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
+        opName::MlirStringRef,
+        context::MlirContext,
+        location::MlirLocation,
+        nOperands::intptr_t,
+        operands::Ptr{MlirValue},
+        attributes::MlirAttribute,
+        nRegions::intptr_t,
+        regions::Ptr{MlirRegion},
+        callback::MlirTypesCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -5788,4 +6611,3 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
-

--- a/src/API/16/libMLIR_h.jl
+++ b/src/API/16/libMLIR_h.jl
@@ -2,30 +2,6 @@ using CEnum
 
 const intptr_t = Clong
 
-struct MlirDialectHandle
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeID
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeIDAllocator
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirStringRef
-
-| Field | Note                          |
-| :---- | :---------------------------- |
-| data  | Pointer to the first symbol.  |
-"""
-struct MlirStringRef
-    data::Cstring
-    length::Cint
-end
-
 function mlirStringRefCreate(str, length)
     @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
@@ -55,15 +31,6 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
-
-"""
-    MlirLogicalResult
-
-A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
-"""
-struct MlirLogicalResult
-    value::Int8
-end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -157,78 +124,6 @@ Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
     @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
-end
-
-struct MlirContext
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialect
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialectRegistry
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOperation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpOperand
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPrintingFlags
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirBlock
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirRegion
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirSymbolTable
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirAttribute
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirIdentifier
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirLocation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirModule
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirType
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirValue
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirNamedAttribute
-
-Named MLIR attribute.
-
-A named attribute is essentially a (name, attribute) pair where the name is a string.
-"""
-struct MlirNamedAttribute
-    name::MlirIdentifier
-    attribute::MlirAttribute
 end
 
 """
@@ -598,22 +493,6 @@ Views the generic operation as a module. The returned module is null when the in
 """
 function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
-end
-
-struct MlirOperationState
-    name::MlirStringRef
-    location::MlirLocation
-    nResults::intptr_t
-    results::Ptr{MlirType}
-    nOperands::intptr_t
-    operands::Ptr{MlirValue}
-    nRegions::intptr_t
-    regions::Ptr{MlirRegion}
-    nSuccessors::intptr_t
-    successors::Ptr{MlirBlock}
-    nAttributes::intptr_t
-    attributes::Ptr{MlirNamedAttribute}
-    enableResultTypeInference::Bool
 end
 
 """
@@ -1705,10 +1584,6 @@ function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, user
     @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
-struct MlirAffineExpr
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirAffineExprGetContext(affineExpr)
 
@@ -1797,10 +1672,6 @@ Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
     @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
-end
-
-struct MlirAffineMap
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -3941,22 +3812,6 @@ function mlirOpaqueTypeGetData(type)
     @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGetData(type::MlirType)::MlirStringRef
 end
 
-struct MlirPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirExternalPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirPassManager
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPassManager
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirPassManagerCreate(ctx)
 
@@ -4090,27 +3945,6 @@ Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. 
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
     @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
-end
-
-"""
-    MlirExternalPassCallbacks
-
-Structure of external [`MlirPass`](@ref) callbacks. All callbacks are required to be set unless otherwise specified.
-
-| Field      | Note                                                                                                                                                                                              |
-| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| construct  | This callback is called from the pass is created. This is analogous to a C++ pass constructor.                                                                                                    |
-| destruct   | This callback is called when the pass is destroyed This is analogous to a C++ pass destructor.                                                                                                    |
-| initialize | This callback is optional. The callback is called before the pass is run, allowing a chance to initialize any complex state necessary for running the pass. See Pass::initialize(MLIRContext *).  |
-| clone      | This callback is called when the pass is cloned. See Pass::clonePass().                                                                                                                           |
-| run        | This callback is called when the pass is run. See Pass::runOnOperation().                                                                                                                         |
-"""
-struct MlirExternalPassCallbacks
-    construct::Ptr{Cvoid}
-    destruct::Ptr{Cvoid}
-    initialize::Ptr{Cvoid}
-    clone::Ptr{Cvoid}
-    run::Ptr{Cvoid}
 end
 
 """
@@ -4599,15 +4433,6 @@ Retuns `true` if the global debugging flag is set, false otherwise.
 """
 function mlirIsGlobalDebugEnabled()
     @ccall (MLIR_C_PATH[]).mlirIsGlobalDebugEnabled()::Bool
-end
-
-"""
-    MlirDiagnostic
-
-An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
-"""
-struct MlirDiagnostic
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -5554,10 +5379,6 @@ function mlirTransformOperationTypeGetOperationName(type)
     @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
 end
 
-struct MlirExecutionEngine
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
 
@@ -5628,10 +5449,6 @@ Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
     @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
-end
-
-struct MlirIntegerSet
-    ptr::Ptr{Cvoid}
 end
 
 """

--- a/src/API/17/libMLIR_h.jl
+++ b/src/API/17/libMLIR_h.jl
@@ -2,13 +2,8 @@ using CEnum
 
 const intptr_t = Clong
 
-"""
-    mlirStringRefCreate(str, length)
-
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
-"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -26,9 +21,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -120,13 +113,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -153,9 +141,7 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
-        allocator::MlirTypeIDAllocator
-    )::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
 end
 
 """
@@ -173,9 +159,7 @@ end
 Creates an MLIR context with an explicit setting of the multithreading setting and transfers its ownership to the caller.
 """
 function mlirContextCreateWithThreading(threadingEnabled)
-    @ccall (MLIR_C_PATH[]).mlirContextCreateWithThreading(
-        threadingEnabled::Bool
-    )::MlirContext
+    @ccall (MLIR_C_PATH[]).mlirContextCreateWithThreading(threadingEnabled::Bool)::MlirContext
 end
 
 """
@@ -184,9 +168,7 @@ end
 Creates an MLIR context, setting the multithreading setting explicitly and pre-loading the dialects from the provided DialectRegistry.
 """
 function mlirContextCreateWithRegistry(registry, threadingEnabled)
-    @ccall (MLIR_C_PATH[]).mlirContextCreateWithRegistry(
-        registry::MlirDialectRegistry, threadingEnabled::Bool
-    )::MlirContext
+    @ccall (MLIR_C_PATH[]).mlirContextCreateWithRegistry(registry::MlirDialectRegistry, threadingEnabled::Bool)::MlirContext
 end
 
 """
@@ -222,9 +204,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -233,9 +213,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -244,9 +222,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -255,9 +231,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -275,9 +249,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -286,9 +258,7 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -306,9 +276,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -317,9 +285,7 @@ end
 Sets the thread pool of the context explicitly, enabling multithreading in the process. This API should be used to avoid re-creating thread pools in long-running applications that perform multiple compilations, see the C++ documentation for MLIRContext for details.
 """
 function mlirContextSetThreadPool(context, threadPool)
-    @ccall (MLIR_C_PATH[]).mlirContextSetThreadPool(
-        context::MlirContext, threadPool::MlirLlvmThreadPool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetThreadPool(context::MlirContext, threadPool::MlirLlvmThreadPool)::Cvoid
 end
 
 """
@@ -346,9 +312,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -366,9 +330,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -377,9 +339,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -388,9 +348,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -399,9 +357,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -455,9 +411,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -466,9 +420,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -477,12 +429,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -491,9 +438,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -538,9 +483,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -558,9 +501,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -623,9 +564,7 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -634,33 +573,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -669,9 +598,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -698,9 +625,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -709,9 +634,7 @@ end
 Enable or disable printing of debug information (based on `enable`). If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, enable, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -720,9 +643,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -731,9 +652,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -742,9 +661,7 @@ end
 Do not verify the operation when using custom operation printers.
 """
 function mlirOpPrintingFlagsAssumeVerified(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsAssumeVerified(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsAssumeVerified(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -762,9 +679,7 @@ end
 Destroys printing flags created with [`mlirBytecodeWriterConfigCreate`](@ref).
 """
 function mlirBytecodeWriterConfigDestroy(config)
-    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDestroy(
-        config::MlirBytecodeWriterConfig
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDestroy(config::MlirBytecodeWriterConfig)::Cvoid
 end
 
 """
@@ -773,9 +688,7 @@ end
 Sets the version to emit in the writer config.
 """
 function mlirBytecodeWriterConfigDesiredEmitVersion(flags, version)
-    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDesiredEmitVersion(
-        flags::MlirBytecodeWriterConfig, version::Int64
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDesiredEmitVersion(flags::MlirBytecodeWriterConfig, version::Int64)::Cvoid
 end
 
 """
@@ -786,9 +699,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -799,9 +710,7 @@ Parses an operation, giving ownership to the caller. If parsing fails a null ope
 `sourceStr` may be either the text assembly format, or binary bytecode format. `sourceName` is used as the file name of the source; any IR without locations will get a `FileLineColLoc` location with `sourceName` as the file name.
 """
 function mlirOperationCreateParse(context, sourceStr, sourceName)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreateParse(
-        context::MlirContext, sourceStr::MlirStringRef, sourceName::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreateParse(context::MlirContext, sourceStr::MlirStringRef, sourceName::MlirStringRef)::MlirOperation
 end
 
 """
@@ -918,9 +827,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -947,9 +854,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -958,9 +863,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -969,9 +872,7 @@ end
 Replaces the operands of the operation.
 """
 function mlirOperationSetOperands(op, nOperands, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperands(
-        op::MlirOperation, nOperands::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperands(op::MlirOperation, nOperands::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 """
@@ -989,9 +890,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -1009,9 +908,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -1029,9 +926,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -1040,9 +935,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1051,9 +944,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -1062,9 +953,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -1073,9 +962,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1084,12 +971,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1098,9 +980,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but writing the bytecode format.
 """
 function mlirOperationWriteBytecode(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1109,12 +989,7 @@ end
 Same as [`mlirOperationWriteBytecode`](@ref) but with writer config and returns failure only if desired bytecode could not be honored.
 """
 function mlirOperationWriteBytecodeWithConfig(op, config, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecodeWithConfig(
-        op::MlirOperation,
-        config::MlirBytecodeWriterConfig,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecodeWithConfig(op::MlirOperation, config::MlirBytecodeWriterConfig, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -1141,9 +1016,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1152,9 +1025,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1208,9 +1079,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1219,9 +1088,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1230,9 +1097,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1241,9 +1106,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1279,9 +1142,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1371,9 +1232,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1382,9 +1241,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1393,9 +1250,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1404,9 +1259,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1424,9 +1277,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1435,9 +1286,7 @@ end
 Inserts an argument of the specified type at a specified index to the block. Returns the newly added argument.
 """
 function mlirBlockInsertArgument(block, pos, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertArgument(
-        block::MlirBlock, pos::intptr_t, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertArgument(block::MlirBlock, pos::intptr_t, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1455,9 +1304,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1565,9 +1412,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1576,12 +1421,7 @@ end
 Prints a value as an operand (i.e., the ValueID).
 """
 function mlirValuePrintAsOperand(value, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrintAsOperand(
-        value::MlirValue,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrintAsOperand(value::MlirValue, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1599,9 +1439,7 @@ end
 Replace all uses of 'of' value with the 'with' value, updating anything in the IR that uses 'of' to use the other value instead. When this returns there are zero uses of 'of'.
 """
 function mlirValueReplaceAllUsesOfWith(of, with)
-    @ccall (MLIR_C_PATH[]).mlirValueReplaceAllUsesOfWith(
-        of::MlirValue, with::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValueReplaceAllUsesOfWith(of::MlirValue, with::MlirValue)::Cvoid
 end
 
 """
@@ -1646,9 +1484,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1702,9 +1538,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1722,9 +1556,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1787,9 +1619,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1807,9 +1637,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1818,9 +1646,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1838,9 +1664,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1903,9 +1727,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1914,9 +1736,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1925,9 +1745,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1936,9 +1754,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1947,12 +1763,7 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1970,9 +1781,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1990,9 +1799,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2010,9 +1817,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -2030,9 +1835,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -2041,9 +1844,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -2052,9 +1853,7 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
 end
 
 """
@@ -2063,9 +1862,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -2083,9 +1880,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2094,9 +1889,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -2114,9 +1907,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2125,9 +1916,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -2145,9 +1934,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -2174,9 +1961,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2194,9 +1979,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2214,9 +1997,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2234,9 +2015,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2254,9 +2033,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2274,9 +2051,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2285,9 +2060,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2323,9 +2096,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2352,9 +2123,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2363,13 +2132,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2378,9 +2141,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2389,9 +2150,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2400,9 +2159,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2411,9 +2168,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2458,9 +2213,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2496,9 +2249,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2516,9 +2267,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2536,9 +2285,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2547,9 +2294,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2558,9 +2303,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2568,16 +2311,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2586,12 +2321,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2658,9 +2388,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2678,9 +2406,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2707,9 +2433,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2727,9 +2451,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2738,9 +2460,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2767,9 +2487,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2778,9 +2496,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2915,13 +2631,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2930,9 +2640,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2968,9 +2676,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2979,9 +2685,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -3017,12 +2721,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -3031,9 +2730,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3042,9 +2739,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3053,9 +2748,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -3064,9 +2757,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -3093,9 +2784,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -3185,9 +2874,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -3196,9 +2883,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -3253,45 +2938,31 @@ end
 Create a dense array attribute with the given elements.
 """
 function mlirDenseBoolArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseI8ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseI16ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseI32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseI64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseF32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseF64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -3309,45 +2980,31 @@ end
 Get an element of a dense array.
 """
 function mlirDenseBoolArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseI8ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseI16ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseI32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseI64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseF32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseF64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3382,24 +3039,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -3408,63 +3052,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -3473,81 +3097,55 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 """
@@ -3556,9 +3154,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -3567,9 +3163,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -3587,9 +3181,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3601,51 +3193,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3654,75 +3230,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3734,125 +3286,48 @@ function mlirDenseElementsAttrGetRawData(attr)
     @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetRawData(attr::MlirAttribute)::Ptr{Cvoid}
 end
 
-function mlirUnmanagedDenseBoolResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cint},
-    )::MlirAttribute
+function mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt8},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int8},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt16},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int16},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt32},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int32},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt64},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int64},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseFloatResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cfloat},
-    )::MlirAttribute
+function mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
-function mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cdouble},
-    )::MlirAttribute
+function mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -3861,69 +3336,47 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense resource elements attribute.
 """
 function mlirDenseBoolResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseUInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseUInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseUInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseUInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseFloatResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseDoubleResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3941,9 +3394,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3952,9 +3403,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3963,9 +3412,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3982,9 +3429,7 @@ function mlirAttributeIsAStridedLayout(attr)
 end
 
 function mlirStridedLayoutAttrGet(ctx, offset, numStrides, strides)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(
-        ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64})::MlirAttribute
 end
 
 function mlirStridedLayoutAttrGetOffset(attr)
@@ -3996,9 +3441,7 @@ function mlirStridedLayoutAttrGetNumStrides(attr)
 end
 
 function mlirStridedLayoutAttrGetStride(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 """
@@ -4043,9 +3486,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -4054,9 +3495,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -4578,9 +4017,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4589,9 +4026,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4645,9 +4080,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4656,13 +4089,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4689,9 +4116,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -4736,13 +4161,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4751,14 +4170,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4767,9 +4179,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4778,13 +4188,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4793,9 +4197,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4804,9 +4206,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4869,9 +4269,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4916,13 +4314,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4958,9 +4350,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -4987,9 +4377,7 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
-        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
 end
 
 """
@@ -5025,9 +4413,7 @@ end
 Create a new top-level PassManager anchored on `anchorOp`.
 """
 function mlirPassManagerCreateOnOperation(ctx, anchorOp)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(
-        ctx::MlirContext, anchorOp::MlirStringRef
-    )::MlirPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(ctx::MlirContext, anchorOp::MlirStringRef)::MlirPassManager
 end
 
 """
@@ -5054,9 +4440,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -5065,9 +4449,7 @@ end
 Run the provided `passManager` on the given `op`.
 """
 function mlirPassManagerRunOnOp(passManager, op)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRunOnOp(
-        passManager::MlirPassManager, op::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRunOnOp(passManager::MlirPassManager, op::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -5076,9 +4458,7 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -5087,9 +4467,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -5098,9 +4476,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -5109,9 +4485,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -5120,9 +4494,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -5131,9 +4503,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -5142,12 +4512,7 @@ end
 Parse a sequence of textual MLIR pass pipeline elements and add them to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirOpPassManagerAddPipeline(passManager, pipelineElements, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(
-        passManager::MlirOpPassManager,
-        pipelineElements::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(passManager::MlirOpPassManager, pipelineElements::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -5156,9 +4521,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5167,12 +4530,7 @@ end
 Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager,
-        pipeline::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -5180,28 +4538,8 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(
-    passID,
-    name,
-    argument,
-    description,
-    opName,
-    nDependentDialects,
-    dependentDialects,
-    callbacks,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
-        passID::MlirTypeID,
-        name::MlirStringRef,
-        argument::MlirStringRef,
-        description::MlirStringRef,
-        opName::MlirStringRef,
-        nDependentDialects::intptr_t,
-        dependentDialects::Ptr{MlirDialectHandle},
-        callbacks::MlirExternalPassCallbacks,
-        userData::Ptr{Cvoid},
-    )::MlirPass
+function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
 end
 
 """
@@ -5744,9 +5082,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5755,9 +5091,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -5766,9 +5100,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -5786,9 +5118,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -5797,12 +5127,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -5811,9 +5136,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -5899,9 +5222,7 @@ end
 Sets the argument attribute 'name' of an argument at index 'pos'. Asserts that the operation is a FuncOp.
 """
 function mlirFuncSetArgAttr(op, pos, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirFuncSetArgAttr(
-        op::MlirOperation, pos::intptr_t, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirFuncSetArgAttr(op::MlirOperation, pos::intptr_t, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 function mlirGetDialectHandle__gpu__()
@@ -5954,9 +5275,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -5974,9 +5293,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -5985,12 +5302,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -5999,9 +5311,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -6201,9 +5511,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -6212,9 +5520,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -6277,9 +5583,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -6288,9 +5592,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -6299,9 +5601,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -6310,9 +5610,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -6330,9 +5628,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -6350,9 +5646,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -6369,16 +5663,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -6395,18 +5681,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -6450,28 +5726,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -6480,9 +5736,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -6491,9 +5745,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -6502,9 +5754,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -6513,9 +5763,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -6542,9 +5790,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -6607,9 +5853,7 @@ end
 Checks whether the given attribute is a `sparse\\_tensor.encoding` attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -6617,17 +5861,8 @@ end
 
 Creates a `sparse\\_tensor.encoding` attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx, lvlRank, lvlTypes, dimToLvl, posWidth, crdWidth
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        lvlRank::intptr_t,
-        lvlTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimToLvl::MlirAffineMap,
-        posWidth::Cint,
-        crdWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, lvlRank, lvlTypes, dimToLvl, posWidth, crdWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, lvlRank::intptr_t, lvlTypes::Ptr{MlirSparseTensorDimLevelType}, dimToLvl::MlirAffineMap, posWidth::Cint, crdWidth::Cint)::MlirAttribute
 end
 
 """
@@ -6645,9 +5880,7 @@ end
 Returns a specified level-type of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetLvlType(attr, lvl)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetLvlType(
-        attr::MlirAttribute, lvl::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetLvlType(attr::MlirAttribute, lvl::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -6656,9 +5889,7 @@ end
 Returns the dimension-to-level mapping of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimToLvl(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimToLvl(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimToLvl(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -6667,9 +5898,7 @@ end
 Returns the position bitwidth of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetPosWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPosWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPosWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -6678,9 +5907,7 @@ end
 Returns the coordinate bitwidth of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetCrdWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetCrdWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetCrdWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -6784,15 +6011,11 @@ function mlirTransformOperationTypeGetTypeID()
 end
 
 function mlirTransformOperationTypeGet(ctx, operationName)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(
-        ctx::MlirContext, operationName::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(ctx::MlirContext, operationName::MlirStringRef)::MlirType
 end
 
 function mlirTransformOperationTypeGetOperationName(type)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(
-        type::MlirType
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
 end
 
 function mlirGetDialectHandle__vector__()
@@ -6805,13 +6028,7 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule,
-        optLevel::Cint,
-        numPaths::Cint,
-        sharedLibPaths::Ptr{MlirStringRef},
-        enableObjectDump::Bool,
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}, enableObjectDump::Bool)::MlirExecutionEngine
 end
 
 """
@@ -6838,9 +6055,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -6849,9 +6064,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6860,9 +6073,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6871,9 +6082,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6882,9 +6091,7 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
 end
 
 """
@@ -6920,9 +6127,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6940,9 +6145,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -6950,17 +6153,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -6968,16 +6162,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -7049,9 +6235,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -7060,9 +6244,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -7071,9 +6253,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -7082,9 +6262,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -7107,32 +6285,8 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    properties,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        properties::Ptr{Cvoid},
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, properties, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, properties::Ptr{Cvoid}, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -7155,32 +6309,8 @@ const MlirShapedTypeComponentsCallback = Ptr{Cvoid}
 
 Infers the return shaped type components of the operation. Calls `callback` with the types of inferred arguments on success. Returns failure otherwise.
 """
-function mlirInferShapedTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    properties,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferShapedTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        properties::Ptr{Cvoid},
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirShapedTypeComponentsCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferShapedTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, properties, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferShapedTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, properties::Ptr{Cvoid}, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirShapedTypeComponentsCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -7349,3 +6479,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/17/libMLIR_h.jl
+++ b/src/API/17/libMLIR_h.jl
@@ -1,16 +1,42 @@
 using CEnum
 
-const __darwin_intptr_t = Clong
+const intptr_t = Clong
 
-const intptr_t = __darwin_intptr_t
+struct MlirDialectHandle
+    ptr::Ptr{Cvoid}
+end
 
 """
-    mlirStringRefCreate(str, length)
+    MlirLlvmThreadPool
 
-Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+Re-export llvm::ThreadPool so as to avoid including the LLVM C API directly.
 """
+struct MlirLlvmThreadPool
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeID
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirTypeIDAllocator
+    ptr::Ptr{Cvoid}
+end
+
+"""
+    MlirStringRef
+
+| Field | Note                          |
+| :---- | :---------------------------- |
+| data  | Pointer to the first symbol.  |
+"""
+struct MlirStringRef
+    data::Cstring
+    length::Cint
+end
+
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
 
 """
@@ -28,9 +54,7 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
-        string::MlirStringRef, other::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -40,6 +64,15 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
+
+"""
+    MlirLogicalResult
+
+A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
+"""
+struct MlirLogicalResult
+    value::Int8
+end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -122,13 +155,8 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
-"""
-    mlirTypeIDHashValue(typeID)
-
-Returns the hash value of the type id.
-"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
 end
 
 """
@@ -155,9 +183,83 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
-        allocator::MlirTypeIDAllocator
-    )::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
+end
+
+struct MlirBytecodeWriterConfig
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirContext
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialect
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirDialectRegistry
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOperation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpOperand
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPrintingFlags
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirBlock
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirRegion
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirSymbolTable
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirAttribute
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirIdentifier
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirLocation
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirModule
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirType
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirValue
+    ptr::Ptr{Cvoid}
+end
+
+"""
+    MlirNamedAttribute
+
+Named MLIR attribute.
+
+A named attribute is essentially a (name, attribute) pair where the name is a string.
+"""
+struct MlirNamedAttribute
+    name::MlirIdentifier
+    attribute::MlirAttribute
 end
 
 """
@@ -175,9 +277,7 @@ end
 Creates an MLIR context with an explicit setting of the multithreading setting and transfers its ownership to the caller.
 """
 function mlirContextCreateWithThreading(threadingEnabled)
-    @ccall (MLIR_C_PATH[]).mlirContextCreateWithThreading(
-        threadingEnabled::Bool
-    )::MlirContext
+    @ccall (MLIR_C_PATH[]).mlirContextCreateWithThreading(threadingEnabled::Bool)::MlirContext
 end
 
 """
@@ -186,9 +286,7 @@ end
 Creates an MLIR context, setting the multithreading setting explicitly and pre-loading the dialects from the provided DialectRegistry.
 """
 function mlirContextCreateWithRegistry(registry, threadingEnabled)
-    @ccall (MLIR_C_PATH[]).mlirContextCreateWithRegistry(
-        registry::MlirDialectRegistry, threadingEnabled::Bool
-    )::MlirContext
+    @ccall (MLIR_C_PATH[]).mlirContextCreateWithRegistry(registry::MlirDialectRegistry, threadingEnabled::Bool)::MlirContext
 end
 
 """
@@ -224,9 +322,7 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
-        context::MlirContext, allow::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
 end
 
 """
@@ -235,9 +331,7 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
-        context::MlirContext
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
 end
 
 """
@@ -246,9 +340,7 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
-        context::MlirContext
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
 end
 
 """
@@ -257,9 +349,7 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
-        ctx::MlirContext, registry::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -277,9 +367,7 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
-        context::MlirContext, name::MlirStringRef
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
 end
 
 """
@@ -288,9 +376,7 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
-        context::MlirContext, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
 end
 
 """
@@ -308,9 +394,7 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
-        context::MlirContext, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
 end
 
 """
@@ -319,9 +403,7 @@ end
 Sets the thread pool of the context explicitly, enabling multithreading in the process. This API should be used to avoid re-creating thread pools in long-running applications that perform multiple compilations, see the C++ documentation for MLIRContext for details.
 """
 function mlirContextSetThreadPool(context, threadPool)
-    @ccall (MLIR_C_PATH[]).mlirContextSetThreadPool(
-        context::MlirContext, threadPool::MlirLlvmThreadPool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetThreadPool(context::MlirContext, threadPool::MlirLlvmThreadPool)::Cvoid
 end
 
 """
@@ -348,9 +430,7 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
-        dialect1::MlirDialect, dialect2::MlirDialect
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
 end
 
 """
@@ -368,9 +448,7 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
-        arg1::MlirDialectHandle
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
 end
 
 """
@@ -379,9 +457,7 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
-        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
 end
 
 """
@@ -390,9 +466,7 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
 end
 
 """
@@ -401,9 +475,7 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
-        arg1::MlirDialectHandle, arg2::MlirContext
-    )::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
 end
 
 """
@@ -457,9 +529,7 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
-        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
 end
 
 """
@@ -468,9 +538,7 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
-        callee::MlirLocation, caller::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
 end
 
 """
@@ -479,12 +547,7 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
-        ctx::MlirContext,
-        nLocations::intptr_t,
-        locations::Ptr{MlirLocation},
-        metadata::MlirAttribute,
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
 end
 
 """
@@ -493,9 +556,7 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
-        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
 end
 
 """
@@ -540,9 +601,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
-        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -560,9 +619,7 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
-        context::MlirContext, _module::MlirStringRef
-    )::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
 end
 
 """
@@ -619,15 +676,29 @@ function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
 end
 
+struct MlirOperationState
+    name::MlirStringRef
+    location::MlirLocation
+    nResults::intptr_t
+    results::Ptr{MlirType}
+    nOperands::intptr_t
+    operands::Ptr{MlirValue}
+    nRegions::intptr_t
+    regions::Ptr{MlirRegion}
+    nSuccessors::intptr_t
+    successors::Ptr{MlirBlock}
+    nAttributes::intptr_t
+    attributes::Ptr{MlirNamedAttribute}
+    enableResultTypeInference::Bool
+end
+
 """
     mlirOperationStateGet(name, loc)
 
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
-        name::MlirStringRef, loc::MlirLocation
-    )::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
 end
 
 """
@@ -636,33 +707,23 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
-        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
-        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
-        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
-        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
-        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
 end
 
 """
@@ -671,9 +732,7 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
-        state::Ptr{MlirOperationState}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
 end
 
 """
@@ -700,9 +759,7 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
-        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
 end
 
 """
@@ -711,9 +768,7 @@ end
 Enable or disable printing of debug information (based on `enable`). If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, enable, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
-        flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool)::Cvoid
 end
 
 """
@@ -722,9 +777,7 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -733,9 +786,7 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -744,9 +795,7 @@ end
 Do not verify the operation when using custom operation printers.
 """
 function mlirOpPrintingFlagsAssumeVerified(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsAssumeVerified(
-        flags::MlirOpPrintingFlags
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsAssumeVerified(flags::MlirOpPrintingFlags)::Cvoid
 end
 
 """
@@ -764,9 +813,7 @@ end
 Destroys printing flags created with [`mlirBytecodeWriterConfigCreate`](@ref).
 """
 function mlirBytecodeWriterConfigDestroy(config)
-    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDestroy(
-        config::MlirBytecodeWriterConfig
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDestroy(config::MlirBytecodeWriterConfig)::Cvoid
 end
 
 """
@@ -775,9 +822,7 @@ end
 Sets the version to emit in the writer config.
 """
 function mlirBytecodeWriterConfigDesiredEmitVersion(flags, version)
-    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDesiredEmitVersion(
-        flags::MlirBytecodeWriterConfig, version::Int64
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDesiredEmitVersion(flags::MlirBytecodeWriterConfig, version::Int64)::Cvoid
 end
 
 """
@@ -788,9 +833,7 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
-        state::Ptr{MlirOperationState}
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
 end
 
 """
@@ -801,9 +844,7 @@ Parses an operation, giving ownership to the caller. If parsing fails a null ope
 `sourceStr` may be either the text assembly format, or binary bytecode format. `sourceName` is used as the file name of the source; any IR without locations will get a `FileLineColLoc` location with `sourceName` as the file name.
 """
 function mlirOperationCreateParse(context, sourceStr, sourceName)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreateParse(
-        context::MlirContext, sourceStr::MlirStringRef, sourceName::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreateParse(context::MlirContext, sourceStr::MlirStringRef, sourceName::MlirStringRef)::MlirOperation
 end
 
 """
@@ -920,9 +961,7 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
-        op::MlirOperation, pos::intptr_t
-    )::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
 end
 
 """
@@ -949,9 +988,7 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -960,9 +997,7 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
-        op::MlirOperation, pos::intptr_t, newValue::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
 end
 
 """
@@ -971,9 +1006,7 @@ end
 Replaces the operands of the operation.
 """
 function mlirOperationSetOperands(op, nOperands, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperands(
-        op::MlirOperation, nOperands::intptr_t, operands::Ptr{MlirValue}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperands(op::MlirOperation, nOperands::intptr_t, operands::Ptr{MlirValue})::Cvoid
 end
 
 """
@@ -991,9 +1024,7 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
-        op::MlirOperation, pos::intptr_t
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
 end
 
 """
@@ -1011,9 +1042,7 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
-        op::MlirOperation, pos::intptr_t
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
 end
 
 """
@@ -1031,9 +1060,7 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
-        op::MlirOperation, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -1042,9 +1069,7 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1053,9 +1078,7 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
-        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 """
@@ -1064,9 +1087,7 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
-        op::MlirOperation, name::MlirStringRef
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
 end
 
 """
@@ -1075,9 +1096,7 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1086,12 +1105,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
-        op::MlirOperation,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1100,9 +1114,7 @@ end
 Same as [`mlirOperationPrint`](@ref) but writing the bytecode format.
 """
 function mlirOperationWriteBytecode(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(
-        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1111,12 +1123,7 @@ end
 Same as [`mlirOperationWriteBytecode`](@ref) but with writer config and returns failure only if desired bytecode could not be honored.
 """
 function mlirOperationWriteBytecodeWithConfig(op, config, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecodeWithConfig(
-        op::MlirOperation,
-        config::MlirBytecodeWriterConfig,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecodeWithConfig(op::MlirOperation, config::MlirBytecodeWriterConfig, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -1143,9 +1150,7 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1154,9 +1159,7 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
-        op::MlirOperation, other::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
 end
 
 """
@@ -1210,9 +1213,7 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
-        region::MlirRegion, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1221,9 +1222,7 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
-        region::MlirRegion, pos::intptr_t, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1232,9 +1231,7 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1243,9 +1240,7 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
-        region::MlirRegion, reference::MlirBlock, block::MlirBlock
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
 end
 
 """
@@ -1281,9 +1276,7 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
-        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
-    )::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
 end
 
 """
@@ -1373,9 +1366,7 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
-        block::MlirBlock, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1384,9 +1375,7 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
-        block::MlirBlock, pos::intptr_t, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1395,9 +1384,7 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1406,9 +1393,7 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
-        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1426,9 +1411,7 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
-        block::MlirBlock, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1437,9 +1420,7 @@ end
 Inserts an argument of the specified type at a specified index to the block. Returns the newly added argument.
 """
 function mlirBlockInsertArgument(block, pos, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertArgument(
-        block::MlirBlock, pos::intptr_t, type::MlirType, loc::MlirLocation
-    )::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertArgument(block::MlirBlock, pos::intptr_t, type::MlirType, loc::MlirLocation)::MlirValue
 end
 
 """
@@ -1457,9 +1438,7 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
-        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1567,9 +1546,7 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(
-        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1578,12 +1555,7 @@ end
 Prints a value as an operand (i.e., the ValueID).
 """
 function mlirValuePrintAsOperand(value, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrintAsOperand(
-        value::MlirValue,
-        flags::MlirOpPrintingFlags,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrintAsOperand(value::MlirValue, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1601,9 +1573,7 @@ end
 Replace all uses of 'of' value with the 'with' value, updating anything in the IR that uses 'of' to use the other value instead. When this returns there are zero uses of 'of'.
 """
 function mlirValueReplaceAllUsesOfWith(of, with)
-    @ccall (MLIR_C_PATH[]).mlirValueReplaceAllUsesOfWith(
-        of::MlirValue, with::MlirValue
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValueReplaceAllUsesOfWith(of::MlirValue, with::MlirValue)::Cvoid
 end
 
 """
@@ -1648,9 +1618,7 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
-        context::MlirContext, type::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
 end
 
 """
@@ -1704,9 +1672,7 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(
-        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1724,9 +1690,7 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
-        context::MlirContext, attr::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -1789,9 +1753,7 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
-        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -1809,9 +1771,7 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
-        name::MlirIdentifier, attr::MlirAttribute
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
 end
 
 """
@@ -1820,9 +1780,7 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
-        context::MlirContext, str::MlirStringRef
-    )::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
 end
 
 """
@@ -1840,9 +1798,7 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
-        ident::MlirIdentifier, other::MlirIdentifier
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
 end
 
 """
@@ -1905,9 +1861,7 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
-        symbolTable::MlirSymbolTable, name::MlirStringRef
-    )::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
 end
 
 """
@@ -1916,9 +1870,7 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
 end
 
 """
@@ -1927,9 +1879,7 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
-        symbolTable::MlirSymbolTable, operation::MlirOperation
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
 end
 
 """
@@ -1938,9 +1888,7 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
-        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -1949,12 +1897,11 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
-        from::MlirOperation,
-        allSymUsesVisible::Bool,
-        callback::Ptr{Cvoid},
-        userData::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+end
+
+struct MlirAffineExpr
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -1972,9 +1919,7 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
 end
 
 """
@@ -1992,9 +1937,7 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
-        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2012,9 +1955,7 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
-        affineExpr::MlirAffineExpr
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
 end
 
 """
@@ -2032,9 +1973,7 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
-        affineExpr::MlirAffineExpr
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
 end
 
 """
@@ -2043,9 +1982,7 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
-        affineExpr::MlirAffineExpr, factor::Int64
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
 end
 
 """
@@ -2054,9 +1991,11 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
-        affineExpr::MlirAffineExpr, position::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+end
+
+struct MlirAffineMap
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -2065,9 +2004,7 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
-        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
 end
 
 """
@@ -2085,9 +2022,7 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2096,9 +2031,7 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -2116,9 +2049,7 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
-        ctx::MlirContext, position::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2127,9 +2058,7 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
-        affineExpr::MlirAffineExpr
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
 end
 
 """
@@ -2147,9 +2076,7 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
-        ctx::MlirContext, constant::Int64
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
 end
 
 """
@@ -2176,9 +2103,7 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2196,9 +2121,7 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2216,9 +2139,7 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2236,9 +2157,7 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2256,9 +2175,7 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
-        lhs::MlirAffineExpr, rhs::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2276,9 +2193,7 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2287,9 +2202,7 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
-        affineExpr::MlirAffineExpr
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
 end
 
 """
@@ -2325,9 +2238,7 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
-        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2354,9 +2265,7 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
-        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2365,13 +2274,7 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
-        ctx::MlirContext,
-        dimCount::intptr_t,
-        symbolCount::intptr_t,
-        nAffineExprs::intptr_t,
-        affineExprs::Ptr{MlirAffineExpr},
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
 end
 
 """
@@ -2380,9 +2283,7 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
-        ctx::MlirContext, val::Int64
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
 end
 
 """
@@ -2391,9 +2292,7 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
-        ctx::MlirContext, numDims::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2402,9 +2301,7 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
-        ctx::MlirContext, dims::intptr_t, results::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2413,9 +2310,7 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
-        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
 end
 
 """
@@ -2460,9 +2355,7 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
-        affineMap::MlirAffineMap
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
 end
 
 """
@@ -2498,9 +2391,7 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
-        affineMap::MlirAffineMap, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -2518,9 +2409,7 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
-        affineMap::MlirAffineMap
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
 end
 
 """
@@ -2538,9 +2427,7 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
-        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
 end
 
 """
@@ -2549,9 +2436,7 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2560,9 +2445,7 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
-        affineMap::MlirAffineMap, numResults::intptr_t
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2570,16 +2453,8 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(
-    affineMap, expression, replacement, numResultDims, numResultSyms
-)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
-        affineMap::MlirAffineMap,
-        expression::MlirAffineExpr,
-        replacement::MlirAffineExpr,
-        numResultDims::intptr_t,
-        numResultSyms::intptr_t,
-    )::MlirAffineMap
+function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
 end
 
 """
@@ -2588,12 +2463,7 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
-        affineMaps::Ptr{MlirAffineMap},
-        size::intptr_t,
-        result::Ptr{Cvoid},
-        populateResult::Ptr{Cvoid},
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -2660,9 +2530,7 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -2680,9 +2548,7 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -2709,9 +2575,7 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
 end
 
 """
@@ -2729,9 +2593,7 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
 end
 
 """
@@ -2740,9 +2602,7 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
-        attr::MlirAttribute, name::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2769,9 +2629,7 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
-        ctx::MlirContext, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2780,9 +2638,7 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
-        loc::MlirLocation, type::MlirType, value::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
 end
 
 """
@@ -2917,13 +2773,7 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
-        ctx::MlirContext,
-        dialectNamespace::MlirStringRef,
-        dataLength::intptr_t,
-        data::Cstring,
-        type::MlirType,
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
 end
 
 """
@@ -2932,9 +2782,7 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -2970,9 +2818,7 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
-        ctx::MlirContext, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -2981,9 +2827,7 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
-        type::MlirType, str::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -3019,12 +2863,7 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
-        ctx::MlirContext,
-        symbol::MlirStringRef,
-        numReferences::intptr_t,
-        references::Ptr{MlirAttribute},
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
 end
 
 """
@@ -3033,9 +2872,7 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3044,9 +2881,7 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3055,9 +2890,7 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
-        attr::MlirAttribute
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
 end
 
 """
@@ -3066,9 +2899,7 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
 end
 
 """
@@ -3095,9 +2926,7 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
-        ctx::MlirContext, symbol::MlirStringRef
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
 end
 
 """
@@ -3187,9 +3016,7 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
 end
 
 """
@@ -3198,9 +3025,7 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
-        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
 end
 
 """
@@ -3255,45 +3080,31 @@ end
 Create a dense array attribute with the given elements.
 """
 function mlirDenseBoolArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseI8ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseI16ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseI32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseI64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseF32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseF64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(
-        ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -3311,45 +3122,31 @@ end
 Get an element of a dense array.
 """
 function mlirDenseBoolArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseI8ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseI16ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseI32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseI64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseF32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseF64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3384,24 +3181,11 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
 end
 
-"""
-    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-
-Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
-
-The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
-
-A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
-"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
-        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
 end
 
 """
@@ -3410,63 +3194,43 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
-        shapedType::MlirType, element::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
-        shapedType::MlirType, element::Bool
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
-        shapedType::MlirType, element::UInt8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
-        shapedType::MlirType, element::Int8
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
-        shapedType::MlirType, element::UInt32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
-        shapedType::MlirType, element::Int32
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
-        shapedType::MlirType, element::UInt64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
-        shapedType::MlirType, element::Int64
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
-        shapedType::MlirType, element::Cfloat
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
-        shapedType::MlirType, element::Cdouble
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
 end
 
 """
@@ -3475,81 +3239,55 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
-        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
 """
@@ -3558,9 +3296,7 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
-        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
 end
 
 """
@@ -3569,9 +3305,7 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
-        attr::MlirAttribute, shapedType::MlirType
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
 end
 
 """
@@ -3589,9 +3323,7 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3603,51 +3335,35 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
-        attr::MlirAttribute
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
-        attr::MlirAttribute
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
-        attr::MlirAttribute
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
-        attr::MlirAttribute
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
-        attr::MlirAttribute
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
-        attr::MlirAttribute
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
-        attr::MlirAttribute
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
-        attr::MlirAttribute
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
 end
 
 """
@@ -3656,75 +3372,51 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
 end
 
 """
@@ -3736,125 +3428,48 @@ function mlirDenseElementsAttrGetRawData(attr)
     @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetRawData(attr::MlirAttribute)::Ptr{Cvoid}
 end
 
-function mlirUnmanagedDenseBoolResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cint},
-    )::MlirAttribute
+function mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt8},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int8},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt16},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int16},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt32},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int32},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{UInt64},
-    )::MlirAttribute
+function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Int64},
-    )::MlirAttribute
+function mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
 end
 
-function mlirUnmanagedDenseFloatResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cfloat},
-    )::MlirAttribute
+function mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
 end
 
-function mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-    shapedType, name, numElements, elements
-)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(
-        shapedType::MlirType,
-        name::MlirStringRef,
-        numElements::intptr_t,
-        elements::Ptr{Cdouble},
-    )::MlirAttribute
+function mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType, name, numElements, elements)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
 end
 
 """
@@ -3863,69 +3478,47 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense resource elements attribute.
 """
 function mlirDenseBoolResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Bool
 end
 
 function mlirDenseInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int8
 end
 
 function mlirDenseUInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt8
 end
 
 function mlirDenseInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int16
 end
 
 function mlirDenseUInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt16
 end
 
 function mlirDenseInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int32
 end
 
 function mlirDenseUInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt32
 end
 
 function mlirDenseInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 function mlirDenseUInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt64
 end
 
 function mlirDenseFloatResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
 end
 
 function mlirDenseDoubleResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(
-        attr::MlirAttribute, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
 end
 
 """
@@ -3943,9 +3536,7 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
-        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3954,9 +3545,7 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3965,9 +3554,7 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
-        attr::MlirAttribute
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
 end
 
 """
@@ -3984,9 +3571,7 @@ function mlirAttributeIsAStridedLayout(attr)
 end
 
 function mlirStridedLayoutAttrGet(ctx, offset, numStrides, strides)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(
-        ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64}
-    )::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64})::MlirAttribute
 end
 
 function mlirStridedLayoutAttrGetOffset(attr)
@@ -3998,9 +3583,7 @@ function mlirStridedLayoutAttrGetNumStrides(attr)
 end
 
 function mlirStridedLayoutAttrGetStride(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(
-        attr::MlirAttribute, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(attr::MlirAttribute, pos::intptr_t)::Int64
 end
 
 """
@@ -4045,9 +3628,7 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -4056,9 +3637,7 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
-        ctx::MlirContext, bitwidth::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
 end
 
 """
@@ -4580,9 +4159,7 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4591,9 +4168,7 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
-        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
 end
 
 """
@@ -4647,9 +4222,7 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
-        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4658,13 +4231,7 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
-        loc::MlirLocation,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        elementType::MlirType,
-        encoding::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
 end
 
 """
@@ -4691,9 +4258,7 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
 end
 
 """
@@ -4738,13 +4303,7 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4753,14 +4312,7 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        layout::MlirAttribute,
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4769,9 +4321,7 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
-        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4780,13 +4330,7 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
-        loc::MlirLocation,
-        elementType::MlirType,
-        rank::intptr_t,
-        shape::Ptr{Int64},
-        memorySpace::MlirAttribute,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4795,9 +4339,7 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
-        elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4806,9 +4348,7 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
-        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
 end
 
 """
@@ -4871,9 +4411,7 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
-        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4918,13 +4456,7 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
-        ctx::MlirContext,
-        numInputs::intptr_t,
-        inputs::Ptr{MlirType},
-        numResults::intptr_t,
-        results::Ptr{MlirType},
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
 end
 
 """
@@ -4960,9 +4492,7 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
-        type::MlirType, pos::intptr_t
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
 end
 
 """
@@ -4989,9 +4519,7 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
-        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
 end
 
 """
@@ -5012,6 +4540,22 @@ function mlirOpaqueTypeGetData(type)
     @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGetData(type::MlirType)::MlirStringRef
 end
 
+struct MlirPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirExternalPass
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirPassManager
+    ptr::Ptr{Cvoid}
+end
+
+struct MlirOpPassManager
+    ptr::Ptr{Cvoid}
+end
+
 """
     mlirPassManagerCreate(ctx)
 
@@ -5027,9 +4571,7 @@ end
 Create a new top-level PassManager anchored on `anchorOp`.
 """
 function mlirPassManagerCreateOnOperation(ctx, anchorOp)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(
-        ctx::MlirContext, anchorOp::MlirStringRef
-    )::MlirPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(ctx::MlirContext, anchorOp::MlirStringRef)::MlirPassManager
 end
 
 """
@@ -5056,9 +4598,7 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
-        passManager::MlirPassManager
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
 end
 
 """
@@ -5067,9 +4607,7 @@ end
 Run the provided `passManager` on the given `op`.
 """
 function mlirPassManagerRunOnOp(passManager, op)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRunOnOp(
-        passManager::MlirPassManager, op::MlirOperation
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRunOnOp(passManager::MlirPassManager, op::MlirOperation)::MlirLogicalResult
 end
 
 """
@@ -5078,9 +4616,7 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
-        passManager::MlirPassManager
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
 end
 
 """
@@ -5089,9 +4625,7 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
-        passManager::MlirPassManager, enable::Bool
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
 end
 
 """
@@ -5100,9 +4634,7 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
-        passManager::MlirPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -5111,9 +4643,7 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
-        passManager::MlirOpPassManager, operationName::MlirStringRef
-    )::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
 end
 
 """
@@ -5122,9 +4652,7 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
-        passManager::MlirPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -5133,9 +4661,7 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
-        passManager::MlirOpPassManager, pass::MlirPass
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
 end
 
 """
@@ -5144,12 +4670,7 @@ end
 Parse a sequence of textual MLIR pass pipeline elements and add them to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirOpPassManagerAddPipeline(passManager, pipelineElements, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(
-        passManager::MlirOpPassManager,
-        pipelineElements::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(passManager::MlirOpPassManager, pipelineElements::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -5158,9 +4679,7 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
-        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5169,12 +4688,28 @@ end
 Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
-        passManager::MlirOpPassManager,
-        pipeline::MlirStringRef,
-        callback::MlirStringCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+end
+
+"""
+    MlirExternalPassCallbacks
+
+Structure of external [`MlirPass`](@ref) callbacks. All callbacks are required to be set unless otherwise specified.
+
+| Field      | Note                                                                                                                                                                                              |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| construct  | This callback is called from the pass is created. This is analogous to a C++ pass constructor.                                                                                                    |
+| destruct   | This callback is called when the pass is destroyed This is analogous to a C++ pass destructor.                                                                                                    |
+| initialize | This callback is optional. The callback is called before the pass is run, allowing a chance to initialize any complex state necessary for running the pass. See Pass::initialize(MLIRContext *).  |
+| clone      | This callback is called when the pass is cloned. See Pass::clonePass().                                                                                                                           |
+| run        | This callback is called when the pass is run. See Pass::runOnOperation().                                                                                                                         |
+"""
+struct MlirExternalPassCallbacks
+    construct::Ptr{Cvoid}
+    destruct::Ptr{Cvoid}
+    initialize::Ptr{Cvoid}
+    clone::Ptr{Cvoid}
+    run::Ptr{Cvoid}
 end
 
 """
@@ -5182,28 +4717,8 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(
-    passID,
-    name,
-    argument,
-    description,
-    opName,
-    nDependentDialects,
-    dependentDialects,
-    callbacks,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
-        passID::MlirTypeID,
-        name::MlirStringRef,
-        argument::MlirStringRef,
-        description::MlirStringRef,
-        opName::MlirStringRef,
-        nDependentDialects::intptr_t,
-        dependentDialects::Ptr{MlirDialectHandle},
-        callbacks::MlirExternalPassCallbacks,
-        userData::Ptr{Cvoid},
-    )::MlirPass
+function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
 end
 
 """
@@ -5718,6 +5233,15 @@ function mlirIsGlobalDebugEnabled()
 end
 
 """
+    MlirDiagnostic
+
+An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
+"""
+struct MlirDiagnostic
+    ptr::Ptr{Cvoid}
+end
+
+"""
     MlirDiagnosticSeverity
 
 Severity of a diagnostic.
@@ -5746,9 +5270,7 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
-        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -5757,9 +5279,7 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
-        diagnostic::MlirDiagnostic
-    )::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
 end
 
 """
@@ -5768,9 +5288,7 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
-        diagnostic::MlirDiagnostic
-    )::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
 end
 
 """
@@ -5788,9 +5306,7 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
-        diagnostic::MlirDiagnostic, pos::intptr_t
-    )::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
 end
 
 """
@@ -5799,12 +5315,7 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
-        context::MlirContext,
-        handler::MlirDiagnosticHandler,
-        userData::Ptr{Cvoid},
-        deleteUserData::Ptr{Cvoid},
-    )::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
 end
 
 """
@@ -5813,9 +5324,7 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
-        context::MlirContext, id::MlirDiagnosticHandlerID
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
 end
 
 """
@@ -5901,9 +5410,7 @@ end
 Sets the argument attribute 'name' of an argument at index 'pos'. Asserts that the operation is a FuncOp.
 """
 function mlirFuncSetArgAttr(op, pos, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirFuncSetArgAttr(
-        op::MlirOperation, pos::intptr_t, name::MlirStringRef, attr::MlirAttribute
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirFuncSetArgAttr(op::MlirOperation, pos::intptr_t, name::MlirStringRef, attr::MlirAttribute)::Cvoid
 end
 
 function mlirGetDialectHandle__gpu__()
@@ -5956,9 +5463,7 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
-        pointee::MlirType, addressSpace::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
 end
 
 """
@@ -5976,9 +5481,7 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
-        elementType::MlirType, numElements::Cuint
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
 end
 
 """
@@ -5987,12 +5490,7 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
-        resultType::MlirType,
-        nArgumentTypes::intptr_t,
-        argumentTypes::Ptr{MlirType},
-        isVarArg::Bool,
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
 end
 
 """
@@ -6001,9 +5499,7 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
-        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
 end
 
 """
@@ -6203,9 +5699,7 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -6214,9 +5708,7 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
-        isSigned::Bool, integralWidth::Cuint
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
 end
 
 """
@@ -6279,9 +5771,7 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
-        type::MlirType
-    )::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
 end
 
 """
@@ -6290,9 +5780,7 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
-        type::MlirType, candidate::MlirType
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
 end
 
 """
@@ -6301,9 +5789,7 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
-        type::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
 end
 
 """
@@ -6312,9 +5798,7 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -6332,9 +5816,7 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -6352,9 +5834,7 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
-        type::MlirType, candidate::MlirType
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
 end
 
 """
@@ -6371,16 +5851,8 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(
-    flags, storageType, expressedType, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -6397,18 +5869,8 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(
-    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        scale::Cdouble,
-        zeroPoint::Int64,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -6452,28 +5914,8 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(
-    flags,
-    storageType,
-    expressedType,
-    nDims,
-    scales,
-    zeroPoints,
-    quantizedDimension,
-    storageTypeMin,
-    storageTypeMax,
-)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
-        flags::Cuint,
-        storageType::MlirType,
-        expressedType::MlirType,
-        nDims::intptr_t,
-        scales::Ptr{Cdouble},
-        zeroPoints::Ptr{Int64},
-        quantizedDimension::Int32,
-        storageTypeMin::Int64,
-        storageTypeMax::Int64,
-    )::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
 end
 
 """
@@ -6482,9 +5924,7 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
-        type::MlirType
-    )::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
 end
 
 """
@@ -6493,9 +5933,7 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
-        type::MlirType, pos::intptr_t
-    )::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
 end
 
 """
@@ -6504,9 +5942,7 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
-        type::MlirType, pos::intptr_t
-    )::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
 end
 
 """
@@ -6515,9 +5951,7 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
-        type::MlirType
-    )::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
 end
 
 """
@@ -6544,9 +5978,7 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
-        expressedType::MlirType, min::Cdouble, max::Cdouble
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
 end
 
 """
@@ -6609,9 +6041,7 @@ end
 Checks whether the given attribute is a `sparse\\_tensor.encoding` attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
-        attr::MlirAttribute
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
 end
 
 """
@@ -6619,17 +6049,8 @@ end
 
 Creates a `sparse\\_tensor.encoding` attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(
-    ctx, lvlRank, lvlTypes, dimToLvl, posWidth, crdWidth
-)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
-        ctx::MlirContext,
-        lvlRank::intptr_t,
-        lvlTypes::Ptr{MlirSparseTensorDimLevelType},
-        dimToLvl::MlirAffineMap,
-        posWidth::Cint,
-        crdWidth::Cint,
-    )::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(ctx, lvlRank, lvlTypes, dimToLvl, posWidth, crdWidth)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, lvlRank::intptr_t, lvlTypes::Ptr{MlirSparseTensorDimLevelType}, dimToLvl::MlirAffineMap, posWidth::Cint, crdWidth::Cint)::MlirAttribute
 end
 
 """
@@ -6647,9 +6068,7 @@ end
 Returns a specified level-type of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetLvlType(attr, lvl)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetLvlType(
-        attr::MlirAttribute, lvl::intptr_t
-    )::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetLvlType(attr::MlirAttribute, lvl::intptr_t)::MlirSparseTensorDimLevelType
 end
 
 """
@@ -6658,9 +6077,7 @@ end
 Returns the dimension-to-level mapping of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimToLvl(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimToLvl(
-        attr::MlirAttribute
-    )::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimToLvl(attr::MlirAttribute)::MlirAffineMap
 end
 
 """
@@ -6669,9 +6086,7 @@ end
 Returns the position bitwidth of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetPosWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPosWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPosWidth(attr::MlirAttribute)::Cint
 end
 
 """
@@ -6680,9 +6095,7 @@ end
 Returns the coordinate bitwidth of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetCrdWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetCrdWidth(
-        attr::MlirAttribute
-    )::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetCrdWidth(attr::MlirAttribute)::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -6786,19 +6199,19 @@ function mlirTransformOperationTypeGetTypeID()
 end
 
 function mlirTransformOperationTypeGet(ctx, operationName)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(
-        ctx::MlirContext, operationName::MlirStringRef
-    )::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(ctx::MlirContext, operationName::MlirStringRef)::MlirType
 end
 
 function mlirTransformOperationTypeGetOperationName(type)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(
-        type::MlirType
-    )::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
 end
 
 function mlirGetDialectHandle__vector__()
     @ccall (MLIR_C_PATH[]).mlirGetDialectHandle__vector__()::MlirDialectHandle
+end
+
+struct MlirExecutionEngine
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -6807,13 +6220,7 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
-        op::MlirModule,
-        optLevel::Cint,
-        numPaths::Cint,
-        sharedLibPaths::Ptr{MlirStringRef},
-        enableObjectDump::Bool,
-    )::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}, enableObjectDump::Bool)::MlirExecutionEngine
 end
 
 """
@@ -6840,9 +6247,7 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
-        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
-    )::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
 end
 
 """
@@ -6851,9 +6256,7 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6862,9 +6265,7 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
-        jit::MlirExecutionEngine, name::MlirStringRef
-    )::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
 end
 
 """
@@ -6873,9 +6274,7 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
-        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6884,9 +6283,11 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
-        jit::MlirExecutionEngine, fileName::MlirStringRef
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+end
+
+struct MlirIntegerSet
+    ptr::Ptr{Cvoid}
 end
 
 """
@@ -6922,9 +6323,7 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
-        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
-    )::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -6942,9 +6341,7 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
-        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
-    )::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -6952,17 +6349,8 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(
-    context, numDims, numSymbols, numConstraints, constraints, eqFlags
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
-        context::MlirContext,
-        numDims::intptr_t,
-        numSymbols::intptr_t,
-        numConstraints::intptr_t,
-        constraints::Ptr{MlirAffineExpr},
-        eqFlags::Ptr{Bool},
-    )::MlirIntegerSet
+function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
 end
 
 """
@@ -6970,16 +6358,8 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(
-    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
-)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
-        set::MlirIntegerSet,
-        dimReplacements::Ptr{MlirAffineExpr},
-        symbolReplacements::Ptr{MlirAffineExpr},
-        numResultDims::intptr_t,
-        numResultSymbols::intptr_t,
-    )::MlirIntegerSet
+function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
 end
 
 """
@@ -7051,9 +6431,7 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
-        set::MlirIntegerSet, pos::intptr_t
-    )::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
 end
 
 """
@@ -7062,9 +6440,7 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
-        set::MlirIntegerSet, pos::intptr_t
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
 end
 
 """
@@ -7073,9 +6449,7 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
-        operation::MlirOperation, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -7084,9 +6458,7 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
-        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
-    )::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
 end
 
 """
@@ -7109,32 +6481,8 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    properties,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        properties::Ptr{Cvoid},
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirTypesCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, properties, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, properties::Ptr{Cvoid}, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -7157,32 +6505,8 @@ const MlirShapedTypeComponentsCallback = Ptr{Cvoid}
 
 Infers the return shaped type components of the operation. Calls `callback` with the types of inferred arguments on success. Returns failure otherwise.
 """
-function mlirInferShapedTypeOpInterfaceInferReturnTypes(
-    opName,
-    context,
-    location,
-    nOperands,
-    operands,
-    attributes,
-    properties,
-    nRegions,
-    regions,
-    callback,
-    userData,
-)
-    @ccall (MLIR_C_PATH[]).mlirInferShapedTypeOpInterfaceInferReturnTypes(
-        opName::MlirStringRef,
-        context::MlirContext,
-        location::MlirLocation,
-        nOperands::intptr_t,
-        operands::Ptr{MlirValue},
-        attributes::MlirAttribute,
-        properties::Ptr{Cvoid},
-        nRegions::intptr_t,
-        regions::Ptr{MlirRegion},
-        callback::MlirShapedTypeComponentsCallback,
-        userData::Ptr{Cvoid},
-    )::MlirLogicalResult
+function mlirInferShapedTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, properties, nRegions, regions, callback, userData)
+    @ccall (MLIR_C_PATH[]).mlirInferShapedTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, properties::Ptr{Cvoid}, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirShapedTypeComponentsCallback, userData::Ptr{Cvoid})::MlirLogicalResult
 end
 
 """
@@ -7351,3 +6675,4 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
+

--- a/src/API/17/libMLIR_h.jl
+++ b/src/API/17/libMLIR_h.jl
@@ -2,8 +2,13 @@ using CEnum
 
 const intptr_t = Clong
 
+"""
+    mlirStringRefCreate(str, length)
+
+Constructs a string reference from the pointer and length. The pointer need not reference to a null-terminated string.
+"""
 function mlirStringRefCreate(str, length)
-    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Csize_t)::MlirStringRef
 end
 
 """
@@ -21,7 +26,9 @@ end
 Returns true if two string references are equal, false otherwise.
 """
 function mlirStringRefEqual(string, other)
-    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(string::MlirStringRef, other::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirStringRefEqual(
+        string::MlirStringRef, other::MlirStringRef
+    )::Bool
 end
 
 # typedef void ( * MlirStringCallback ) ( MlirStringRef , void * )
@@ -113,8 +120,13 @@ function mlirTypeIDEqual(typeID1, typeID2)
     @ccall (MLIR_C_PATH[]).mlirTypeIDEqual(typeID1::MlirTypeID, typeID2::MlirTypeID)::Bool
 end
 
+"""
+    mlirTypeIDHashValue(typeID)
+
+Returns the hash value of the type id.
+"""
 function mlirTypeIDHashValue(typeID)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Cint
+    @ccall (MLIR_C_PATH[]).mlirTypeIDHashValue(typeID::MlirTypeID)::Csize_t
 end
 
 """
@@ -141,7 +153,9 @@ end
 Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
-    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
+    @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(
+        allocator::MlirTypeIDAllocator
+    )::MlirTypeID
 end
 
 """
@@ -159,7 +173,9 @@ end
 Creates an MLIR context with an explicit setting of the multithreading setting and transfers its ownership to the caller.
 """
 function mlirContextCreateWithThreading(threadingEnabled)
-    @ccall (MLIR_C_PATH[]).mlirContextCreateWithThreading(threadingEnabled::Bool)::MlirContext
+    @ccall (MLIR_C_PATH[]).mlirContextCreateWithThreading(
+        threadingEnabled::Bool
+    )::MlirContext
 end
 
 """
@@ -168,7 +184,9 @@ end
 Creates an MLIR context, setting the multithreading setting explicitly and pre-loading the dialects from the provided DialectRegistry.
 """
 function mlirContextCreateWithRegistry(registry, threadingEnabled)
-    @ccall (MLIR_C_PATH[]).mlirContextCreateWithRegistry(registry::MlirDialectRegistry, threadingEnabled::Bool)::MlirContext
+    @ccall (MLIR_C_PATH[]).mlirContextCreateWithRegistry(
+        registry::MlirDialectRegistry, threadingEnabled::Bool
+    )::MlirContext
 end
 
 """
@@ -204,7 +222,9 @@ end
 Sets whether unregistered dialects are allowed in this context.
 """
 function mlirContextSetAllowUnregisteredDialects(context, allow)
-    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(context::MlirContext, allow::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetAllowUnregisteredDialects(
+        context::MlirContext, allow::Bool
+    )::Cvoid
 end
 
 """
@@ -213,7 +233,9 @@ end
 Returns whether the context allows unregistered dialects.
 """
 function mlirContextGetAllowUnregisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(context::MlirContext)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextGetAllowUnregisteredDialects(
+        context::MlirContext
+    )::Bool
 end
 
 """
@@ -222,7 +244,9 @@ end
 Returns the number of dialects registered with the given context. A registered dialect will be loaded if needed by the parser.
 """
 function mlirContextGetNumRegisteredDialects(context)
-    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(context::MlirContext)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirContextGetNumRegisteredDialects(
+        context::MlirContext
+    )::intptr_t
 end
 
 """
@@ -231,7 +255,9 @@ end
 Append the contents of the given dialect registry to the registry associated with the context.
 """
 function mlirContextAppendDialectRegistry(ctx, registry)
-    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(ctx::MlirContext, registry::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextAppendDialectRegistry(
+        ctx::MlirContext, registry::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -249,7 +275,9 @@ end
 Gets the dialect instance owned by the given context using the dialect namespace to identify it, loads (i.e., constructs the instance of) the dialect if necessary. If the dialect is not registered with the context, returns null. Use mlirContextLoad<Name>Dialect to load an unregistered dialect.
 """
 function mlirContextGetOrLoadDialect(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(context::MlirContext, name::MlirStringRef)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirContextGetOrLoadDialect(
+        context::MlirContext, name::MlirStringRef
+    )::MlirDialect
 end
 
 """
@@ -258,7 +286,9 @@ end
 Set threading mode (must be set to false to mlir-print-ir-after-all).
 """
 function mlirContextEnableMultithreading(context, enable)
-    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(context::MlirContext, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextEnableMultithreading(
+        context::MlirContext, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -276,7 +306,9 @@ end
 Returns whether the given fully-qualified operation (i.e. 'dialect.operation') is registered with the context. This will return true if the dialect is loaded and the operation is registered within the dialect.
 """
 function mlirContextIsRegisteredOperation(context, name)
-    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(context::MlirContext, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirContextIsRegisteredOperation(
+        context::MlirContext, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -285,7 +317,9 @@ end
 Sets the thread pool of the context explicitly, enabling multithreading in the process. This API should be used to avoid re-creating thread pools in long-running applications that perform multiple compilations, see the C++ documentation for MLIRContext for details.
 """
 function mlirContextSetThreadPool(context, threadPool)
-    @ccall (MLIR_C_PATH[]).mlirContextSetThreadPool(context::MlirContext, threadPool::MlirLlvmThreadPool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextSetThreadPool(
+        context::MlirContext, threadPool::MlirLlvmThreadPool
+    )::Cvoid
 end
 
 """
@@ -312,7 +346,9 @@ end
 Checks if two dialects that belong to the same context are equal. Dialects from different contexts will not compare equal.
 """
 function mlirDialectEqual(dialect1, dialect2)
-    @ccall (MLIR_C_PATH[]).mlirDialectEqual(dialect1::MlirDialect, dialect2::MlirDialect)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDialectEqual(
+        dialect1::MlirDialect, dialect2::MlirDialect
+    )::Bool
 end
 
 """
@@ -330,7 +366,9 @@ end
 Returns the namespace associated with the provided dialect handle.
 """
 function mlirDialectHandleGetNamespace(arg1)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(arg1::MlirDialectHandle)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleGetNamespace(
+        arg1::MlirDialectHandle
+    )::MlirStringRef
 end
 
 """
@@ -339,7 +377,9 @@ end
 Inserts the dialect associated with the provided dialect handle into the provided dialect registry
 """
 function mlirDialectHandleInsertDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(arg1::MlirDialectHandle, arg2::MlirDialectRegistry)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleInsertDialect(
+        arg1::MlirDialectHandle, arg2::MlirDialectRegistry
+    )::Cvoid
 end
 
 """
@@ -348,7 +388,9 @@ end
 Registers the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleRegisterDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(arg1::MlirDialectHandle, arg2::MlirContext)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleRegisterDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::Cvoid
 end
 
 """
@@ -357,7 +399,9 @@ end
 Loads the dialect associated with the provided dialect handle.
 """
 function mlirDialectHandleLoadDialect(arg1, arg2)
-    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(arg1::MlirDialectHandle, arg2::MlirContext)::MlirDialect
+    @ccall (MLIR_C_PATH[]).mlirDialectHandleLoadDialect(
+        arg1::MlirDialectHandle, arg2::MlirContext
+    )::MlirDialect
 end
 
 """
@@ -411,7 +455,9 @@ end
 Creates an File/Line/Column location owned by the given context.
 """
 function mlirLocationFileLineColGet(context, filename, line, col)
-    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFileLineColGet(
+        context::MlirContext, filename::MlirStringRef, line::Cuint, col::Cuint
+    )::MlirLocation
 end
 
 """
@@ -420,7 +466,9 @@ end
 Creates a call site location with a callee and a caller.
 """
 function mlirLocationCallSiteGet(callee, caller)
-    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(callee::MlirLocation, caller::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationCallSiteGet(
+        callee::MlirLocation, caller::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -429,7 +477,12 @@ end
 Creates a fused location with an array of locations and metadata.
 """
 function mlirLocationFusedGet(ctx, nLocations, locations, metadata)
-    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(ctx::MlirContext, nLocations::intptr_t, locations::Ptr{MlirLocation}, metadata::MlirAttribute)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationFusedGet(
+        ctx::MlirContext,
+        nLocations::intptr_t,
+        locations::Ptr{MlirLocation},
+        metadata::MlirAttribute,
+    )::MlirLocation
 end
 
 """
@@ -438,7 +491,9 @@ end
 Creates a name location owned by the given context. Providing null location for childLoc is allowed and if childLoc is null location, then the behavior is the same as having unknown child location.
 """
 function mlirLocationNameGet(context, name, childLoc)
-    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(context::MlirContext, name::MlirStringRef, childLoc::MlirLocation)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirLocationNameGet(
+        context::MlirContext, name::MlirStringRef, childLoc::MlirLocation
+    )::MlirLocation
 end
 
 """
@@ -483,7 +538,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirLocationPrint(location, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirLocationPrint(location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirLocationPrint(
+        location::MlirLocation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -501,7 +558,9 @@ end
 Parses a module from the string and transfers ownership to the caller.
 """
 function mlirModuleCreateParse(context, _module)
-    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(context::MlirContext, _module::MlirStringRef)::MlirModule
+    @ccall (MLIR_C_PATH[]).mlirModuleCreateParse(
+        context::MlirContext, _module::MlirStringRef
+    )::MlirModule
 end
 
 """
@@ -564,7 +623,9 @@ end
 Constructs an operation state from a name and a location.
 """
 function mlirOperationStateGet(name, loc)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(name::MlirStringRef, loc::MlirLocation)::MlirOperationState
+    @ccall (MLIR_C_PATH[]).mlirOperationStateGet(
+        name::MlirStringRef, loc::MlirLocation
+    )::MlirOperationState
 end
 
 """
@@ -573,23 +634,33 @@ end
 Adds a list of components to the operation state.
 """
 function mlirOperationStateAddResults(state, n, results)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddResults(
+        state::Ptr{MlirOperationState}, n::intptr_t, results::Ptr{MlirType}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOperands(state, n, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOperands(
+        state::Ptr{MlirOperationState}, n::intptr_t, operands::Ptr{MlirValue}
+    )::Cvoid
 end
 
 function mlirOperationStateAddOwnedRegions(state, n, regions)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddOwnedRegions(
+        state::Ptr{MlirOperationState}, n::intptr_t, regions::Ptr{MlirRegion}
+    )::Cvoid
 end
 
 function mlirOperationStateAddSuccessors(state, n, successors)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddSuccessors(
+        state::Ptr{MlirOperationState}, n::intptr_t, successors::Ptr{MlirBlock}
+    )::Cvoid
 end
 
 function mlirOperationStateAddAttributes(state, n, attributes)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateAddAttributes(
+        state::Ptr{MlirOperationState}, n::intptr_t, attributes::Ptr{MlirNamedAttribute}
+    )::Cvoid
 end
 
 """
@@ -598,7 +669,9 @@ end
 Enables result type inference for the operation under construction. If enabled, then the caller must not have called [`mlirOperationStateAddResults`](@ref)(). Note that if enabled, the [`mlirOperationCreate`](@ref)() call is failable: it will return a null operation on inference failure and will emit diagnostics.
 """
 function mlirOperationStateEnableResultTypeInference(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(state::Ptr{MlirOperationState})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationStateEnableResultTypeInference(
+        state::Ptr{MlirOperationState}
+    )::Cvoid
 end
 
 """
@@ -625,7 +698,9 @@ end
 Enables the elision of large elements attributes by printing a lexically valid but otherwise meaningless form instead of the element data. The `largeElementLimit` is used to configure what is considered to be a "large" ElementsAttr by providing an upper limit to the number of elements.
 """
 function mlirOpPrintingFlagsElideLargeElementsAttrs(flags, largeElementLimit)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(flags::MlirOpPrintingFlags, largeElementLimit::intptr_t)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsElideLargeElementsAttrs(
+        flags::MlirOpPrintingFlags, largeElementLimit::intptr_t
+    )::Cvoid
 end
 
 """
@@ -634,7 +709,9 @@ end
 Enable or disable printing of debug information (based on `enable`). If 'prettyForm' is set to true, debug information is printed in a more readable 'pretty' form. Note: The IR generated with 'prettyForm' is not parsable.
 """
 function mlirOpPrintingFlagsEnableDebugInfo(flags, enable, prettyForm)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsEnableDebugInfo(
+        flags::MlirOpPrintingFlags, enable::Bool, prettyForm::Bool
+    )::Cvoid
 end
 
 """
@@ -643,7 +720,9 @@ end
 Always print operations in the generic form.
 """
 function mlirOpPrintingFlagsPrintGenericOpForm(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsPrintGenericOpForm(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -652,7 +731,9 @@ end
 Use local scope when printing the operation. This allows for using the printer in a more localized and thread-safe setting, but may not necessarily be identical to what the IR will look like when dumping the full module.
 """
 function mlirOpPrintingFlagsUseLocalScope(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsUseLocalScope(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -661,7 +742,9 @@ end
 Do not verify the operation when using custom operation printers.
 """
 function mlirOpPrintingFlagsAssumeVerified(flags)
-    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsAssumeVerified(flags::MlirOpPrintingFlags)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPrintingFlagsAssumeVerified(
+        flags::MlirOpPrintingFlags
+    )::Cvoid
 end
 
 """
@@ -679,7 +762,9 @@ end
 Destroys printing flags created with [`mlirBytecodeWriterConfigCreate`](@ref).
 """
 function mlirBytecodeWriterConfigDestroy(config)
-    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDestroy(config::MlirBytecodeWriterConfig)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDestroy(
+        config::MlirBytecodeWriterConfig
+    )::Cvoid
 end
 
 """
@@ -688,7 +773,9 @@ end
 Sets the version to emit in the writer config.
 """
 function mlirBytecodeWriterConfigDesiredEmitVersion(flags, version)
-    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDesiredEmitVersion(flags::MlirBytecodeWriterConfig, version::Int64)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBytecodeWriterConfigDesiredEmitVersion(
+        flags::MlirBytecodeWriterConfig, version::Int64
+    )::Cvoid
 end
 
 """
@@ -699,7 +786,9 @@ Creates an operation and transfers ownership to the caller. Note that caller own
 This call can fail under the following conditions, in which case, it will return a null operation and emit diagnostics: - Result type inference is enabled and cannot be performed.
 """
 function mlirOperationCreate(state)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreate(state::Ptr{MlirOperationState})::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreate(
+        state::Ptr{MlirOperationState}
+    )::MlirOperation
 end
 
 """
@@ -710,7 +799,9 @@ Parses an operation, giving ownership to the caller. If parsing fails a null ope
 `sourceStr` may be either the text assembly format, or binary bytecode format. `sourceName` is used as the file name of the source; any IR without locations will get a `FileLineColLoc` location with `sourceName` as the file name.
 """
 function mlirOperationCreateParse(context, sourceStr, sourceName)
-    @ccall (MLIR_C_PATH[]).mlirOperationCreateParse(context::MlirContext, sourceStr::MlirStringRef, sourceName::MlirStringRef)::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirOperationCreateParse(
+        context::MlirContext, sourceStr::MlirStringRef, sourceName::MlirStringRef
+    )::MlirOperation
 end
 
 """
@@ -827,7 +918,9 @@ end
 Returns `pos`-th region attached to the operation.
 """
 function mlirOperationGetRegion(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(op::MlirOperation, pos::intptr_t)::MlirRegion
+    @ccall (MLIR_C_PATH[]).mlirOperationGetRegion(
+        op::MlirOperation, pos::intptr_t
+    )::MlirRegion
 end
 
 """
@@ -854,7 +947,9 @@ end
 Returns `pos`-th operand of the operation.
 """
 function mlirOperationGetOperand(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetOperand(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -863,7 +958,9 @@ end
 Sets the `pos`-th operand of the operation.
 """
 function mlirOperationSetOperand(op, pos, newValue)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(op::MlirOperation, pos::intptr_t, newValue::MlirValue)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperand(
+        op::MlirOperation, pos::intptr_t, newValue::MlirValue
+    )::Cvoid
 end
 
 """
@@ -872,7 +969,9 @@ end
 Replaces the operands of the operation.
 """
 function mlirOperationSetOperands(op, nOperands, operands)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetOperands(op::MlirOperation, nOperands::intptr_t, operands::Ptr{MlirValue})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetOperands(
+        op::MlirOperation, nOperands::intptr_t, operands::Ptr{MlirValue}
+    )::Cvoid
 end
 
 """
@@ -890,7 +989,9 @@ end
 Returns `pos`-th result of the operation.
 """
 function mlirOperationGetResult(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(op::MlirOperation, pos::intptr_t)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirOperationGetResult(
+        op::MlirOperation, pos::intptr_t
+    )::MlirValue
 end
 
 """
@@ -908,7 +1009,9 @@ end
 Returns `pos`-th successor of the operation.
 """
 function mlirOperationGetSuccessor(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(op::MlirOperation, pos::intptr_t)::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirOperationGetSuccessor(
+        op::MlirOperation, pos::intptr_t
+    )::MlirBlock
 end
 
 """
@@ -926,7 +1029,9 @@ end
 Return `pos`-th attribute of the operation.
 """
 function mlirOperationGetAttribute(op, pos)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(op::MlirOperation, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttribute(
+        op::MlirOperation, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -935,7 +1040,9 @@ end
 Returns an attribute attached to the operation given its name.
 """
 function mlirOperationGetAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(op::MlirOperation, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOperationGetAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -944,7 +1051,9 @@ end
 Sets an attribute by name, replacing the existing if it exists or adding a new one otherwise.
 """
 function mlirOperationSetAttributeByName(op, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(op::MlirOperation, name::MlirStringRef, attr::MlirAttribute)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationSetAttributeByName(
+        op::MlirOperation, name::MlirStringRef, attr::MlirAttribute
+    )::Cvoid
 end
 
 """
@@ -953,7 +1062,9 @@ end
 Removes an attribute by name. Returns false if the attribute was not found and true if removed.
 """
 function mlirOperationRemoveAttributeByName(op, name)
-    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(op::MlirOperation, name::MlirStringRef)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationRemoveAttributeByName(
+        op::MlirOperation, name::MlirStringRef
+    )::Bool
 end
 
 """
@@ -962,7 +1073,9 @@ end
 Prints an operation by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirOperationPrint(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrint(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrint(
+        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -971,7 +1084,12 @@ end
 Same as [`mlirOperationPrint`](@ref) but accepts flags controlling the printing behavior.
 """
 function mlirOperationPrintWithFlags(op, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(op::MlirOperation, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationPrintWithFlags(
+        op::MlirOperation,
+        flags::MlirOpPrintingFlags,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -980,7 +1098,9 @@ end
 Same as [`mlirOperationPrint`](@ref) but writing the bytecode format.
 """
 function mlirOperationWriteBytecode(op, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecode(
+        op::MlirOperation, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -989,7 +1109,12 @@ end
 Same as [`mlirOperationWriteBytecode`](@ref) but with writer config and returns failure only if desired bytecode could not be honored.
 """
 function mlirOperationWriteBytecodeWithConfig(op, config, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecodeWithConfig(op::MlirOperation, config::MlirBytecodeWriterConfig, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOperationWriteBytecodeWithConfig(
+        op::MlirOperation,
+        config::MlirBytecodeWriterConfig,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -1016,7 +1141,9 @@ end
 Moves the given operation immediately after the other operation in its parent block. The given operation may be owned by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveAfter(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveAfter(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1025,7 +1152,9 @@ end
 Moves the given operation immediately before the other operation in its parent block. The given operation may be owner by the caller or by its current block. The other operation must belong to a block. In any case, the ownership is transferred to the block of the other operation.
 """
 function mlirOperationMoveBefore(op, other)
-    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(op::MlirOperation, other::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOperationMoveBefore(
+        op::MlirOperation, other::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1079,7 +1208,9 @@ end
 Takes a block owned by the caller and appends it to the given region.
 """
 function mlirRegionAppendOwnedBlock(region, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(region::MlirRegion, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionAppendOwnedBlock(
+        region::MlirRegion, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -1088,7 +1219,9 @@ end
 Takes a block owned by the caller and inserts it at `pos` to the given region. This is an expensive operation that linearly scans the region, prefer insertAfter/Before instead.
 """
 function mlirRegionInsertOwnedBlock(region, pos, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(region::MlirRegion, pos::intptr_t, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlock(
+        region::MlirRegion, pos::intptr_t, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -1097,7 +1230,9 @@ end
 Takes a block owned by the caller and inserts it after the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, prepends the block to the region.
 """
 function mlirRegionInsertOwnedBlockAfter(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockAfter(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -1106,7 +1241,9 @@ end
 Takes a block owned by the caller and inserts it before the (non-owned) reference block in the given region. The reference block must belong to the region. If the reference block is null, appends the block to the region.
 """
 function mlirRegionInsertOwnedBlockBefore(region, reference, block)
-    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(region::MlirRegion, reference::MlirBlock, block::MlirBlock)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirRegionInsertOwnedBlockBefore(
+        region::MlirRegion, reference::MlirBlock, block::MlirBlock
+    )::Cvoid
 end
 
 """
@@ -1142,7 +1279,9 @@ end
 Creates a new empty block with the given argument types and transfers ownership to the caller.
 """
 function mlirBlockCreate(nArgs, args, locs)
-    @ccall (MLIR_C_PATH[]).mlirBlockCreate(nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation})::MlirBlock
+    @ccall (MLIR_C_PATH[]).mlirBlockCreate(
+        nArgs::intptr_t, args::Ptr{MlirType}, locs::Ptr{MlirLocation}
+    )::MlirBlock
 end
 
 """
@@ -1232,7 +1371,9 @@ end
 Takes an operation owned by the caller and appends it to the block.
 """
 function mlirBlockAppendOwnedOperation(block, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(block::MlirBlock, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockAppendOwnedOperation(
+        block::MlirBlock, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1241,7 +1382,9 @@ end
 Takes an operation owned by the caller and inserts it as `pos` to the block. This is an expensive operation that scans the block linearly, prefer insertBefore/After instead.
 """
 function mlirBlockInsertOwnedOperation(block, pos, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(block::MlirBlock, pos::intptr_t, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperation(
+        block::MlirBlock, pos::intptr_t, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1250,7 +1393,9 @@ end
 Takes an operation owned by the caller and inserts it after the (non-owned) reference operation in the given block. If the reference is null, prepends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationAfter(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationAfter(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1259,7 +1404,9 @@ end
 Takes an operation owned by the caller and inserts it before the (non-owned) reference operation in the given block. If the reference is null, appends the operation. Otherwise, the reference must belong to the block.
 """
 function mlirBlockInsertOwnedOperationBefore(block, reference, operation)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(block::MlirBlock, reference::MlirOperation, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertOwnedOperationBefore(
+        block::MlirBlock, reference::MlirOperation, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1277,7 +1424,9 @@ end
 Appends an argument of the specified type to the block. Returns the newly added argument.
 """
 function mlirBlockAddArgument(block, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(block::MlirBlock, type::MlirType, loc::MlirLocation)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockAddArgument(
+        block::MlirBlock, type::MlirType, loc::MlirLocation
+    )::MlirValue
 end
 
 """
@@ -1286,7 +1435,9 @@ end
 Inserts an argument of the specified type at a specified index to the block. Returns the newly added argument.
 """
 function mlirBlockInsertArgument(block, pos, type, loc)
-    @ccall (MLIR_C_PATH[]).mlirBlockInsertArgument(block::MlirBlock, pos::intptr_t, type::MlirType, loc::MlirLocation)::MlirValue
+    @ccall (MLIR_C_PATH[]).mlirBlockInsertArgument(
+        block::MlirBlock, pos::intptr_t, type::MlirType, loc::MlirLocation
+    )::MlirValue
 end
 
 """
@@ -1304,7 +1455,9 @@ end
 Prints a block by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirBlockPrint(block, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirBlockPrint(block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirBlockPrint(
+        block::MlirBlock, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1412,7 +1565,9 @@ end
 Prints a value by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirValuePrint(value, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrint(value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrint(
+        value::MlirValue, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1421,7 +1576,12 @@ end
 Prints a value as an operand (i.e., the ValueID).
 """
 function mlirValuePrintAsOperand(value, flags, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirValuePrintAsOperand(value::MlirValue, flags::MlirOpPrintingFlags, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValuePrintAsOperand(
+        value::MlirValue,
+        flags::MlirOpPrintingFlags,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -1439,7 +1599,9 @@ end
 Replace all uses of 'of' value with the 'with' value, updating anything in the IR that uses 'of' to use the other value instead. When this returns there are zero uses of 'of'.
 """
 function mlirValueReplaceAllUsesOfWith(of, with)
-    @ccall (MLIR_C_PATH[]).mlirValueReplaceAllUsesOfWith(of::MlirValue, with::MlirValue)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirValueReplaceAllUsesOfWith(
+        of::MlirValue, with::MlirValue
+    )::Cvoid
 end
 
 """
@@ -1484,7 +1646,9 @@ end
 Parses a type. The type is owned by the context.
 """
 function mlirTypeParseGet(context, type)
-    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(context::MlirContext, type::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTypeParseGet(
+        context::MlirContext, type::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -1538,7 +1702,9 @@ end
 Prints a location by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirTypePrint(type, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirTypePrint(type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirTypePrint(
+        type::MlirType, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1556,7 +1722,9 @@ end
 Parses an attribute. The attribute is owned by the context.
 """
 function mlirAttributeParseGet(context, attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(context::MlirContext, attr::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirAttributeParseGet(
+        context::MlirContext, attr::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -1619,7 +1787,9 @@ end
 Prints an attribute by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAttributePrint(attr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAttributePrint(attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAttributePrint(
+        attr::MlirAttribute, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1637,7 +1807,9 @@ end
 Associates an attribute with the name. Takes ownership of neither.
 """
 function mlirNamedAttributeGet(name, attr)
-    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(name::MlirIdentifier, attr::MlirAttribute)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirNamedAttributeGet(
+        name::MlirIdentifier, attr::MlirAttribute
+    )::MlirNamedAttribute
 end
 
 """
@@ -1646,7 +1818,9 @@ end
 Gets an identifier with the given string value.
 """
 function mlirIdentifierGet(context, str)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(context::MlirContext, str::MlirStringRef)::MlirIdentifier
+    @ccall (MLIR_C_PATH[]).mlirIdentifierGet(
+        context::MlirContext, str::MlirStringRef
+    )::MlirIdentifier
 end
 
 """
@@ -1664,7 +1838,9 @@ end
 Checks whether two identifiers are the same.
 """
 function mlirIdentifierEqual(ident, other)
-    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(ident::MlirIdentifier, other::MlirIdentifier)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIdentifierEqual(
+        ident::MlirIdentifier, other::MlirIdentifier
+    )::Bool
 end
 
 """
@@ -1727,7 +1903,9 @@ end
 Looks up a symbol with the given name in the given symbol table and returns the operation that corresponds to the symbol. If the symbol cannot be found, returns a null operation.
 """
 function mlirSymbolTableLookup(symbolTable, name)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(symbolTable::MlirSymbolTable, name::MlirStringRef)::MlirOperation
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableLookup(
+        symbolTable::MlirSymbolTable, name::MlirStringRef
+    )::MlirOperation
 end
 
 """
@@ -1736,7 +1914,9 @@ end
 Inserts the given operation into the given symbol table. The operation must have the symbol trait. If the symbol table already has a symbol with the same name, renames the symbol being inserted to ensure name uniqueness. Note that this does not move the operation itself into the block of the symbol table operation, this should be done separately. Returns the name of the symbol after insertion.
 """
 function mlirSymbolTableInsert(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(symbolTable::MlirSymbolTable, operation::MlirOperation)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableInsert(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::MlirAttribute
 end
 
 """
@@ -1745,7 +1925,9 @@ end
 Removes the given operation from the symbol table and erases it.
 """
 function mlirSymbolTableErase(symbolTable, operation)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(symbolTable::MlirSymbolTable, operation::MlirOperation)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableErase(
+        symbolTable::MlirSymbolTable, operation::MlirOperation
+    )::Cvoid
 end
 
 """
@@ -1754,7 +1936,9 @@ end
 Attempt to replace all uses that are nested within the given operation of the given symbol 'oldSymbol' with the provided 'newSymbol'. This does not traverse into nested symbol tables. Will fail atomically if there are any unknown operations that may be potential symbol tables.
 """
 function mlirSymbolTableReplaceAllSymbolUses(oldSymbol, newSymbol, from)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableReplaceAllSymbolUses(
+        oldSymbol::MlirStringRef, newSymbol::MlirStringRef, from::MlirOperation
+    )::MlirLogicalResult
 end
 
 """
@@ -1763,7 +1947,12 @@ end
 Walks all symbol table operations nested within, and including, `op`. For each symbol table operation, the provided callback is invoked with the op and a boolean signifying if the symbols within that symbol table can be treated as if all uses within the IR are visible to the caller. `allSymUsesVisible` identifies whether all of the symbol uses of symbols within `op` are visible.
 """
 function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(
+        from::MlirOperation,
+        allSymUsesVisible::Bool,
+        callback::Ptr{Cvoid},
+        userData::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -1781,7 +1970,9 @@ end
 Returns `true` if the two affine expressions are equal.
 """
 function mlirAffineExprEqual(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprEqual(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1799,7 +1990,9 @@ end
 Prints an affine expression by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineExprPrint(affineExpr, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineExprPrint(
+        affineExpr::MlirAffineExpr, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -1817,7 +2010,9 @@ end
 Checks whether the given affine expression is made out of only symbols and constants.
 """
 function mlirAffineExprIsSymbolicOrConstant(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(affineExpr::MlirAffineExpr)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsSymbolicOrConstant(
+        affineExpr::MlirAffineExpr
+    )::Bool
 end
 
 """
@@ -1835,7 +2030,9 @@ end
 Returns the greatest known integral divisor of this affine expression. The result is always positive.
 """
 function mlirAffineExprGetLargestKnownDivisor(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(affineExpr::MlirAffineExpr)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineExprGetLargestKnownDivisor(
+        affineExpr::MlirAffineExpr
+    )::Int64
 end
 
 """
@@ -1844,7 +2041,9 @@ end
 Checks whether the given affine expression is a multiple of 'factor'.
 """
 function mlirAffineExprIsMultipleOf(affineExpr, factor)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(affineExpr::MlirAffineExpr, factor::Int64)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsMultipleOf(
+        affineExpr::MlirAffineExpr, factor::Int64
+    )::Bool
 end
 
 """
@@ -1853,7 +2052,9 @@ end
 Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(
+        affineExpr::MlirAffineExpr, position::intptr_t
+    )::Bool
 end
 
 """
@@ -1862,7 +2063,9 @@ end
 Composes the given map with the given expression.
 """
 function mlirAffineExprCompose(affineExpr, affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(affineExpr::MlirAffineExpr, affineMap::MlirAffineMap)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineExprCompose(
+        affineExpr::MlirAffineExpr, affineMap::MlirAffineMap
+    )::MlirAffineExpr
 end
 
 """
@@ -1880,7 +2083,9 @@ end
 Creates an affine dimension expression with 'position' in the context.
 """
 function mlirAffineDimExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1889,7 +2094,9 @@ end
 Returns the position of the given affine dimension expression.
 """
 function mlirAffineDimExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineDimExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1907,7 +2114,9 @@ end
 Creates an affine symbol expression with 'position' in the context.
 """
 function mlirAffineSymbolExprGet(ctx, position)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(ctx::MlirContext, position::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGet(
+        ctx::MlirContext, position::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -1916,7 +2125,9 @@ end
 Returns the position of the given affine symbol expression.
 """
 function mlirAffineSymbolExprGetPosition(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(affineExpr::MlirAffineExpr)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirAffineSymbolExprGetPosition(
+        affineExpr::MlirAffineExpr
+    )::intptr_t
 end
 
 """
@@ -1934,7 +2145,9 @@ end
 Creates an affine constant expression with 'constant' in the context.
 """
 function mlirAffineConstantExprGet(ctx, constant)
-    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(ctx::MlirContext, constant::Int64)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineConstantExprGet(
+        ctx::MlirContext, constant::Int64
+    )::MlirAffineExpr
 end
 
 """
@@ -1961,7 +2174,9 @@ end
 Creates an affine add expression with 'lhs' and 'rhs'.
 """
 function mlirAffineAddExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineAddExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1979,7 +2194,9 @@ end
 Creates an affine mul expression with 'lhs' and 'rhs'.
 """
 function mlirAffineMulExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMulExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -1997,7 +2214,9 @@ end
 Creates an affine mod expression with 'lhs' and 'rhs'.
 """
 function mlirAffineModExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineModExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -2015,7 +2234,9 @@ end
 Creates an affine floordiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineFloorDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineFloorDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -2033,7 +2254,9 @@ end
 Creates an affine ceildiv expression with 'lhs' and 'rhs'.
 """
 function mlirAffineCeilDivExprGet(lhs, rhs)
-    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(lhs::MlirAffineExpr, rhs::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineCeilDivExprGet(
+        lhs::MlirAffineExpr, rhs::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -2051,7 +2274,9 @@ end
 Returns the left hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetLHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetLHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -2060,7 +2285,9 @@ end
 Returns the right hand side affine expression of the given affine binary operation expression.
 """
 function mlirAffineBinaryOpExprGetRHS(affineExpr)
-    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(affineExpr::MlirAffineExpr)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineBinaryOpExprGetRHS(
+        affineExpr::MlirAffineExpr
+    )::MlirAffineExpr
 end
 
 """
@@ -2096,7 +2323,9 @@ end
 Prints an affine map by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirAffineMapPrint(affineMap, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPrint(
+        affineMap::MlirAffineMap, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -2123,7 +2352,9 @@ end
 Creates a zero result affine map of the given dimensions and symbols in the context. The affine map is owned by the context.
 """
 function mlirAffineMapZeroResultGet(ctx, dimCount, symbolCount)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapZeroResultGet(
+        ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2132,7 +2363,13 @@ end
 Creates an affine map with results defined by the given list of affine expressions. The map resulting map also has the requested number of input dimensions and symbols, regardless of them being used in the results.
 """
 function mlirAffineMapGet(ctx, dimCount, symbolCount, nAffineExprs, affineExprs)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(ctx::MlirContext, dimCount::intptr_t, symbolCount::intptr_t, nAffineExprs::intptr_t, affineExprs::Ptr{MlirAffineExpr})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGet(
+        ctx::MlirContext,
+        dimCount::intptr_t,
+        symbolCount::intptr_t,
+        nAffineExprs::intptr_t,
+        affineExprs::Ptr{MlirAffineExpr},
+    )::MlirAffineMap
 end
 
 """
@@ -2141,7 +2378,9 @@ end
 Creates a single constant result affine map in the context. The affine map is owned by the context.
 """
 function mlirAffineMapConstantGet(ctx, val)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(ctx::MlirContext, val::Int64)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapConstantGet(
+        ctx::MlirContext, val::Int64
+    )::MlirAffineMap
 end
 
 """
@@ -2150,7 +2389,9 @@ end
 Creates an affine map with 'numDims' identity in the context. The affine map is owned by the context.
 """
 function mlirAffineMapMultiDimIdentityGet(ctx, numDims)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(ctx::MlirContext, numDims::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMultiDimIdentityGet(
+        ctx::MlirContext, numDims::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2159,7 +2400,9 @@ end
 Creates an identity affine map on the most minor dimensions in the context. The affine map is owned by the context. The function asserts that the number of dimensions is greater or equal to the number of results.
 """
 function mlirAffineMapMinorIdentityGet(ctx, dims, results)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(ctx::MlirContext, dims::intptr_t, results::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapMinorIdentityGet(
+        ctx::MlirContext, dims::intptr_t, results::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2168,7 +2411,9 @@ end
 Creates an affine map with a permutation expression and its size in the context. The permutation expression is a non-empty vector of integers. The elements of the permutation vector must be continuous from 0 and cannot be repeated (i.e. `[1,2,0]` is a valid permutation. `[2,0]` or `[1,1,2]` is an invalid invalid permutation.) The affine map is owned by the context.
 """
 function mlirAffineMapPermutationGet(ctx, size, permutation)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapPermutationGet(
+        ctx::MlirContext, size::intptr_t, permutation::Ptr{Cuint}
+    )::MlirAffineMap
 end
 
 """
@@ -2213,7 +2458,9 @@ end
 Returns the constant result of the given affine map. The function asserts that the map has a single constant result.
 """
 function mlirAffineMapGetSingleConstantResult(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(affineMap::MlirAffineMap)::Int64
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSingleConstantResult(
+        affineMap::MlirAffineMap
+    )::Int64
 end
 
 """
@@ -2249,7 +2496,9 @@ end
 Returns the result at the given position.
 """
 function mlirAffineMapGetResult(affineMap, pos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(affineMap::MlirAffineMap, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetResult(
+        affineMap::MlirAffineMap, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -2267,7 +2516,9 @@ end
 Checks whether the given affine map represents a subset of a symbol-less permutation map.
 """
 function mlirAffineMapIsProjectedPermutation(affineMap)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(affineMap::MlirAffineMap)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAffineMapIsProjectedPermutation(
+        affineMap::MlirAffineMap
+    )::Bool
 end
 
 """
@@ -2285,7 +2536,9 @@ end
 Returns the affine map consisting of the `resultPos` subset.
 """
 function mlirAffineMapGetSubMap(affineMap, size, resultPos)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t})::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetSubMap(
+        affineMap::MlirAffineMap, size::intptr_t, resultPos::Ptr{intptr_t}
+    )::MlirAffineMap
 end
 
 """
@@ -2294,7 +2547,9 @@ end
 Returns the affine map consisting of the most major `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMajorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMajorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2303,7 +2558,9 @@ end
 Returns the affine map consisting of the most minor `numResults` results. Returns the null AffineMap if the `numResults` is equal to zero. Returns the `affineMap` if `numResults` is greater or equals to number of results of the given affine map.
 """
 function mlirAffineMapGetMinorSubMap(affineMap, numResults)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(affineMap::MlirAffineMap, numResults::intptr_t)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirAffineMapGetMinorSubMap(
+        affineMap::MlirAffineMap, numResults::intptr_t
+    )::MlirAffineMap
 end
 
 """
@@ -2311,8 +2568,16 @@ end
 
 Apply AffineExpr::replace(`map`) to each of the results and return a new new AffineMap with the new results and the specified number of dims and symbols.
 """
-function mlirAffineMapReplace(affineMap, expression, replacement, numResultDims, numResultSyms)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(affineMap::MlirAffineMap, expression::MlirAffineExpr, replacement::MlirAffineExpr, numResultDims::intptr_t, numResultSyms::intptr_t)::MlirAffineMap
+function mlirAffineMapReplace(
+    affineMap, expression, replacement, numResultDims, numResultSyms
+)
+    @ccall (MLIR_C_PATH[]).mlirAffineMapReplace(
+        affineMap::MlirAffineMap,
+        expression::MlirAffineExpr,
+        replacement::MlirAffineExpr,
+        numResultDims::intptr_t,
+        numResultSyms::intptr_t,
+    )::MlirAffineMap
 end
 
 """
@@ -2321,7 +2586,12 @@ end
 Returns the simplified affine map resulting from dropping the symbols that do not appear in any of the individual maps in `affineMaps`. Asserts that all maps in `affineMaps` are normalized to the same number of dims and symbols. Takes a callback `populateResult` to fill the `res` container with value `m` at entry `idx`. This allows returning without worrying about ownership considerations.
 """
 function mlirAffineMapCompressUnusedSymbols(affineMaps, size, result, populateResult)
-    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(affineMaps::Ptr{MlirAffineMap}, size::intptr_t, result::Ptr{Cvoid}, populateResult::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirAffineMapCompressUnusedSymbols(
+        affineMaps::Ptr{MlirAffineMap},
+        size::intptr_t,
+        result::Ptr{Cvoid},
+        populateResult::Ptr{Cvoid},
+    )::Cvoid
 end
 
 """
@@ -2388,7 +2658,9 @@ end
 Creates an array element containing the given list of elements in the given context.
 """
 function mlirArrayAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2406,7 +2678,9 @@ end
 Returns pos-th element stored in the given array attribute.
 """
 function mlirArrayAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirArrayAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2433,7 +2707,9 @@ end
 Creates a dictionary attribute containing the given list of elements in the provided context.
 """
 function mlirDictionaryAttrGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirNamedAttribute}
+    )::MlirAttribute
 end
 
 """
@@ -2451,7 +2727,9 @@ end
 Returns pos-th element of the given dictionary attribute.
 """
 function mlirDictionaryAttrGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(attr::MlirAttribute, pos::intptr_t)::MlirNamedAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirNamedAttribute
 end
 
 """
@@ -2460,7 +2738,9 @@ end
 Returns the dictionary attribute element with the given name or NULL if the given name does not exist in the dictionary.
 """
 function mlirDictionaryAttrGetElementByName(attr, name)
-    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(attr::MlirAttribute, name::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDictionaryAttrGetElementByName(
+        attr::MlirAttribute, name::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2487,7 +2767,9 @@ end
 Creates a floating point attribute in the given context with the given double value and double-precision FP semantics.
 """
 function mlirFloatAttrDoubleGet(ctx, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(ctx::MlirContext, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGet(
+        ctx::MlirContext, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2496,7 +2778,9 @@ end
 Same as "[`mlirFloatAttrDoubleGet`](@ref)", but if the type is not valid for a construction of a FloatAttr, returns a null [`MlirAttribute`](@ref).
 """
 function mlirFloatAttrDoubleGetChecked(loc, type, value)
-    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(loc::MlirLocation, type::MlirType, value::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFloatAttrDoubleGetChecked(
+        loc::MlirLocation, type::MlirType, value::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -2631,7 +2915,13 @@ end
 Creates an opaque attribute in the given context associated with the dialect identified by its namespace. The attribute contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueAttrGet(ctx, dialectNamespace, dataLength, data, type)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(ctx::MlirContext, dialectNamespace::MlirStringRef, dataLength::intptr_t, data::Cstring, type::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGet(
+        ctx::MlirContext,
+        dialectNamespace::MlirStringRef,
+        dataLength::intptr_t,
+        data::Cstring,
+        type::MlirType,
+    )::MlirAttribute
 end
 
 """
@@ -2640,7 +2930,9 @@ end
 Returns the namespace of the dialect with which the given opaque attribute is associated. The namespace string is owned by the context.
 """
 function mlirOpaqueAttrGetDialectNamespace(attr)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirOpaqueAttrGetDialectNamespace(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2676,7 +2968,9 @@ end
 Creates a string attribute in the given context containing the given string.
 """
 function mlirStringAttrGet(ctx, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(ctx::MlirContext, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrGet(
+        ctx::MlirContext, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2685,7 +2979,9 @@ end
 Creates a string attribute in the given context containing the given string. Additionally, the attribute has the given type.
 """
 function mlirStringAttrTypedGet(type, str)
-    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(type::MlirType, str::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStringAttrTypedGet(
+        type::MlirType, str::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2721,7 +3017,12 @@ end
 Creates a symbol reference attribute in the given context referencing a symbol identified by the given string inside a list of nested references. Each of the references in the list must not be nested.
 """
 function mlirSymbolRefAttrGet(ctx, symbol, numReferences, references)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef, numReferences::intptr_t, references::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGet(
+        ctx::MlirContext,
+        symbol::MlirStringRef,
+        numReferences::intptr_t,
+        references::Ptr{MlirAttribute},
+    )::MlirAttribute
 end
 
 """
@@ -2730,7 +3031,9 @@ end
 Returns the string reference to the root referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetRootReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetRootReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2739,7 +3042,9 @@ end
 Returns the string reference to the leaf referenced symbol. The data remains live as long as the context in which the attribute lives.
 """
 function mlirSymbolRefAttrGetLeafReference(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetLeafReference(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -2748,7 +3053,9 @@ end
 Returns the number of references nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNumNestedReferences(attr)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(attr::MlirAttribute)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNumNestedReferences(
+        attr::MlirAttribute
+    )::intptr_t
 end
 
 """
@@ -2757,7 +3064,9 @@ end
 Returns pos-th reference nested in the given symbol reference attribute.
 """
 function mlirSymbolRefAttrGetNestedReference(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(attr::MlirAttribute, pos::intptr_t)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSymbolRefAttrGetNestedReference(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirAttribute
 end
 
 """
@@ -2784,7 +3093,9 @@ end
 Creates a flat symbol reference attribute in the given context referencing a symbol identified by the given string.
 """
 function mlirFlatSymbolRefAttrGet(ctx, symbol)
-    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(ctx::MlirContext, symbol::MlirStringRef)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirFlatSymbolRefAttrGet(
+        ctx::MlirContext, symbol::MlirStringRef
+    )::MlirAttribute
 end
 
 """
@@ -2874,7 +3185,9 @@ end
 Returns the element at the given rank-dimensional index.
 """
 function mlirElementsAttrGetValue(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrGetValue(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 """
@@ -2883,7 +3196,9 @@ end
 Checks whether the given rank-dimensional index is valid in the given elements attribute.
 """
 function mlirElementsAttrIsValidIndex(attr, rank, idxs)
-    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64})::Bool
+    @ccall (MLIR_C_PATH[]).mlirElementsAttrIsValidIndex(
+        attr::MlirAttribute, rank::intptr_t, idxs::Ptr{UInt64}
+    )::Bool
 end
 
 """
@@ -2938,31 +3253,45 @@ end
 Create a dense array attribute with the given elements.
 """
 function mlirDenseBoolArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cint})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Cint}
+    )::MlirAttribute
 end
 
 function mlirDenseI8ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int8}
+    )::MlirAttribute
 end
 
 function mlirDenseI16ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int16}
+    )::MlirAttribute
 end
 
 function mlirDenseI32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int32}
+    )::MlirAttribute
 end
 
 function mlirDenseI64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirDenseF32ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Cfloat}
+    )::MlirAttribute
 end
 
 function mlirDenseF64ArrayGet(ctx, size, values)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGet(
+        ctx::MlirContext, size::intptr_t, values::Ptr{Cdouble}
+    )::MlirAttribute
 end
 
 """
@@ -2980,31 +3309,45 @@ end
 Get an element of a dense array.
 """
 function mlirDenseBoolArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseI8ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseI8ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseI16ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseI16ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseI32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseI32ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseI64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseI64ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseF32ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseF32ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseF64ArrayGetElement(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseF64ArrayGetElement(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -3039,11 +3382,24 @@ end
 Creates a dense elements attribute with the given Shaped type and elements in the same context as the type.
 """
 function mlirDenseElementsAttrGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{MlirAttribute}
+    )::MlirAttribute
 end
 
+"""
+    mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
+
+Creates a dense elements attribute with the given Shaped type and elements populated from a packed, row-major opaque buffer of contents.
+
+The format of the raw buffer is a densely packed array of values that can be bitcast to the storage format of the element type specified. Types that are not byte aligned will be: - For bitwidth > 1: Rounded up to the next byte. - For bitwidth = 1: Packed into 8bit bytes with bits corresponding to the linear order of the shape type from MSB to LSB, padded to on the right.
+
+A raw buffer of a single element (or for 1-bit, a byte of value 0 or 255) will be interpreted as a splat. User code should be prepared for additional, conformant patterns to be identified as splats in the future.
+"""
 function mlirDenseElementsAttrRawBufferGet(shapedType, rawBufferSize, rawBuffer)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(shapedType::MlirType, rawBufferSize::Cint, rawBuffer::Ptr{Cvoid})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrRawBufferGet(
+        shapedType::MlirType, rawBufferSize::Csize_t, rawBuffer::Ptr{Cvoid}
+    )::MlirAttribute
 end
 
 """
@@ -3052,43 +3408,63 @@ end
 Creates a dense elements attribute with the given Shaped type containing a single replicated element (splat).
 """
 function mlirDenseElementsAttrSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(shapedType::MlirType, element::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrSplatGet(
+        shapedType::MlirType, element::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBoolSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(shapedType::MlirType, element::Bool)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolSplatGet(
+        shapedType::MlirType, element::Bool
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(shapedType::MlirType, element::UInt8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8SplatGet(
+        shapedType::MlirType, element::UInt8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(shapedType::MlirType, element::Int8)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8SplatGet(
+        shapedType::MlirType, element::Int8
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(shapedType::MlirType, element::UInt32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32SplatGet(
+        shapedType::MlirType, element::UInt32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(shapedType::MlirType, element::Int32)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32SplatGet(
+        shapedType::MlirType, element::Int32
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(shapedType::MlirType, element::UInt64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64SplatGet(
+        shapedType::MlirType, element::UInt64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64SplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(shapedType::MlirType, element::Int64)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64SplatGet(
+        shapedType::MlirType, element::Int64
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(shapedType::MlirType, element::Cfloat)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatSplatGet(
+        shapedType::MlirType, element::Cfloat
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleSplatGet(shapedType, element)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(shapedType::MlirType, element::Cdouble)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleSplatGet(
+        shapedType::MlirType, element::Cdouble
+    )::MlirAttribute
 end
 
 """
@@ -3097,55 +3473,81 @@ end
 Creates a dense elements attribute with the given shaped type from elements of a specific type. Expects the element type of the shaped type to match the data element type.
 """
 function mlirDenseElementsAttrBoolGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBoolGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cint}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt8Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt8Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int8}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt32Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt32Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int32}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrUInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrUInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrInt64Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrInt64Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloatGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloatGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cfloat}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrDoubleGet(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrDoubleGet(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{Cdouble}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrBFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrBFloat16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrFloat16Get(shapedType, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrFloat16Get(
+        shapedType::MlirType, numElements::intptr_t, elements::Ptr{UInt16}
+    )::MlirAttribute
 end
 
 """
@@ -3154,7 +3556,9 @@ end
 Creates a dense elements attribute with the given shaped type from string elements.
 """
 function mlirDenseElementsAttrStringGet(shapedType, numElements, strs)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrStringGet(
+        shapedType::MlirType, numElements::intptr_t, strs::Ptr{MlirStringRef}
+    )::MlirAttribute
 end
 
 """
@@ -3163,7 +3567,9 @@ end
 Creates a dense elements attribute that has the same data as the given dense elements attribute and a different shaped type. The new type must have the same total number of elements.
 """
 function mlirDenseElementsAttrReshapeGet(attr, shapedType)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(attr::MlirAttribute, shapedType::MlirType)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrReshapeGet(
+        attr::MlirAttribute, shapedType::MlirType
+    )::MlirAttribute
 end
 
 """
@@ -3181,7 +3587,9 @@ end
 Returns the single replicated value (splat) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetSplatValue(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 function mlirDenseElementsAttrGetBoolSplatValue(attr)
@@ -3193,35 +3601,51 @@ function mlirDenseElementsAttrGetInt8SplatValue(attr)
 end
 
 function mlirDenseElementsAttrGetUInt8SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(attr::MlirAttribute)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8SplatValue(
+        attr::MlirAttribute
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(attr::MlirAttribute)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32SplatValue(
+        attr::MlirAttribute
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(attr::MlirAttribute)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32SplatValue(
+        attr::MlirAttribute
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(attr::MlirAttribute)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64SplatValue(
+        attr::MlirAttribute
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64SplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(attr::MlirAttribute)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64SplatValue(
+        attr::MlirAttribute
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(attr::MlirAttribute)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatSplatValue(
+        attr::MlirAttribute
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(attr::MlirAttribute)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleSplatValue(
+        attr::MlirAttribute
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringSplatValue(attr)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(attr::MlirAttribute)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringSplatValue(
+        attr::MlirAttribute
+    )::MlirStringRef
 end
 
 """
@@ -3230,51 +3654,75 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense elements attribute.
 """
 function mlirDenseElementsAttrGetBoolValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetBoolValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseElementsAttrGetInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseElementsAttrGetUInt8Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(attr::MlirAttribute, pos::intptr_t)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt8Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt8
 end
 
 function mlirDenseElementsAttrGetInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseElementsAttrGetUInt16Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(attr::MlirAttribute, pos::intptr_t)::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt16Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt16
 end
 
 function mlirDenseElementsAttrGetInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseElementsAttrGetUInt32Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(attr::MlirAttribute, pos::intptr_t)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt32Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt32
 end
 
 function mlirDenseElementsAttrGetInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseElementsAttrGetUInt64Value(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(attr::MlirAttribute, pos::intptr_t)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetUInt64Value(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt64
 end
 
 function mlirDenseElementsAttrGetFloatValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetFloatValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseElementsAttrGetDoubleValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetDoubleValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 function mlirDenseElementsAttrGetStringValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(attr::MlirAttribute, pos::intptr_t)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetStringValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::MlirStringRef
 end
 
 """
@@ -3286,48 +3734,125 @@ function mlirDenseElementsAttrGetRawData(attr)
     @ccall (MLIR_C_PATH[]).mlirDenseElementsAttrGetRawData(attr::MlirAttribute)::Ptr{Cvoid}
 end
 
-function mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cint})::MlirAttribute
+function mlirUnmanagedDenseBoolResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseBoolResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Cint},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt8})::MlirAttribute
+function mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt8ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt8},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int8})::MlirAttribute
+function mlirUnmanagedDenseInt8ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt8ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int8},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt16})::MlirAttribute
+function mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt16ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt16},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int16})::MlirAttribute
+function mlirUnmanagedDenseInt16ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt16ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int16},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt32})::MlirAttribute
+function mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt32ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt32},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int32})::MlirAttribute
+function mlirUnmanagedDenseInt32ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt32ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int32},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{UInt64})::MlirAttribute
+function mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseUInt64ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{UInt64},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Int64})::MlirAttribute
+function mlirUnmanagedDenseInt64ResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseInt64ResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Int64},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cfloat})::MlirAttribute
+function mlirUnmanagedDenseFloatResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseFloatResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Cfloat},
+    )::MlirAttribute
 end
 
-function mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType, name, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(shapedType::MlirType, name::MlirStringRef, numElements::intptr_t, elements::Ptr{Cdouble})::MlirAttribute
+function mlirUnmanagedDenseDoubleResourceElementsAttrGet(
+    shapedType, name, numElements, elements
+)
+    @ccall (MLIR_C_PATH[]).mlirUnmanagedDenseDoubleResourceElementsAttrGet(
+        shapedType::MlirType,
+        name::MlirStringRef,
+        numElements::intptr_t,
+        elements::Ptr{Cdouble},
+    )::MlirAttribute
 end
 
 """
@@ -3336,47 +3861,69 @@ end
 Returns the pos-th value (flat contiguous indexing) of a specific type contained by the given dense resource elements attribute.
 """
 function mlirDenseBoolResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirDenseBoolResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Bool
 end
 
 function mlirDenseInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int8
+    @ccall (MLIR_C_PATH[]).mlirDenseInt8ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int8
 end
 
 function mlirDenseUInt8ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt8
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt8ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt8
 end
 
 function mlirDenseInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int16
+    @ccall (MLIR_C_PATH[]).mlirDenseInt16ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int16
 end
 
 function mlirDenseUInt16ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt16
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt16ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt16
 end
 
 function mlirDenseInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int32
+    @ccall (MLIR_C_PATH[]).mlirDenseInt32ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int32
 end
 
 function mlirDenseUInt32ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt32
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt32ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt32
 end
 
 function mlirDenseInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirDenseInt64ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 function mlirDenseUInt64ResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::UInt64
+    @ccall (MLIR_C_PATH[]).mlirDenseUInt64ResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::UInt64
 end
 
 function mlirDenseFloatResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cfloat
+    @ccall (MLIR_C_PATH[]).mlirDenseFloatResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cfloat
 end
 
 function mlirDenseDoubleResourceElementsAttrGetValue(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(attr::MlirAttribute, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirDenseDoubleResourceElementsAttrGetValue(
+        attr::MlirAttribute, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -3394,7 +3941,9 @@ end
 Creates a sparse elements attribute of the given shape from a list of indices and a list of associated values. Both lists are expected to be dense elements attributes with the same number of elements. The list of indices is expected to contain 64-bit integers. The attribute is created in the same context as the type.
 """
 function mlirSparseElementsAttribute(shapedType, denseIndices, denseValues)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttribute(
+        shapedType::MlirType, denseIndices::MlirAttribute, denseValues::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -3403,7 +3952,9 @@ end
 Returns the dense elements attribute containing 64-bit integer indices of non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetIndices(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetIndices(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -3412,7 +3963,9 @@ end
 Returns the dense elements attribute containing the non-null elements in the given sparse elements attribute.
 """
 function mlirSparseElementsAttrGetValues(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(attr::MlirAttribute)::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirSparseElementsAttrGetValues(
+        attr::MlirAttribute
+    )::MlirAttribute
 end
 
 """
@@ -3429,7 +3982,9 @@ function mlirAttributeIsAStridedLayout(attr)
 end
 
 function mlirStridedLayoutAttrGet(ctx, offset, numStrides, strides)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64})::MlirAttribute
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGet(
+        ctx::MlirContext, offset::Int64, numStrides::intptr_t, strides::Ptr{Int64}
+    )::MlirAttribute
 end
 
 function mlirStridedLayoutAttrGetOffset(attr)
@@ -3441,7 +3996,9 @@ function mlirStridedLayoutAttrGetNumStrides(attr)
 end
 
 function mlirStridedLayoutAttrGetStride(attr, pos)
-    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(attr::MlirAttribute, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirStridedLayoutAttrGetStride(
+        attr::MlirAttribute, pos::intptr_t
+    )::Int64
 end
 
 """
@@ -3486,7 +4043,9 @@ end
 Creates a signed integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeSignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeSignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -3495,7 +4054,9 @@ end
 Creates an unsigned integer type of the given bitwidth in the context. The type is owned by the context.
 """
 function mlirIntegerTypeUnsignedGet(ctx, bitwidth)
-    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(ctx::MlirContext, bitwidth::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirIntegerTypeUnsignedGet(
+        ctx::MlirContext, bitwidth::Cuint
+    )::MlirType
 end
 
 """
@@ -4017,7 +4578,9 @@ end
 Creates a vector type of the shape identified by its rank and dimensions, with the given element type in the same context as the element type. The type is owned by the context.
 """
 function mlirVectorTypeGet(rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -4026,7 +4589,9 @@ end
 Same as "[`mlirVectorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirVectorTypeGetChecked(loc, rank, shape, elementType)
-    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirVectorTypeGetChecked(
+        loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -4080,7 +4645,9 @@ end
 Creates a tensor type of a fixed rank with the given shape, element type, and optional encoding in the same context as the element type. The type is owned by the context. Tensor types without any specific encoding field should assign [`mlirAttributeGetNull`](@ref)() to this parameter.
 """
 function mlirRankedTensorTypeGet(rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGet(
+        rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -4089,7 +4656,13 @@ end
 Same as "[`mlirRankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirRankedTensorTypeGetChecked(loc, rank, shape, elementType, encoding)
-    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(loc::MlirLocation, rank::intptr_t, shape::Ptr{Int64}, elementType::MlirType, encoding::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirRankedTensorTypeGetChecked(
+        loc::MlirLocation,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        elementType::MlirType,
+        encoding::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -4116,7 +4689,9 @@ end
 Same as "[`mlirUnrankedTensorTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedTensorTypeGetChecked(loc, elementType)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(loc::MlirLocation, elementType::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedTensorTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType
+    )::MlirType
 end
 
 """
@@ -4161,7 +4736,13 @@ end
 Creates a MemRef type with the given rank and shape, a potentially empty list of affine layout maps, the given memory space and element type, in the same context as element type. The type is owned by the context.
 """
 function mlirMemRefTypeGet(elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGet(
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -4170,7 +4751,14 @@ end
 Same as "[`mlirMemRefTypeGet`](@ref)" but returns a nullptr-wrapping [`MlirType`](@ref) o illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeGetChecked(loc, elementType, rank, shape, layout, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, layout::MlirAttribute, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        layout::MlirAttribute,
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -4179,7 +4767,9 @@ end
 Creates a MemRef type with the given rank, shape, memory space and element type in the same context as the element type. The type has no affine maps, i.e. represents a default row-major contiguous memref. The type is owned by the context.
 """
 function mlirMemRefTypeContiguousGet(elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGet(
+        elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -4188,7 +4778,13 @@ end
 Same as "[`mlirMemRefTypeContiguousGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirMemRefTypeContiguousGetChecked(loc, elementType, rank, shape, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(loc::MlirLocation, elementType::MlirType, rank::intptr_t, shape::Ptr{Int64}, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirMemRefTypeContiguousGetChecked(
+        loc::MlirLocation,
+        elementType::MlirType,
+        rank::intptr_t,
+        shape::Ptr{Int64},
+        memorySpace::MlirAttribute,
+    )::MlirType
 end
 
 """
@@ -4197,7 +4793,9 @@ end
 Creates an Unranked MemRef type with the given element type and in the given memory space. The type is owned by the context of element type.
 """
 function mlirUnrankedMemRefTypeGet(elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGet(
+        elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -4206,7 +4804,9 @@ end
 Same as "[`mlirUnrankedMemRefTypeGet`](@ref)" but returns a nullptr wrapping [`MlirType`](@ref) on illegal arguments, emitting appropriate diagnostics.
 """
 function mlirUnrankedMemRefTypeGetChecked(loc, elementType, memorySpace)
-    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirUnrankedMemRefTypeGetChecked(
+        loc::MlirLocation, elementType::MlirType, memorySpace::MlirAttribute
+    )::MlirType
 end
 
 """
@@ -4269,7 +4869,9 @@ end
 Creates a tuple type that consists of the given list of elemental types. The type is owned by the context.
 """
 function mlirTupleTypeGet(ctx, numElements, elements)
-    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTupleTypeGet(
+        ctx::MlirContext, numElements::intptr_t, elements::Ptr{MlirType}
+    )::MlirType
 end
 
 """
@@ -4314,7 +4916,13 @@ end
 Creates a function type, mapping a list of input types to result types.
 """
 function mlirFunctionTypeGet(ctx, numInputs, inputs, numResults, results)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(ctx::MlirContext, numInputs::intptr_t, inputs::Ptr{MlirType}, numResults::intptr_t, results::Ptr{MlirType})::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGet(
+        ctx::MlirContext,
+        numInputs::intptr_t,
+        inputs::Ptr{MlirType},
+        numResults::intptr_t,
+        results::Ptr{MlirType},
+    )::MlirType
 end
 
 """
@@ -4350,7 +4958,9 @@ end
 Returns the pos-th result type.
 """
 function mlirFunctionTypeGetResult(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(type::MlirType, pos::intptr_t)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirFunctionTypeGetResult(
+        type::MlirType, pos::intptr_t
+    )::MlirType
 end
 
 """
@@ -4377,7 +4987,9 @@ end
 Creates an opaque type in the given context associated with the dialect identified by its namespace. The type contains opaque byte data of the specified length (data need not be null-terminated).
 """
 function mlirOpaqueTypeGet(ctx, dialectNamespace, typeData)
-    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGet(
+        ctx::MlirContext, dialectNamespace::MlirStringRef, typeData::MlirStringRef
+    )::MlirType
 end
 
 """
@@ -4413,7 +5025,9 @@ end
 Create a new top-level PassManager anchored on `anchorOp`.
 """
 function mlirPassManagerCreateOnOperation(ctx, anchorOp)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(ctx::MlirContext, anchorOp::MlirStringRef)::MlirPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerCreateOnOperation(
+        ctx::MlirContext, anchorOp::MlirStringRef
+    )::MlirPassManager
 end
 
 """
@@ -4440,7 +5054,9 @@ end
 Cast a top-level PassManager to a generic OpPassManager.
 """
 function mlirPassManagerGetAsOpPassManager(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(passManager::MlirPassManager)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetAsOpPassManager(
+        passManager::MlirPassManager
+    )::MlirOpPassManager
 end
 
 """
@@ -4449,7 +5065,9 @@ end
 Run the provided `passManager` on the given `op`.
 """
 function mlirPassManagerRunOnOp(passManager, op)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerRunOnOp(passManager::MlirPassManager, op::MlirOperation)::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirPassManagerRunOnOp(
+        passManager::MlirPassManager, op::MlirOperation
+    )::MlirLogicalResult
 end
 
 """
@@ -4458,7 +5076,9 @@ end
 Enable mlir-print-ir-after-all.
 """
 function mlirPassManagerEnableIRPrinting(passManager)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(passManager::MlirPassManager)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableIRPrinting(
+        passManager::MlirPassManager
+    )::Cvoid
 end
 
 """
@@ -4467,7 +5087,9 @@ end
 Enable / disable verify-each.
 """
 function mlirPassManagerEnableVerifier(passManager, enable)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(passManager::MlirPassManager, enable::Bool)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerEnableVerifier(
+        passManager::MlirPassManager, enable::Bool
+    )::Cvoid
 end
 
 """
@@ -4476,7 +5098,9 @@ end
 Nest an OpPassManager under the top-level PassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed. To further nest more OpPassManager under the newly returned one, see `mlirOpPassManagerNest` below.
 """
 function mlirPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(passManager::MlirPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirPassManagerGetNestedUnder(
+        passManager::MlirPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -4485,7 +5109,9 @@ end
 Nest an OpPassManager under the provided OpPassManager, the nested passmanager will only run on operations matching the provided name. The returned OpPassManager will be destroyed when the parent is destroyed.
 """
 function mlirOpPassManagerGetNestedUnder(passManager, operationName)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(passManager::MlirOpPassManager, operationName::MlirStringRef)::MlirOpPassManager
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerGetNestedUnder(
+        passManager::MlirOpPassManager, operationName::MlirStringRef
+    )::MlirOpPassManager
 end
 
 """
@@ -4494,7 +5120,9 @@ end
 Add a pass and transfer ownership to the provided top-level mlirPassManager. If the pass is not a generic operation pass or a ModulePass, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(passManager::MlirPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPassManagerAddOwnedPass(
+        passManager::MlirPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -4503,7 +5131,9 @@ end
 Add a pass and transfer ownership to the provided mlirOpPassManager. If the pass is not a generic operation pass or matching the type of the provided PassManager, a new OpPassManager is implicitly nested under the provided PassManager.
 """
 function mlirOpPassManagerAddOwnedPass(passManager, pass)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(passManager::MlirOpPassManager, pass::MlirPass)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddOwnedPass(
+        passManager::MlirOpPassManager, pass::MlirPass
+    )::Cvoid
 end
 
 """
@@ -4512,7 +5142,12 @@ end
 Parse a sequence of textual MLIR pass pipeline elements and add them to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirOpPassManagerAddPipeline(passManager, pipelineElements, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(passManager::MlirOpPassManager, pipelineElements::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirOpPassManagerAddPipeline(
+        passManager::MlirOpPassManager,
+        pipelineElements::MlirStringRef,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -4521,7 +5156,9 @@ end
 Print a textual MLIR pass pipeline by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirPrintPassPipeline(passManager, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirPrintPassPipeline(
+        passManager::MlirOpPassManager, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -4530,7 +5167,12 @@ end
 Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. If parsing fails an error message is reported using the provided callback.
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(
+        passManager::MlirOpPassManager,
+        pipeline::MlirStringRef,
+        callback::MlirStringCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -4538,8 +5180,28 @@ end
 
 Creates an external [`MlirPass`](@ref) that calls the supplied `callbacks` using the supplied `userData`. If `opName` is empty, the pass is a generic operation pass. Otherwise it is an operation pass specific to the specified pass name.
 """
-function mlirCreateExternalPass(passID, name, argument, description, opName, nDependentDialects, dependentDialects, callbacks, userData)
-    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(passID::MlirTypeID, name::MlirStringRef, argument::MlirStringRef, description::MlirStringRef, opName::MlirStringRef, nDependentDialects::intptr_t, dependentDialects::Ptr{MlirDialectHandle}, callbacks::MlirExternalPassCallbacks, userData::Ptr{Cvoid})::MlirPass
+function mlirCreateExternalPass(
+    passID,
+    name,
+    argument,
+    description,
+    opName,
+    nDependentDialects,
+    dependentDialects,
+    callbacks,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirCreateExternalPass(
+        passID::MlirTypeID,
+        name::MlirStringRef,
+        argument::MlirStringRef,
+        description::MlirStringRef,
+        opName::MlirStringRef,
+        nDependentDialects::intptr_t,
+        dependentDialects::Ptr{MlirDialectHandle},
+        callbacks::MlirExternalPassCallbacks,
+        userData::Ptr{Cvoid},
+    )::MlirPass
 end
 
 """
@@ -5082,7 +5744,9 @@ const MlirDiagnosticHandler = Ptr{Cvoid}
 Prints a diagnostic using the provided callback.
 """
 function mlirDiagnosticPrint(diagnostic, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticPrint(
+        diagnostic::MlirDiagnostic, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -5091,7 +5755,9 @@ end
 Returns the location at which the diagnostic is reported.
 """
 function mlirDiagnosticGetLocation(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(diagnostic::MlirDiagnostic)::MlirLocation
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetLocation(
+        diagnostic::MlirDiagnostic
+    )::MlirLocation
 end
 
 """
@@ -5100,7 +5766,9 @@ end
 Returns the severity of the diagnostic.
 """
 function mlirDiagnosticGetSeverity(diagnostic)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(diagnostic::MlirDiagnostic)::MlirDiagnosticSeverity
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetSeverity(
+        diagnostic::MlirDiagnostic
+    )::MlirDiagnosticSeverity
 end
 
 """
@@ -5118,7 +5786,9 @@ end
 Returns `pos`-th note attached to the diagnostic. Expects `pos` to be a valid zero-based index into the list of notes.
 """
 function mlirDiagnosticGetNote(diagnostic, pos)
-    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(diagnostic::MlirDiagnostic, pos::intptr_t)::MlirDiagnostic
+    @ccall (MLIR_C_PATH[]).mlirDiagnosticGetNote(
+        diagnostic::MlirDiagnostic, pos::intptr_t
+    )::MlirDiagnostic
 end
 
 """
@@ -5127,7 +5797,12 @@ end
 Attaches the diagnostic handler to the context. Handlers are invoked in the reverse order of attachment until one of them processes the diagnostic completely. When a handler is invoked it is passed the `userData` that was provided when it was attached. If non-NULL, `deleteUserData` is called once the system no longer needs to call the handler (for instance after the handler is detached or the context is destroyed). Returns an identifier that can be used to detach the handler.
 """
 function mlirContextAttachDiagnosticHandler(context, handler, userData, deleteUserData)
-    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(context::MlirContext, handler::MlirDiagnosticHandler, userData::Ptr{Cvoid}, deleteUserData::Ptr{Cvoid})::MlirDiagnosticHandlerID
+    @ccall (MLIR_C_PATH[]).mlirContextAttachDiagnosticHandler(
+        context::MlirContext,
+        handler::MlirDiagnosticHandler,
+        userData::Ptr{Cvoid},
+        deleteUserData::Ptr{Cvoid},
+    )::MlirDiagnosticHandlerID
 end
 
 """
@@ -5136,7 +5811,9 @@ end
 Detaches an attached diagnostic handler from the context given its identifier.
 """
 function mlirContextDetachDiagnosticHandler(context, id)
-    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(context::MlirContext, id::MlirDiagnosticHandlerID)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirContextDetachDiagnosticHandler(
+        context::MlirContext, id::MlirDiagnosticHandlerID
+    )::Cvoid
 end
 
 """
@@ -5222,7 +5899,9 @@ end
 Sets the argument attribute 'name' of an argument at index 'pos'. Asserts that the operation is a FuncOp.
 """
 function mlirFuncSetArgAttr(op, pos, name, attr)
-    @ccall (MLIR_C_PATH[]).mlirFuncSetArgAttr(op::MlirOperation, pos::intptr_t, name::MlirStringRef, attr::MlirAttribute)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirFuncSetArgAttr(
+        op::MlirOperation, pos::intptr_t, name::MlirStringRef, attr::MlirAttribute
+    )::Cvoid
 end
 
 function mlirGetDialectHandle__gpu__()
@@ -5275,7 +5954,9 @@ end
 Creates an llvm.ptr type.
 """
 function mlirLLVMPointerTypeGet(pointee, addressSpace)
-    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(pointee::MlirType, addressSpace::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMPointerTypeGet(
+        pointee::MlirType, addressSpace::Cuint
+    )::MlirType
 end
 
 """
@@ -5293,7 +5974,9 @@ end
 Creates an llvm.array type.
 """
 function mlirLLVMArrayTypeGet(elementType, numElements)
-    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(elementType::MlirType, numElements::Cuint)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMArrayTypeGet(
+        elementType::MlirType, numElements::Cuint
+    )::MlirType
 end
 
 """
@@ -5302,7 +5985,12 @@ end
 Creates an llvm.func type.
 """
 function mlirLLVMFunctionTypeGet(resultType, nArgumentTypes, argumentTypes, isVarArg)
-    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(resultType::MlirType, nArgumentTypes::intptr_t, argumentTypes::Ptr{MlirType}, isVarArg::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMFunctionTypeGet(
+        resultType::MlirType,
+        nArgumentTypes::intptr_t,
+        argumentTypes::Ptr{MlirType},
+        isVarArg::Bool,
+    )::MlirType
 end
 
 """
@@ -5311,7 +5999,9 @@ end
 Creates an LLVM literal (unnamed) struct type.
 """
 function mlirLLVMStructTypeLiteralGet(ctx, nFieldTypes, fieldTypes, isPacked)
-    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirLLVMStructTypeLiteralGet(
+        ctx::MlirContext, nFieldTypes::intptr_t, fieldTypes::Ptr{MlirType}, isPacked::Bool
+    )::MlirType
 end
 
 """
@@ -5511,7 +6201,9 @@ end
 Returns the minimum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMinimumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -5520,7 +6212,9 @@ end
 Returns the maximum possible value stored by a quantized type.
 """
 function mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned, integralWidth)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(isSigned::Bool, integralWidth::Cuint)::Int64
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetDefaultMaximumForInteger(
+        isSigned::Bool, integralWidth::Cuint
+    )::Int64
 end
 
 """
@@ -5583,7 +6277,9 @@ end
 Returns the integral bitwidth that the storage type of the given quantized type can represent exactly.
 """
 function mlirQuantizedTypeGetStorageTypeIntegralWidth(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(type::MlirType)::Cuint
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetStorageTypeIntegralWidth(
+        type::MlirType
+    )::Cuint
 end
 
 """
@@ -5592,7 +6288,9 @@ end
 Returns `true` if the `candidate` type is compatible with the given quantized `type`.
 """
 function mlirQuantizedTypeIsCompatibleExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(type::MlirType, candidate::MlirType)::Bool
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeIsCompatibleExpressedType(
+        type::MlirType, candidate::MlirType
+    )::Bool
 end
 
 """
@@ -5601,7 +6299,9 @@ end
 Returns the element type of the given quantized type as another quantized type.
 """
 function mlirQuantizedTypeGetQuantizedElementType(type)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(type::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeGetQuantizedElementType(
+        type::MlirType
+    )::MlirType
 end
 
 """
@@ -5610,7 +6310,9 @@ end
 Casts from a type based on the storage type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -5628,7 +6330,9 @@ end
 Casts from a type based on the expressed type of the given type to a corresponding type based on the given type. Returns a null type if the cast is not valid.
 """
 function mlirQuantizedTypeCastFromExpressedType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastFromExpressedType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -5646,7 +6350,9 @@ end
 Casts from a type based on the expressed type of the given quantized type to equivalent type based on storage type of the same quantized type.
 """
 function mlirQuantizedTypeCastExpressedToStorageType(type, candidate)
-    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(type::MlirType, candidate::MlirType)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirQuantizedTypeCastExpressedToStorageType(
+        type::MlirType, candidate::MlirType
+    )::MlirType
 end
 
 """
@@ -5663,8 +6369,16 @@ end
 
 Creates an instance of AnyQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirAnyQuantizedTypeGet(flags, storageType, expressedType, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirAnyQuantizedTypeGet(
+    flags, storageType, expressedType, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirAnyQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -5681,8 +6395,18 @@ end
 
 Creates an instance of UniformQuantizedType with the given parameters in the same context as `storageType` and returns it. The instance is owned by the context.
 """
-function mlirUniformQuantizedTypeGet(flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, scale::Cdouble, zeroPoint::Int64, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedTypeGet(
+    flags, storageType, expressedType, scale, zeroPoint, storageTypeMin, storageTypeMax
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        scale::Cdouble,
+        zeroPoint::Int64,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -5726,8 +6450,28 @@ end
 
 Creates an instance of UniformQuantizedPerAxisType with the given parameters in the same context as `storageType` and returns it. `scales` and `zeroPoints` point to `nDims` number of elements. The instance is owned by the context.
 """
-function mlirUniformQuantizedPerAxisTypeGet(flags, storageType, expressedType, nDims, scales, zeroPoints, quantizedDimension, storageTypeMin, storageTypeMax)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(flags::Cuint, storageType::MlirType, expressedType::MlirType, nDims::intptr_t, scales::Ptr{Cdouble}, zeroPoints::Ptr{Int64}, quantizedDimension::Int32, storageTypeMin::Int64, storageTypeMax::Int64)::MlirType
+function mlirUniformQuantizedPerAxisTypeGet(
+    flags,
+    storageType,
+    expressedType,
+    nDims,
+    scales,
+    zeroPoints,
+    quantizedDimension,
+    storageTypeMin,
+    storageTypeMax,
+)
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGet(
+        flags::Cuint,
+        storageType::MlirType,
+        expressedType::MlirType,
+        nDims::intptr_t,
+        scales::Ptr{Cdouble},
+        zeroPoints::Ptr{Int64},
+        quantizedDimension::Int32,
+        storageTypeMin::Int64,
+        storageTypeMax::Int64,
+    )::MlirType
 end
 
 """
@@ -5736,7 +6480,9 @@ end
 Returns the number of axes in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetNumDims(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(type::MlirType)::intptr_t
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetNumDims(
+        type::MlirType
+    )::intptr_t
 end
 
 """
@@ -5745,7 +6491,9 @@ end
 Returns `pos`-th scale of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetScale(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(type::MlirType, pos::intptr_t)::Cdouble
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetScale(
+        type::MlirType, pos::intptr_t
+    )::Cdouble
 end
 
 """
@@ -5754,7 +6502,9 @@ end
 Returns `pos`-th zero point of the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetZeroPoint(type, pos)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(type::MlirType, pos::intptr_t)::Int64
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetZeroPoint(
+        type::MlirType, pos::intptr_t
+    )::Int64
 end
 
 """
@@ -5763,7 +6513,9 @@ end
 Returns the index of the quantized dimension in the given quantized per-axis type.
 """
 function mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type)
-    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(type::MlirType)::Int32
+    @ccall (MLIR_C_PATH[]).mlirUniformQuantizedPerAxisTypeGetQuantizedDimension(
+        type::MlirType
+    )::Int32
 end
 
 """
@@ -5790,7 +6542,9 @@ end
 Creates an instance of CalibratedQuantizedType with the given parameters in the same context as `expressedType` and returns it. The instance is owned by the context.
 """
 function mlirCalibratedQuantizedTypeGet(expressedType, min, max)
-    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(expressedType::MlirType, min::Cdouble, max::Cdouble)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirCalibratedQuantizedTypeGet(
+        expressedType::MlirType, min::Cdouble, max::Cdouble
+    )::MlirType
 end
 
 """
@@ -5853,7 +6607,9 @@ end
 Checks whether the given attribute is a `sparse\\_tensor.encoding` attribute.
 """
 function mlirAttributeIsASparseTensorEncodingAttr(attr)
-    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(attr::MlirAttribute)::Bool
+    @ccall (MLIR_C_PATH[]).mlirAttributeIsASparseTensorEncodingAttr(
+        attr::MlirAttribute
+    )::Bool
 end
 
 """
@@ -5861,8 +6617,17 @@ end
 
 Creates a `sparse\\_tensor.encoding` attribute with the given parameters.
 """
-function mlirSparseTensorEncodingAttrGet(ctx, lvlRank, lvlTypes, dimToLvl, posWidth, crdWidth)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(ctx::MlirContext, lvlRank::intptr_t, lvlTypes::Ptr{MlirSparseTensorDimLevelType}, dimToLvl::MlirAffineMap, posWidth::Cint, crdWidth::Cint)::MlirAttribute
+function mlirSparseTensorEncodingAttrGet(
+    ctx, lvlRank, lvlTypes, dimToLvl, posWidth, crdWidth
+)
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGet(
+        ctx::MlirContext,
+        lvlRank::intptr_t,
+        lvlTypes::Ptr{MlirSparseTensorDimLevelType},
+        dimToLvl::MlirAffineMap,
+        posWidth::Cint,
+        crdWidth::Cint,
+    )::MlirAttribute
 end
 
 """
@@ -5880,7 +6645,9 @@ end
 Returns a specified level-type of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetLvlType(attr, lvl)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetLvlType(attr::MlirAttribute, lvl::intptr_t)::MlirSparseTensorDimLevelType
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetLvlType(
+        attr::MlirAttribute, lvl::intptr_t
+    )::MlirSparseTensorDimLevelType
 end
 
 """
@@ -5889,7 +6656,9 @@ end
 Returns the dimension-to-level mapping of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetDimToLvl(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimToLvl(attr::MlirAttribute)::MlirAffineMap
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetDimToLvl(
+        attr::MlirAttribute
+    )::MlirAffineMap
 end
 
 """
@@ -5898,7 +6667,9 @@ end
 Returns the position bitwidth of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetPosWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPosWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetPosWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 """
@@ -5907,7 +6678,9 @@ end
 Returns the coordinate bitwidth of the `sparse\\_tensor.encoding` attribute.
 """
 function mlirSparseTensorEncodingAttrGetCrdWidth(attr)
-    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetCrdWidth(attr::MlirAttribute)::Cint
+    @ccall (MLIR_C_PATH[]).mlirSparseTensorEncodingAttrGetCrdWidth(
+        attr::MlirAttribute
+    )::Cint
 end
 
 function mlirRegisterSparseTensorPasses()
@@ -6011,11 +6784,15 @@ function mlirTransformOperationTypeGetTypeID()
 end
 
 function mlirTransformOperationTypeGet(ctx, operationName)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(ctx::MlirContext, operationName::MlirStringRef)::MlirType
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGet(
+        ctx::MlirContext, operationName::MlirStringRef
+    )::MlirType
 end
 
 function mlirTransformOperationTypeGetOperationName(type)
-    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(type::MlirType)::MlirStringRef
+    @ccall (MLIR_C_PATH[]).mlirTransformOperationTypeGetOperationName(
+        type::MlirType
+    )::MlirStringRef
 end
 
 function mlirGetDialectHandle__vector__()
@@ -6028,7 +6805,13 @@ end
 Creates an ExecutionEngine for the provided ModuleOp. The ModuleOp is expected to be "translatable" to LLVM IR (only contains operations in dialects that implement the `LLVMTranslationDialectInterface`). The module ownership stays with the client and can be destroyed as soon as the call returns. `optLevel` is the optimization level to be used for transformation and code generation. LLVM passes at `optLevel` are run before code generation. The number and array of paths corresponding to shared libraries that will be loaded are specified via `numPaths` and `sharedLibPaths` respectively. TODO: figure out other options.
 """
 function mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(op::MlirModule, optLevel::Cint, numPaths::Cint, sharedLibPaths::Ptr{MlirStringRef}, enableObjectDump::Bool)::MlirExecutionEngine
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineCreate(
+        op::MlirModule,
+        optLevel::Cint,
+        numPaths::Cint,
+        sharedLibPaths::Ptr{MlirStringRef},
+        enableObjectDump::Bool,
+    )::MlirExecutionEngine
 end
 
 """
@@ -6055,7 +6838,9 @@ end
 Invoke a native function in the execution engine by name with the arguments and result of the invoked function passed as an array of pointers. The function must have been tagged with the `llvm.emit\\_c\\_interface` attribute. Returns a failure if the execution fails for any reason (the function name can't be resolved for instance).
 """
 function mlirExecutionEngineInvokePacked(jit, name, arguments)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}})::MlirLogicalResult
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineInvokePacked(
+        jit::MlirExecutionEngine, name::MlirStringRef, arguments::Ptr{Ptr{Cvoid}}
+    )::MlirLogicalResult
 end
 
 """
@@ -6064,7 +6849,9 @@ end
 Lookup the wrapper of the native function in the execution engine with the given name, returns nullptr if the function can't be looked-up.
 """
 function mlirExecutionEngineLookupPacked(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookupPacked(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -6073,7 +6860,9 @@ end
 Lookup a native function in the execution engine by name, returns nullptr if the name can't be looked-up.
 """
 function mlirExecutionEngineLookup(jit, name)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(jit::MlirExecutionEngine, name::MlirStringRef)::Ptr{Cvoid}
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineLookup(
+        jit::MlirExecutionEngine, name::MlirStringRef
+    )::Ptr{Cvoid}
 end
 
 """
@@ -6082,7 +6871,9 @@ end
 Register a symbol with the jit: this symbol will be accessible to the jitted code.
 """
 function mlirExecutionEngineRegisterSymbol(jit, name, sym)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineRegisterSymbol(
+        jit::MlirExecutionEngine, name::MlirStringRef, sym::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -6091,7 +6882,9 @@ end
 Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
-    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(
+        jit::MlirExecutionEngine, fileName::MlirStringRef
+    )::Cvoid
 end
 
 """
@@ -6127,7 +6920,9 @@ end
 Prints an integer set by sending chunks of the string representation and forwarding `userData to `callback`. Note that the callback may be called several times with consecutive chunks of the string.
 """
 function mlirIntegerSetPrint(set, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid})::Cvoid
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetPrint(
+        set::MlirIntegerSet, callback::MlirStringCallback, userData::Ptr{Cvoid}
+    )::Cvoid
 end
 
 """
@@ -6145,7 +6940,9 @@ end
 Gets or creates a new canonically empty integer set with the give number of dimensions and symbols in the given context.
 """
 function mlirIntegerSetEmptyGet(context, numDims, numSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t)::MlirIntegerSet
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetEmptyGet(
+        context::MlirContext, numDims::intptr_t, numSymbols::intptr_t
+    )::MlirIntegerSet
 end
 
 """
@@ -6153,8 +6950,17 @@ end
 
 Gets or creates a new integer set in the given context. The set is defined by a list of affine constraints, with the given number of input dimensions and symbols, which are treated as either equalities (eqFlags is 1) or inequalities (eqFlags is 0). Both `constraints` and `eqFlags` are expected to point to at least `numConstraint` consecutive values.
 """
-function mlirIntegerSetGet(context, numDims, numSymbols, numConstraints, constraints, eqFlags)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(context::MlirContext, numDims::intptr_t, numSymbols::intptr_t, numConstraints::intptr_t, constraints::Ptr{MlirAffineExpr}, eqFlags::Ptr{Bool})::MlirIntegerSet
+function mlirIntegerSetGet(
+    context, numDims, numSymbols, numConstraints, constraints, eqFlags
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGet(
+        context::MlirContext,
+        numDims::intptr_t,
+        numSymbols::intptr_t,
+        numConstraints::intptr_t,
+        constraints::Ptr{MlirAffineExpr},
+        eqFlags::Ptr{Bool},
+    )::MlirIntegerSet
 end
 
 """
@@ -6162,8 +6968,16 @@ end
 
 Gets or creates a new integer set in which the values and dimensions of the given set are replaced with the given affine expressions. `dimReplacements` and `symbolReplacements` are expected to point to at least as many consecutive expressions as the given set has dimensions and symbols, respectively. The new set will have `numResultDims` and `numResultSymbols` dimensions and symbols, respectively.
 """
-function mlirIntegerSetReplaceGet(set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(set::MlirIntegerSet, dimReplacements::Ptr{MlirAffineExpr}, symbolReplacements::Ptr{MlirAffineExpr}, numResultDims::intptr_t, numResultSymbols::intptr_t)::MlirIntegerSet
+function mlirIntegerSetReplaceGet(
+    set, dimReplacements, symbolReplacements, numResultDims, numResultSymbols
+)
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetReplaceGet(
+        set::MlirIntegerSet,
+        dimReplacements::Ptr{MlirAffineExpr},
+        symbolReplacements::Ptr{MlirAffineExpr},
+        numResultDims::intptr_t,
+        numResultSymbols::intptr_t,
+    )::MlirIntegerSet
 end
 
 """
@@ -6235,7 +7049,9 @@ end
 Returns `pos`-th constraint of the set.
 """
 function mlirIntegerSetGetConstraint(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(set::MlirIntegerSet, pos::intptr_t)::MlirAffineExpr
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetGetConstraint(
+        set::MlirIntegerSet, pos::intptr_t
+    )::MlirAffineExpr
 end
 
 """
@@ -6244,7 +7060,9 @@ end
 Returns `true` of the `pos`-th constraint of the set is an equality constraint, `false` otherwise.
 """
 function mlirIntegerSetIsConstraintEq(set, pos)
-    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(set::MlirIntegerSet, pos::intptr_t)::Bool
+    @ccall (MLIR_C_PATH[]).mlirIntegerSetIsConstraintEq(
+        set::MlirIntegerSet, pos::intptr_t
+    )::Bool
 end
 
 """
@@ -6253,7 +7071,9 @@ end
 Returns `true` if the given operation implements an interface identified by its TypeID.
 """
 function mlirOperationImplementsInterface(operation, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(operation::MlirOperation, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterface(
+        operation::MlirOperation, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -6262,7 +7082,9 @@ end
 Returns `true` if the operation identified by its canonical string name implements the interface identified by its TypeID in the given context. Note that interfaces may be attached to operations in some contexts and not others.
 """
 function mlirOperationImplementsInterfaceStatic(operationName, context, interfaceTypeID)
-    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID)::Bool
+    @ccall (MLIR_C_PATH[]).mlirOperationImplementsInterfaceStatic(
+        operationName::MlirStringRef, context::MlirContext, interfaceTypeID::MlirTypeID
+    )::Bool
 end
 
 """
@@ -6285,8 +7107,32 @@ const MlirTypesCallback = Ptr{Cvoid}
 
 Infers the return types of the operation identified by its canonical given the arguments that will be supplied to its generic builder. Calls `callback` with the types of inferred arguments, potentially several times, on success. Returns failure otherwise.
 """
-function mlirInferTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, properties, nRegions, regions, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, properties::Ptr{Cvoid}, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirTypesCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+function mlirInferTypeOpInterfaceInferReturnTypes(
+    opName,
+    context,
+    location,
+    nOperands,
+    operands,
+    attributes,
+    properties,
+    nRegions,
+    regions,
+    callback,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirInferTypeOpInterfaceInferReturnTypes(
+        opName::MlirStringRef,
+        context::MlirContext,
+        location::MlirLocation,
+        nOperands::intptr_t,
+        operands::Ptr{MlirValue},
+        attributes::MlirAttribute,
+        properties::Ptr{Cvoid},
+        nRegions::intptr_t,
+        regions::Ptr{MlirRegion},
+        callback::MlirTypesCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -6309,8 +7155,32 @@ const MlirShapedTypeComponentsCallback = Ptr{Cvoid}
 
 Infers the return shaped type components of the operation. Calls `callback` with the types of inferred arguments on success. Returns failure otherwise.
 """
-function mlirInferShapedTypeOpInterfaceInferReturnTypes(opName, context, location, nOperands, operands, attributes, properties, nRegions, regions, callback, userData)
-    @ccall (MLIR_C_PATH[]).mlirInferShapedTypeOpInterfaceInferReturnTypes(opName::MlirStringRef, context::MlirContext, location::MlirLocation, nOperands::intptr_t, operands::Ptr{MlirValue}, attributes::MlirAttribute, properties::Ptr{Cvoid}, nRegions::intptr_t, regions::Ptr{MlirRegion}, callback::MlirShapedTypeComponentsCallback, userData::Ptr{Cvoid})::MlirLogicalResult
+function mlirInferShapedTypeOpInterfaceInferReturnTypes(
+    opName,
+    context,
+    location,
+    nOperands,
+    operands,
+    attributes,
+    properties,
+    nRegions,
+    regions,
+    callback,
+    userData,
+)
+    @ccall (MLIR_C_PATH[]).mlirInferShapedTypeOpInterfaceInferReturnTypes(
+        opName::MlirStringRef,
+        context::MlirContext,
+        location::MlirLocation,
+        nOperands::intptr_t,
+        operands::Ptr{MlirValue},
+        attributes::MlirAttribute,
+        properties::Ptr{Cvoid},
+        nRegions::intptr_t,
+        regions::Ptr{MlirRegion},
+        callback::MlirShapedTypeComponentsCallback,
+        userData::Ptr{Cvoid},
+    )::MlirLogicalResult
 end
 
 """
@@ -6479,4 +7349,3 @@ end
 function mlirRegisterTransformsViewOpGraph()
     @ccall (MLIR_C_PATH[]).mlirRegisterTransformsViewOpGraph()::Cvoid
 end
-

--- a/src/API/17/libMLIR_h.jl
+++ b/src/API/17/libMLIR_h.jl
@@ -2,39 +2,6 @@ using CEnum
 
 const intptr_t = Clong
 
-struct MlirDialectHandle
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirLlvmThreadPool
-
-Re-export llvm::ThreadPool so as to avoid including the LLVM C API directly.
-"""
-struct MlirLlvmThreadPool
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeID
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirTypeIDAllocator
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirStringRef
-
-| Field | Note                          |
-| :---- | :---------------------------- |
-| data  | Pointer to the first symbol.  |
-"""
-struct MlirStringRef
-    data::Cstring
-    length::Cint
-end
-
 function mlirStringRefCreate(str, length)
     @ccall (MLIR_C_PATH[]).mlirStringRefCreate(str::Cstring, length::Cint)::MlirStringRef
 end
@@ -64,15 +31,6 @@ A callback for returning string references.
 This function is called back by the functions that need to return a reference to the portion of the string with the following arguments: - an [`MlirStringRef`](@ref) representing the current portion of the string - a pointer to user data forwarded from the printing call.
 """
 const MlirStringCallback = Ptr{Cvoid}
-
-"""
-    MlirLogicalResult
-
-A logical result value, essentially a boolean with named states. LLVM convention for using boolean values to designate success or failure of an operation is a moving target, so MLIR opted for an explicit class. Instances of [`MlirLogicalResult`](@ref) must only be inspected using the associated functions.
-"""
-struct MlirLogicalResult
-    value::Int8
-end
 
 """
     mlirLogicalResultIsSuccess(res)
@@ -184,82 +142,6 @@ Allocates a type id that is valid for the lifetime of the allocator
 """
 function mlirTypeIDAllocatorAllocateTypeID(allocator)
     @ccall (MLIR_C_PATH[]).mlirTypeIDAllocatorAllocateTypeID(allocator::MlirTypeIDAllocator)::MlirTypeID
-end
-
-struct MlirBytecodeWriterConfig
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirContext
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialect
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirDialectRegistry
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOperation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpOperand
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPrintingFlags
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirBlock
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirRegion
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirSymbolTable
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirAttribute
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirIdentifier
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirLocation
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirModule
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirType
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirValue
-    ptr::Ptr{Cvoid}
-end
-
-"""
-    MlirNamedAttribute
-
-Named MLIR attribute.
-
-A named attribute is essentially a (name, attribute) pair where the name is a string.
-"""
-struct MlirNamedAttribute
-    name::MlirIdentifier
-    attribute::MlirAttribute
 end
 
 """
@@ -674,22 +556,6 @@ Views the generic operation as a module. The returned module is null when the in
 """
 function mlirModuleFromOperation(op)
     @ccall (MLIR_C_PATH[]).mlirModuleFromOperation(op::MlirOperation)::MlirModule
-end
-
-struct MlirOperationState
-    name::MlirStringRef
-    location::MlirLocation
-    nResults::intptr_t
-    results::Ptr{MlirType}
-    nOperands::intptr_t
-    operands::Ptr{MlirValue}
-    nRegions::intptr_t
-    regions::Ptr{MlirRegion}
-    nSuccessors::intptr_t
-    successors::Ptr{MlirBlock}
-    nAttributes::intptr_t
-    attributes::Ptr{MlirNamedAttribute}
-    enableResultTypeInference::Bool
 end
 
 """
@@ -1900,10 +1766,6 @@ function mlirSymbolTableWalkSymbolTables(from, allSymUsesVisible, callback, user
     @ccall (MLIR_C_PATH[]).mlirSymbolTableWalkSymbolTables(from::MlirOperation, allSymUsesVisible::Bool, callback::Ptr{Cvoid}, userData::Ptr{Cvoid})::Cvoid
 end
 
-struct MlirAffineExpr
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirAffineExprGetContext(affineExpr)
 
@@ -1992,10 +1854,6 @@ Checks whether the given affine expression involves AffineDimExpr 'position'.
 """
 function mlirAffineExprIsFunctionOfDim(affineExpr, position)
     @ccall (MLIR_C_PATH[]).mlirAffineExprIsFunctionOfDim(affineExpr::MlirAffineExpr, position::intptr_t)::Bool
-end
-
-struct MlirAffineMap
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -4540,22 +4398,6 @@ function mlirOpaqueTypeGetData(type)
     @ccall (MLIR_C_PATH[]).mlirOpaqueTypeGetData(type::MlirType)::MlirStringRef
 end
 
-struct MlirPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirExternalPass
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirPassManager
-    ptr::Ptr{Cvoid}
-end
-
-struct MlirOpPassManager
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirPassManagerCreate(ctx)
 
@@ -4689,27 +4531,6 @@ Parse a textual MLIR pass pipeline and assign it to the provided OpPassManager. 
 """
 function mlirParsePassPipeline(passManager, pipeline, callback, userData)
     @ccall (MLIR_C_PATH[]).mlirParsePassPipeline(passManager::MlirOpPassManager, pipeline::MlirStringRef, callback::MlirStringCallback, userData::Ptr{Cvoid})::MlirLogicalResult
-end
-
-"""
-    MlirExternalPassCallbacks
-
-Structure of external [`MlirPass`](@ref) callbacks. All callbacks are required to be set unless otherwise specified.
-
-| Field      | Note                                                                                                                                                                                              |
-| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| construct  | This callback is called from the pass is created. This is analogous to a C++ pass constructor.                                                                                                    |
-| destruct   | This callback is called when the pass is destroyed This is analogous to a C++ pass destructor.                                                                                                    |
-| initialize | This callback is optional. The callback is called before the pass is run, allowing a chance to initialize any complex state necessary for running the pass. See Pass::initialize(MLIRContext *).  |
-| clone      | This callback is called when the pass is cloned. See Pass::clonePass().                                                                                                                           |
-| run        | This callback is called when the pass is run. See Pass::runOnOperation().                                                                                                                         |
-"""
-struct MlirExternalPassCallbacks
-    construct::Ptr{Cvoid}
-    destruct::Ptr{Cvoid}
-    initialize::Ptr{Cvoid}
-    clone::Ptr{Cvoid}
-    run::Ptr{Cvoid}
 end
 
 """
@@ -5230,15 +5051,6 @@ Retuns `true` if the global debugging flag is set, false otherwise.
 """
 function mlirIsGlobalDebugEnabled()
     @ccall (MLIR_C_PATH[]).mlirIsGlobalDebugEnabled()::Bool
-end
-
-"""
-    MlirDiagnostic
-
-An opaque reference to a diagnostic, always owned by the diagnostics engine (context). Must not be stored outside of the diagnostic handler.
-"""
-struct MlirDiagnostic
-    ptr::Ptr{Cvoid}
 end
 
 """
@@ -6210,10 +6022,6 @@ function mlirGetDialectHandle__vector__()
     @ccall (MLIR_C_PATH[]).mlirGetDialectHandle__vector__()::MlirDialectHandle
 end
 
-struct MlirExecutionEngine
-    ptr::Ptr{Cvoid}
-end
-
 """
     mlirExecutionEngineCreate(op, optLevel, numPaths, sharedLibPaths, enableObjectDump)
 
@@ -6284,10 +6092,6 @@ Dump as an object in `fileName`.
 """
 function mlirExecutionEngineDumpToObjectFile(jit, fileName)
     @ccall (MLIR_C_PATH[]).mlirExecutionEngineDumpToObjectFile(jit::MlirExecutionEngine, fileName::MlirStringRef)::Cvoid
-end
-
-struct MlirIntegerSet
-    ptr::Ptr{Cvoid}
 end
 
 """

--- a/src/Dialects/14/AMX.jl
+++ b/src/Dialects/14/AMX.jl
@@ -3,7 +3,6 @@ module amx
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `tdpbf16ps`

--- a/src/Dialects/14/AMX.jl
+++ b/src/Dialects/14/AMX.jl
@@ -3,6 +3,7 @@ module amx
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `tdpbf16ps`

--- a/src/Dialects/14/AMX.jl
+++ b/src/Dialects/14/AMX.jl
@@ -1,39 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -41,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -105,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -230,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Affine.jl
+++ b/src/Dialects/14/Affine.jl
@@ -1,9 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -28,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,24 +148,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,28 +233,18 @@ func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -292,21 +271,17 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -322,22 +297,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -363,22 +334,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -447,40 +414,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,33 +447,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -556,20 +486,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -612,24 +538,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -674,24 +594,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,22 +623,18 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Affine.jl
+++ b/src/Dialects/14/Affine.jl
@@ -3,7 +3,6 @@ module affine
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `apply`

--- a/src/Dialects/14/Affine.jl
+++ b/src/Dialects/14/Affine.jl
@@ -3,6 +3,7 @@ module affine
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `apply`

--- a/src/Dialects/14/Arithmetic.jl
+++ b/src/Dialects/14/Arithmetic.jl
@@ -1,9 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `addf`
@@ -29,25 +28,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -72,25 +65,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -115,25 +102,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -156,21 +137,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,25 +166,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -228,25 +199,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -278,21 +243,17 @@ attribute by the parser.
 ```
 """
 function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -362,21 +323,17 @@ complement or large positives
 ```
 """
 function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -398,21 +355,17 @@ forms simple integer and floating point constants.
 ```
 """
 function constant(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -420,25 +373,19 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -464,25 +411,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -509,25 +450,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -539,21 +474,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,21 +509,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -616,21 +543,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -642,21 +565,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -668,21 +587,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,25 +617,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -733,21 +642,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -770,25 +675,19 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -796,25 +695,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -822,25 +715,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -863,25 +750,19 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -889,25 +770,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -915,25 +790,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -961,25 +830,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -987,25 +850,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1030,23 +887,19 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1071,25 +924,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1097,25 +944,19 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1141,25 +982,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1185,25 +1020,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1216,21 +1045,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1248,25 +1073,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1288,25 +1107,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1325,25 +1138,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1371,25 +1178,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1397,25 +1198,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1428,21 +1223,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1465,21 +1256,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1492,21 +1279,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1531,25 +1314,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/14/Arithmetic.jl
+++ b/src/Dialects/14/Arithmetic.jl
@@ -3,6 +3,7 @@ module arith
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `addf`

--- a/src/Dialects/14/Arithmetic.jl
+++ b/src/Dialects/14/Arithmetic.jl
@@ -3,7 +3,6 @@ module arith
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `addf`

--- a/src/Dialects/14/ArmNeon.jl
+++ b/src/Dialects/14/ArmNeon.jl
@@ -1,9 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_smull`
@@ -17,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -48,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/ArmNeon.jl
+++ b/src/Dialects/14/ArmNeon.jl
@@ -3,7 +3,6 @@ module arm_neon
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `intr_smull`

--- a/src/Dialects/14/ArmNeon.jl
+++ b/src/Dialects/14/ArmNeon.jl
@@ -3,6 +3,7 @@ module arm_neon
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `intr_smull`

--- a/src/Dialects/14/ArmSVE.jl
+++ b/src/Dialects/14/ArmSVE.jl
@@ -1,32 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -37,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -90,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -143,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -196,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -249,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -274,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -302,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -327,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -380,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -433,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -461,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -486,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -544,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/ArmSVE.jl
+++ b/src/Dialects/14/ArmSVE.jl
@@ -3,7 +3,6 @@ module arm_sve
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `intr_fadd`

--- a/src/Dialects/14/ArmSVE.jl
+++ b/src/Dialects/14/ArmSVE.jl
@@ -3,6 +3,7 @@ module arm_sve
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `intr_fadd`

--- a/src/Dialects/14/Async.jl
+++ b/src/Dialects/14/Async.jl
@@ -3,7 +3,6 @@ module async
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `add_to_group`

--- a/src/Dialects/14/Async.jl
+++ b/src/Dialects/14/Async.jl
@@ -1,9 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add_to_group`
@@ -20,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -123,23 +108,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -152,20 +133,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -177,20 +154,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,23 +172,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -224,25 +193,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -258,28 +221,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -300,25 +253,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -363,30 +310,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    operands::Vector{Value};
-    token::IR.Type,
-    results::Vector{IR.Type},
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[token, results...]
-    operands = Value[dependencies..., operands...]
-    owned_regions = Region[body,]
+function execute(dependencies::Vector{Value}, operands_::Vector{Value}; token::IR.Type, results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[token, results_..., ]
+    operands = Value[dependencies..., operands_..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(operands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(operands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -398,20 +334,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -421,25 +353,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -452,20 +378,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -477,20 +399,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -500,25 +418,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -529,21 +441,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,20 +463,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -580,25 +484,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -609,21 +507,17 @@ The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
 function runtime_load(storage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[storage,]
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -633,25 +527,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -663,20 +551,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -688,20 +572,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -713,20 +593,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -738,20 +614,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -761,22 +633,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Async.jl
+++ b/src/Dialects/14/Async.jl
@@ -3,6 +3,7 @@ module async
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `add_to_group`

--- a/src/Dialects/14/Bufferization.jl
+++ b/src/Dialects/14/Bufferization.jl
@@ -3,7 +3,6 @@ module bufferization
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `clone`

--- a/src/Dialects/14/Bufferization.jl
+++ b/src/Dialects/14/Bufferization.jl
@@ -3,6 +3,7 @@ module bufferization
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `clone`

--- a/src/Dialects/14/Bufferization.jl
+++ b/src/Dialects/14/Bufferization.jl
@@ -1,9 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `clone`
@@ -22,21 +21,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -58,21 +53,17 @@ unrealized_conversion_cast and is intended for use in the context of
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,21 +89,17 @@ If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
 function to_tensor(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Builtin.jl
+++ b/src/Dialects/14/Builtin.jl
@@ -1,9 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `func`
@@ -47,23 +46,16 @@ func @example_fn_attr() attributes {dialectName.attrName = false}
 function func(; sym_name, type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -86,27 +78,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, body::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -144,24 +129,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Builtin.jl
+++ b/src/Dialects/14/Builtin.jl
@@ -3,6 +3,7 @@ module builtin
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `func`

--- a/src/Dialects/14/Builtin.jl
+++ b/src/Dialects/14/Builtin.jl
@@ -3,7 +3,6 @@ module builtin
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `func`

--- a/src/Dialects/14/Complex.jl
+++ b/src/Dialects/14/Complex.jl
@@ -3,7 +3,6 @@ module complex
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `abs`

--- a/src/Dialects/14/Complex.jl
+++ b/src/Dialects/14/Complex.jl
@@ -1,9 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -17,21 +16,17 @@ The `abs` op takes a single complex number and computes its absolute value.
 ```
 """
 function abs(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[complex,]
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -46,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -81,21 +70,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,21 +97,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,25 +121,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -173,25 +148,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -208,23 +177,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -240,21 +205,17 @@ The `im` op takes a single complex number and extracts the imaginary part.
 ```
 """
 function im(complex::Value; imaginary::IR.Type, location=Location())
-    results = IR.Type[imaginary,]
-    operands = Value[complex,]
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -272,23 +233,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -305,23 +262,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -334,25 +287,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -367,23 +314,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -399,25 +342,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -433,21 +370,17 @@ The `re` op takes a single complex number and extracts the real part.
 ```
 """
 function re(complex::Value; real::IR.Type, location=Location())
-    results = IR.Type[real,]
-    operands = Value[complex,]
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,23 +396,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -494,25 +423,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/14/Complex.jl
+++ b/src/Dialects/14/Complex.jl
@@ -3,6 +3,7 @@ module complex
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `abs`

--- a/src/Dialects/14/EmitC.jl
+++ b/src/Dialects/14/EmitC.jl
@@ -3,6 +3,7 @@ module emitc
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `apply`

--- a/src/Dialects/14/EmitC.jl
+++ b/src/Dialects/14/EmitC.jl
@@ -3,7 +3,6 @@ module emitc
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `apply`

--- a/src/Dialects/14/EmitC.jl
+++ b/src/Dialects/14/EmitC.jl
@@ -1,9 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -24,21 +23,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,32 +56,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,21 +95,17 @@ attribute and the EmitC opaque type.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -157,19 +136,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/GPU.jl
+++ b/src/Dialects/14/GPU.jl
@@ -3,6 +3,7 @@ module gpu
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `all_reduce`

--- a/src/Dialects/14/GPU.jl
+++ b/src/Dialects/14/GPU.jl
@@ -3,7 +3,6 @@ module gpu
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `all_reduce`

--- a/src/Dialects/14/GPU.jl
+++ b/src/Dialects/14/GPU.jl
@@ -1,9 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `all_reduce`
@@ -30,30 +29,20 @@ accumulation as code region. The accumulation operation must be one of:
 Either none or all work items of a workgroup need to execute this op
 in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,36 +65,20 @@ that case, it also returns a !gpu.async.token.
 %memref, %token = gpu.alloc async [%dep] (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -134,16 +107,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,25 +128,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -193,25 +156,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -235,28 +192,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -322,19 +270,15 @@ attribution.
 function func(; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -367,19 +311,15 @@ or not intended to be run on the separate device.
 function module_(; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -395,25 +335,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -431,20 +365,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -529,59 +459,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    operands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; operands_::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        operands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(operands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(operands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -653,33 +545,19 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    body::Region,
-    location=Location(),
-)
+function launch(gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ]
-    owned_regions = Region[body,]
+    operands = Value[gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -701,29 +579,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -745,29 +613,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -782,16 +640,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -806,23 +660,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -837,20 +687,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -861,22 +707,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -901,32 +743,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; result=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(result) && push!(results, result)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -942,23 +772,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -984,29 +810,19 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1034,21 +850,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1072,24 +884,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, operation, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, operation, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operation", operation),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operation", operation), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1117,28 +923,18 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1164,24 +960,18 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location()
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1196,23 +986,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1229,16 +1015,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1254,25 +1036,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1309,27 +1085,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1347,20 +1115,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/LLVMIR.jl
+++ b/src/Dialects/14/LLVMIR.jl
@@ -1,33 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,17 +41,13 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.access_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.access_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -66,25 +55,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -93,21 +76,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,21 +120,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -172,18 +147,14 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope_domain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope_domain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -225,20 +196,14 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -247,22 +212,18 @@ end
 
 """
 function alloca(arraySize::Value; res::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -270,25 +231,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -298,20 +253,16 @@ end
 """
 function intr_assume(cond::Value; location=Location())
     results = IR.Type[]
-    operands = Value[cond,]
+    operands = Value[cond, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.assume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.assume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -319,33 +270,18 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res::IR.Type,
-    success_ordering,
-    failure_ordering,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -353,26 +289,18 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -380,25 +308,19 @@ end
 `intr_bitreverse`
 
 """
-function intr_bitreverse(
-    in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_bitreverse(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.bitreverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.bitreverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,21 +329,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -431,20 +349,16 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -478,31 +392,20 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operand_0...,]
+function call(operand_0::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, fastmathFlags=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -510,36 +413,20 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -574,21 +461,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -596,25 +479,19 @@ end
 `intr_copysign`
 
 """
-function intr_copysign(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_copysign(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -623,21 +500,17 @@ end
 
 """
 function intr_coro_align(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.align",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.align", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,21 +519,17 @@ end
 
 """
 function intr_coro_begin(token::Value, mem::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[token, mem]
+    results = IR.Type[res, ]
+    operands = Value[token, mem, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -669,21 +538,17 @@ end
 
 """
 function intr_coro_end(handle::Value, unwind::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[handle, unwind]
+    results = IR.Type[res, ]
+    operands = Value[handle, unwind, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -692,21 +557,17 @@ end
 
 """
 function intr_coro_free(id::Value, handle::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[id, handle]
+    results = IR.Type[res, ]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -714,29 +575,18 @@ end
 `intr_coro_id`
 
 """
-function intr_coro_id(
-    align::Value,
-    promise::Value,
-    coroaddr::Value,
-    fnaddrs::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[align, promise, coroaddr, fnaddrs]
+function intr_coro_id(align::Value, promise::Value, coroaddr::Value, fnaddrs::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[align, promise, coroaddr, fnaddrs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -746,20 +596,16 @@ end
 """
 function intr_coro_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,21 +614,17 @@ end
 
 """
 function intr_coro_save(handle::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[handle,]
+    results = IR.Type[res, ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -791,21 +633,17 @@ end
 
 """
 function intr_coro_size(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -814,21 +652,17 @@ end
 
 """
 function intr_coro_suspend(save::Value, final::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[save, final]
+    results = IR.Type[res, ]
+    operands = Value[save, final, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -836,23 +670,19 @@ end
 `intr_cos`
 
 """
-function intr_cos(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_cos(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -861,21 +691,17 @@ end
 
 """
 function intr_ctlz(in::Value, zero_undefined::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[in, zero_undefined]
+    results = IR.Type[res, ]
+    operands = Value[in, zero_undefined, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -884,21 +710,17 @@ end
 
 """
 function intr_cttz(in::Value, zero_undefined::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[in, zero_undefined]
+    results = IR.Type[res, ]
+    operands = Value[in, zero_undefined, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -906,23 +728,19 @@ end
 `intr_ctpop`
 
 """
-function intr_ctpop(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_ctpop(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -931,21 +749,17 @@ end
 
 """
 function intr_eh_typeid_for(type_info::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[type_info,]
+    results = IR.Type[res, ]
+    operands = Value[type_info, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.eh.typeid.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.eh.typeid.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -953,23 +767,19 @@ end
 `intr_exp2`
 
 """
-function intr_exp2(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_exp2(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -977,23 +787,19 @@ end
 `intr_exp`
 
 """
-function intr_exp(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_exp(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1002,21 +808,17 @@ end
 
 """
 function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[vector, position]
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1025,21 +827,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1047,23 +845,19 @@ end
 `intr_fabs`
 
 """
-function intr_fabs(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_fabs(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1071,31 +865,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1103,23 +886,19 @@ end
 `intr_ceil`
 
 """
-function intr_ceil(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_ceil(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1127,31 +906,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1159,31 +926,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1191,23 +947,19 @@ end
 `intr_floor`
 
 """
-function intr_floor(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_floor(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1215,25 +967,19 @@ end
 `intr_fma`
 
 """
-function intr_fma(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_fma(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1241,25 +987,19 @@ end
 `intr_fmuladd`
 
 """
-function intr_fmuladd(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_fmuladd(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.fmuladd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.fmuladd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1267,31 +1007,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1299,30 +1028,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1331,21 +1050,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1354,21 +1069,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1377,21 +1088,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1400,21 +1107,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1422,31 +1125,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1454,31 +1146,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1491,19 +1172,13 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
-    ]
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1511,23 +1186,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1535,24 +1206,18 @@ end
 `getelementptr`
 
 """
-function getelementptr(
-    base::Value, indices::Vector{Value}; res::IR.Type, structIndices, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+function getelementptr(base::Value, indices::Vector{Value}; res::IR.Type, structIndices, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("structIndices", structIndices),]
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("structIndices", structIndices), ]
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1561,21 +1226,17 @@ end
 
 """
 function intr_get_active_lane_mask(base::Value, n::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, n]
+    results = IR.Type[res, ]
+    operands = Value[base, n, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.get.active.lane.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.get.active.lane.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1606,19 +1267,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1646,19 +1301,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1759,47 +1408,25 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1808,21 +1435,17 @@ end
 
 """
 function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1836,42 +1459,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1879,24 +1483,18 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value, value::Value, position::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[vector, value, position]
+function insertelement(vector::Value, value::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1904,24 +1502,18 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value, value::Value; res::IR.Type, position, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[container, value]
+function insertvalue(container::Value, value::Value; res::IR.Type, position, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1930,21 +1522,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1952,38 +1540,20 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2016,33 +1586,22 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    linkage=nothing,
-    dso_local=nothing,
-    personality=nothing,
-    passthrough=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; linkage=nothing, dso_local=nothing, personality=nothing, passthrough=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2050,25 +1609,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2076,25 +1629,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2102,41 +1649,24 @@ end
 `load`
 
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2144,23 +1674,19 @@ end
 `intr_log10`
 
 """
-function intr_log10(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_log10(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2168,23 +1694,19 @@ end
 `intr_log2`
 
 """
-function intr_log2(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_log2(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2192,23 +1714,19 @@ end
 `intr_log`
 
 """
-function intr_log(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_log(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2216,29 +1734,18 @@ end
 `intr_masked_load`
 
 """
-function intr_masked_load(
-    data::Value,
-    mask::Value,
-    pass_thru::Vector{Value};
-    res::IR.Type,
-    alignment,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[data, mask, pass_thru...]
+function intr_masked_load(data::Value, mask::Value, pass_thru::Vector{Value}; res::IR.Type, alignment, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[data, mask, pass_thru..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2246,24 +1753,18 @@ end
 `intr_masked_store`
 
 """
-function intr_masked_store(
-    value::Value, data::Value, mask::Value; alignment, location=Location()
-)
+function intr_masked_store(value::Value, data::Value, mask::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[value, data, mask]
+    operands = Value[value, data, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2271,28 +1772,18 @@ end
 `intr_matrix_column_major_load`
 
 """
-function intr_matrix_column_major_load(
-    data::Value, stride::Value; res::IR.Type, isVolatile, rows, columns, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[data, stride]
+function intr_matrix_column_major_load(data::Value, stride::Value; res::IR.Type, isVolatile, rows, columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[data, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isVolatile", isVolatile),
-        namedattribute("rows", rows),
-        namedattribute("columns", columns),
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.column.major.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isVolatile", isVolatile), namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.column.major.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2300,34 +1791,18 @@ end
 `intr_matrix_column_major_store`
 
 """
-function intr_matrix_column_major_store(
-    matrix::Value,
-    data::Value,
-    stride::Value;
-    isVolatile,
-    rows,
-    columns,
-    location=Location(),
-)
+function intr_matrix_column_major_store(matrix::Value, data::Value, stride::Value; isVolatile, rows, columns, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, data, stride]
+    operands = Value[matrix, data, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isVolatile", isVolatile),
-        namedattribute("rows", rows),
-        namedattribute("columns", columns),
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.column.major.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isVolatile", isVolatile), namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.column.major.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2335,34 +1810,18 @@ end
 `intr_matrix_multiply`
 
 """
-function intr_matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function intr_matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2370,26 +1829,18 @@ end
 `intr_matrix_transpose`
 
 """
-function intr_matrix_transpose(
-    matrix::Value; res::IR.Type, rows, columns, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+function intr_matrix_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "llvm.intr.matrix.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "llvm.intr.matrix.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2397,25 +1848,19 @@ end
 `intr_maxnum`
 
 """
-function intr_maxnum(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_maxnum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.maxnum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.maxnum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2423,25 +1868,19 @@ end
 `intr_maximum`
 
 """
-function intr_maximum(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_maximum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2449,24 +1888,18 @@ end
 `intr_memcpy_inline`
 
 """
-function intr_memcpy_inline(
-    dst::Value, src::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memcpy_inline(dst::Value, src::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, src, len, isVolatile]
+    operands = Value[dst, src, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memcpy.inline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memcpy.inline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2474,24 +1907,18 @@ end
 `intr_memcpy`
 
 """
-function intr_memcpy(
-    dst::Value, src::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memcpy(dst::Value, src::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, src, len, isVolatile]
+    operands = Value[dst, src, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2499,24 +1926,18 @@ end
 `intr_memmove`
 
 """
-function intr_memmove(
-    dst::Value, src::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memmove(dst::Value, src::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, src, len, isVolatile]
+    operands = Value[dst, src, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memmove",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memmove", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2524,24 +1945,18 @@ end
 `intr_memset`
 
 """
-function intr_memset(
-    dst::Value, val::Value, len::Value, isVolatile::Value; location=Location()
-)
+function intr_memset(dst::Value, val::Value, len::Value, isVolatile::Value; location=Location())
     results = IR.Type[]
-    operands = Value[dst, val, len, isVolatile]
+    operands = Value[dst, val, len, isVolatile, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2560,19 +1975,15 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2580,25 +1991,19 @@ end
 `intr_minnum`
 
 """
-function intr_minnum(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_minnum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.minnum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.minnum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2606,25 +2011,19 @@ end
 `intr_minimum`
 
 """
-function intr_minimum(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_minimum(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2632,25 +2031,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2673,21 +2066,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2695,25 +2084,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2722,21 +2105,17 @@ end
 
 """
 function intr_powi(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.powi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.powi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2744,25 +2123,19 @@ end
 `intr_pow`
 
 """
-function intr_pow(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_pow(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2770,24 +2143,18 @@ end
 `intr_prefetch`
 
 """
-function intr_prefetch(
-    addr::Value, rw::Value, hint::Value, cache::Value; location=Location()
-)
+function intr_prefetch(addr::Value, rw::Value, hint::Value, cache::Value; location=Location())
     results = IR.Type[]
-    operands = Value[addr, rw, hint, cache]
+    operands = Value[addr, rw, hint, cache, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2796,21 +2163,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2820,20 +2183,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2843,20 +2202,16 @@ end
 """
 function return_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2864,24 +2219,18 @@ end
 `intr_sadd_with_overflow`
 
 """
-function intr_sadd_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_sadd_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.sadd.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.sadd.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2889,25 +2238,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2916,21 +2259,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2939,21 +2278,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2961,25 +2296,19 @@ end
 `intr_smax`
 
 """
-function intr_smax(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_smax(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.smax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2987,25 +2316,19 @@ end
 `intr_smin`
 
 """
-function intr_smin(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_smin(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.smin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.smin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3013,24 +2336,18 @@ end
 `intr_smul_with_overflow`
 
 """
-function intr_smul_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_smul_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.smul.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.smul.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3038,25 +2355,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3064,24 +2375,18 @@ end
 `intr_ssub_with_overflow`
 
 """
-function intr_ssub_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_ssub_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.ssub.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.ssub.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3089,29 +2394,19 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3119,25 +2414,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3146,21 +2435,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3168,23 +2453,19 @@ end
 `intr_sin`
 
 """
-function intr_sin(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_sin(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3192,23 +2473,19 @@ end
 `intr_sqrt`
 
 """
-function intr_sqrt(in::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function intr_sqrt(in::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[in,]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3218,20 +2495,16 @@ end
 """
 function intr_stackrestore(ptr::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr,]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.stackrestore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.stackrestore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3240,21 +2513,17 @@ end
 
 """
 function intr_stacksave(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.stacksave",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.stacksave", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3262,41 +2531,24 @@ end
 `store`
 
 """
-function store(
-    value::Value,
-    addr::Value;
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3304,25 +2556,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3330,40 +2576,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3372,21 +2599,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3394,24 +2617,18 @@ end
 `intr_uadd_with_overflow`
 
 """
-function intr_uadd_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_uadd_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.uadd.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.uadd.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3419,25 +2636,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3446,21 +2657,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3468,25 +2675,19 @@ end
 `intr_umax`
 
 """
-function intr_umax(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_umax(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.umax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.umax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3494,25 +2695,19 @@ end
 `intr_umin`
 
 """
-function intr_umin(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function intr_umin(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.intr.umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.umin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3520,24 +2715,18 @@ end
 `intr_umul_with_overflow`
 
 """
-function intr_umul_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_umul_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.umul.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.umul.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3545,25 +2734,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3571,24 +2754,18 @@ end
 `intr_usub_with_overflow`
 
 """
-function intr_usub_with_overflow(
-    operand_0::Value, operand_1::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_usub_with_overflow(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.usub.with.overflow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.usub.with.overflow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3608,21 +2785,17 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3636,16 +2809,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3653,25 +2822,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3680,21 +2843,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3702,24 +2861,18 @@ end
 `intr_masked_compressstore`
 
 """
-function intr_masked_compressstore(
-    operand_0::Value, operand_1::Value, operand_2::Value; location=Location()
-)
+function intr_masked_compressstore(operand_0::Value, operand_1::Value, operand_2::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.masked.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.masked.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3727,24 +2880,18 @@ end
 `intr_masked_expandload`
 
 """
-function intr_masked_expandload(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_masked_expandload(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.masked.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.masked.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3752,29 +2899,18 @@ end
 `intr_masked_gather`
 
 """
-function intr_masked_gather(
-    ptrs::Value,
-    mask::Value,
-    pass_thru::Vector{Value};
-    res::IR.Type,
-    alignment,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptrs, mask, pass_thru...]
+function intr_masked_gather(ptrs::Value, mask::Value, pass_thru::Vector{Value}; res::IR.Type, alignment, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptrs, mask, pass_thru..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3782,24 +2918,18 @@ end
 `intr_masked_scatter`
 
 """
-function intr_masked_scatter(
-    value::Value, ptrs::Value, mask::Value; alignment, location=Location()
-)
+function intr_masked_scatter(value::Value, ptrs::Value, mask::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[value, ptrs, mask]
+    operands = Value[value, ptrs, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "llvm.intr.masked.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "llvm.intr.masked.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3808,21 +2938,17 @@ end
 
 """
 function intr_vector_reduce_add(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3831,21 +2957,17 @@ end
 
 """
 function intr_vector_reduce_and(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3853,25 +2975,19 @@ end
 `intr_vector_reduce_fadd`
 
 """
-function intr_vector_reduce_fadd(
-    operand_0::Value, operand_1::Value; res::IR.Type, reassoc=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_vector_reduce_fadd(operand_0::Value, operand_1::Value; res::IR.Type, reassoc=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(reassoc) && push!(attributes, namedattribute("reassoc", reassoc))
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3880,21 +2996,17 @@ end
 
 """
 function intr_vector_reduce_fmax(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3903,21 +3015,17 @@ end
 
 """
 function intr_vector_reduce_fmin(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3925,25 +3033,19 @@ end
 `intr_vector_reduce_fmul`
 
 """
-function intr_vector_reduce_fmul(
-    operand_0::Value, operand_1::Value; res::IR.Type, reassoc=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+function intr_vector_reduce_fmul(operand_0::Value, operand_1::Value; res::IR.Type, reassoc=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(reassoc) && push!(attributes, namedattribute("reassoc", reassoc))
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3952,21 +3054,17 @@ end
 
 """
 function intr_vector_reduce_mul(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3975,21 +3073,17 @@ end
 
 """
 function intr_vector_reduce_or(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3998,21 +3092,17 @@ end
 
 """
 function intr_vector_reduce_smax(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.smax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4021,21 +3111,17 @@ end
 
 """
 function intr_vector_reduce_smin(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.smin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.smin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4044,21 +3130,17 @@ end
 
 """
 function intr_vector_reduce_umax(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.umax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.umax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4067,21 +3149,17 @@ end
 
 """
 function intr_vector_reduce_umin(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.umin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4090,21 +3168,17 @@ end
 
 """
 function intr_vector_reduce_xor(operand_0::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0,]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vector.reduce.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vector.reduce.xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4113,21 +3187,17 @@ end
 
 """
 function intr_vscale(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.intr.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.intr.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/LLVMIR.jl
+++ b/src/Dialects/14/LLVMIR.jl
@@ -3,7 +3,6 @@ module llvm
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `ashr`

--- a/src/Dialects/14/LLVMIR.jl
+++ b/src/Dialects/14/LLVMIR.jl
@@ -3,6 +3,7 @@ module llvm
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `ashr`

--- a/src/Dialects/14/Linalg.jl
+++ b/src/Dialects/14/Linalg.jl
@@ -1,9 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `index`
@@ -42,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -68,24 +63,18 @@ end
 `linalg.init_tensor` is an operation that materializes a tensor of
 a given shape. The shape could be dynamic or static.
 """
-function init_tensor(
-    sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[sizes...,]
+function init_tensor(sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sizes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes),]
-
-    return IR.create_operation(
-        "linalg.init_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes), ]
+    
+    IR.create_operation(
+        "linalg.init_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -158,45 +147,20 @@ linalg.tiled_loop (%i) = (%c0) to (%c24) step (%c4)
 }
 ```
 """
-function tiled_loop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    results::Vector{IR.Type},
-    iterator_types,
-    distribution_types=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., inputs..., outputs...]
-    owned_regions = Region[region,]
+function tiled_loop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, inputs::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, iterator_types, distribution_types=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("iterator_types", iterator_types),]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(inputs),
-            length(outputs),
-        ]),
-    )
-    !isnothing(distribution_types) &&
-        push!(attributes, namedattribute("distribution_types", distribution_types))
-
-    return IR.create_operation(
-        "linalg.tiled_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(inputs), length(outputs), ]))
+    !isnothing(distribution_types) && push!(attributes, namedattribute("distribution_types", distribution_types))
+    
+    IR.create_operation(
+        "linalg.tiled_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -215,27 +179,22 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `batch_matmul`
@@ -243,29 +202,19 @@ import ...API
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -275,29 +224,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -307,33 +246,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -343,29 +268,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -379,33 +294,19 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -419,33 +320,19 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -460,33 +347,19 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -496,29 +369,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -528,33 +391,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -564,29 +413,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -597,33 +436,19 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -634,33 +459,19 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -670,33 +481,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -706,33 +503,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -742,33 +525,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -778,29 +547,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -808,29 +567,19 @@ end
 `fill`
 
 """
-function fill(
-    value::Value,
-    output::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function fill(value::Value, output::Value; result=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value, output]
-    owned_regions = Region[region,]
+    operands = Value[value, output, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -845,29 +594,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -970,39 +709,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1012,29 +733,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1044,29 +755,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1076,29 +777,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1113,29 +804,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1145,33 +826,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1181,33 +848,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1217,33 +870,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1253,33 +892,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1289,33 +914,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1325,33 +936,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1361,33 +958,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1397,33 +980,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1433,33 +1002,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides,
-    dilations,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides, dilations, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("strides", strides), namedattribute("dilations", dilations)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("strides", strides), namedattribute("dilations", dilations), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1471,29 +1026,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1505,29 +1050,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1537,29 +1072,19 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function soft_plus_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function soft_plus_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.soft_plus_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.soft_plus_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1569,29 +1094,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Linalg.jl
+++ b/src/Dialects/14/Linalg.jl
@@ -3,7 +3,6 @@ module linalg
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `index`
@@ -235,7 +234,6 @@ end
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `batch_matmul`

--- a/src/Dialects/14/Linalg.jl
+++ b/src/Dialects/14/Linalg.jl
@@ -3,6 +3,7 @@ module linalg
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `index`
@@ -234,6 +235,7 @@ end
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `batch_matmul`

--- a/src/Dialects/14/Math.jl
+++ b/src/Dialects/14/Math.jl
@@ -3,6 +3,7 @@ module math
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `abs`

--- a/src/Dialects/14/Math.jl
+++ b/src/Dialects/14/Math.jl
@@ -3,7 +3,6 @@ module math
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `abs`

--- a/src/Dialects/14/Math.jl
+++ b/src/Dialects/14/Math.jl
@@ -1,9 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -25,23 +24,19 @@ a vector whose element type is float, or a tensor of floats.
 %x = math.abs %y : tensor<4x?xf8>
 ```
 """
-function abs(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -79,25 +74,19 @@ See also https://en.wikipedia.org/wiki/Atan2
 %x = math.atan2 %y, %z : tensor<4x?xf32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -128,23 +117,19 @@ floats.  It has no standard attributes.
 %x = math.atan %y : tensor<4x?xf8>
 ```
 """
-function atan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -175,23 +160,19 @@ It has no standard attributes.
 %x = math.ceil %y : tensor<4x?xf8>
 ```
 """
-function ceil(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -223,25 +204,19 @@ attributes.
 %x = math.copysign %y, %z : tensor<4x?xf8>
 ```
 """
-function copysign(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -272,23 +247,19 @@ It has no standard attributes.
 %x = math.cos %y : tensor<4x?xf8>
 ```
 """
-function cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -310,23 +281,19 @@ The `ctlz` operation computes the number of leading zeros of an integer value.
 %x = math.ctlz %y : tensor<4x?xi8>
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -348,23 +315,19 @@ The `cttz` operation computes the number of trailing zeros of an integer value.
 %x = math.cttz %y : tensor<4x?xi8>
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -386,23 +349,19 @@ The `ctpop` operation computes the number of set bits of an integer value.
 %x = math.ctpop %y : tensor<4x?xi8>
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -433,23 +392,19 @@ no standard attributes.
 %x = math.erf %y : tensor<4x?xf8>
 ```
 """
-function erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -479,23 +434,19 @@ float, or a tensor of floats. It has no standard attributes.
 %x = math.exp2 %y : tensor<4x?xf8>
 ```
 """
-function exp2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -527,23 +478,19 @@ float, or a tensor of floats. It has no standard attributes.
 %x = math.expm1 %y : tensor<4x?xf8>
 ```
 """
-function expm1(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -573,23 +520,19 @@ float, or a tensor of floats. It has no standard attributes.
 %x = math.exp %y : tensor<4x?xf8>
 ```
 """
-function exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -620,23 +563,19 @@ It has no standard attributes.
 %x = math.floor %y : tensor<4x?xf8>
 ```
 """
-function floor(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -672,29 +611,19 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -710,23 +639,19 @@ returns one result of the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -744,23 +669,19 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -776,23 +697,19 @@ returns one result of the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -808,23 +725,19 @@ returns one result of the same type.
 %y = math.log %x : f64
 ```
 """
-function log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -855,25 +768,19 @@ floating point tensor.
 %x = math.powf %y, %z : tensor<4x?xbf16>
 ```
 """
-function powf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -885,23 +792,19 @@ one operand and returns one result of the same type. This type may be a
 float scalar type, a vector whose element type is float, or a tensor of
 floats. It has no standard attributes.
 """
-function rsqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -932,23 +835,19 @@ It has no standard attributes.
 %x = math.sin %y : tensor<4x?xf8>
 ```
 """
-function sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -971,23 +870,19 @@ attributes.
 %x = math.sqrt %y : tensor<4x?xf32>
 ```
 """
-function sqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1018,23 +913,19 @@ no standard attributes.
 %x = math.tanh %y : tensor<4x?xf8>
 ```
 """
-function tanh(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/14/MemRef.jl
+++ b/src/Dialects/14/MemRef.jl
@@ -3,7 +3,6 @@ module memref
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `assume_alignment`

--- a/src/Dialects/14/MemRef.jl
+++ b/src/Dialects/14/MemRef.jl
@@ -3,6 +3,7 @@ module memref
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `assume_alignment`

--- a/src/Dialects/14/MemRef.jl
+++ b/src/Dialects/14/MemRef.jl
@@ -1,9 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assume_alignment`
@@ -17,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -51,29 +46,18 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value, memref, indices...]
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result::IR.Type, kind, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -85,20 +69,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,20 +98,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,28 +135,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -223,21 +189,17 @@ techniques. This is possible because of the
 in these contexts.
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -282,30 +244,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,30 +298,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,22 +349,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -438,22 +376,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -514,21 +448,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -567,21 +497,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -602,20 +528,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,21 +567,17 @@ The specified memref type is that of the first operand.
 ```
 """
 function dim(source::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, index]
+    results = IR.Type[result, ]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,22 +628,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -749,24 +663,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -805,21 +713,17 @@ smaller rank.
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -838,21 +742,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,38 +794,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -947,33 +831,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -990,21 +859,17 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 ```
 """
 function rank(memref::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[memref,]
+    results = IR.Type[result_0, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1028,40 +893,19 @@ memref.reinterpret_cast %unranked to
 : memref<*xf32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1101,21 +945,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1151,20 +991,16 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1182,21 +1018,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1238,28 +1070,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1398,40 +1220,19 @@ Example 5:
 ```
 }
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1452,20 +1253,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/OpenACC.jl
+++ b/src/Dialects/14/OpenACC.jl
@@ -3,7 +3,6 @@ module acc
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `data`

--- a/src/Dialects/14/OpenACC.jl
+++ b/src/Dialects/14/OpenACC.jl
@@ -3,6 +3,7 @@ module acc
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `data`

--- a/src/Dialects/14/OpenACC.jl
+++ b/src/Dialects/14/OpenACC.jl
@@ -1,9 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `data`
@@ -23,68 +22,21 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    deviceptrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        deviceptrOperands...,
-        attachOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (ifCond == nothing) ? 0 : 1length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(deviceptrOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -99,63 +51,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        copyinOperands...,
-        createOperands...,
-        createZeroOperands...,
-        attachOperands...,
-    ]
+    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyinOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -170,59 +83,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    deleteOperands::Vector{Value},
-    detachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
-    ]
+    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyoutOperands),
-            length(deleteOperands),
-            length(detachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -239,42 +118,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -298,68 +156,29 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    reductionOp=nothing,
-    exec_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) &&
-        push!(attributes, namedattribute("exec_mapping", exec_mapping))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,55 +197,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs=nothing::Union{Nothing,Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    devicePtrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionOp=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        devicePtrOperands...,
-        attachOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -435,53 +209,18 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (numGangs == nothing)
-                0
-            elseif 1(numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(devicePtrOperands),
-            length(attachOperands),
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -498,42 +237,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -551,16 +269,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,59 +292,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    hostOperands::Vector{Value},
-    deviceOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
-    ]
+    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(hostOperands),
-            length(deviceOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -647,48 +327,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -699,22 +354,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/OpenMP.jl
+++ b/src/Dialects/14/OpenMP.jl
@@ -3,7 +3,6 @@ module omp
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `atomic_capture`
@@ -714,17 +713,20 @@ function target(
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        elseif 1(thread_limit == nothing)
-            0
-        else
-            1
-        end,
-    ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            elseif 1(thread_limit == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
 
     return IR.create_operation(

--- a/src/Dialects/14/OpenMP.jl
+++ b/src/Dialects/14/OpenMP.jl
@@ -3,6 +3,7 @@ module omp
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `atomic_capture`
@@ -713,20 +714,17 @@ function target(
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            elseif 1(thread_limit == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([
+        if (if_expr == nothing)
+            0
+        elseif 1(device == nothing)
+            0
+        elseif 1(thread_limit == nothing)
+            0
+        else
+            1
+        end,
+    ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
 
     return IR.create_operation(

--- a/src/Dialects/14/OpenMP.jl
+++ b/src/Dialects/14/OpenMP.jl
@@ -1,9 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `atomic_capture`
@@ -38,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint=nothing, memory_order=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint=nothing, memory_order=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint) && push!(attributes, namedattribute("hint", hint))
-    !isnothing(memory_order) &&
-        push!(attributes, namedattribute("memory_order", memory_order))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order) && push!(attributes, namedattribute("memory_order", memory_order))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,27 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acq_rel`, `release`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value, v::Value; hint=nothing, memory_order=nothing, location=Location()
-)
+function atomic_read(x::Value, v::Value; hint=nothing, memory_order=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint) && push!(attributes, namedattribute("hint", hint))
-    !isnothing(memory_order) &&
-        push!(attributes, namedattribute("memory_order", memory_order))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order) && push!(attributes, namedattribute("memory_order", memory_order))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -125,35 +110,21 @@ time constant. As the name suggests, this is just a hint for optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acq_rel`, `release`, `acquire` or `relaxed`.
 """
-function atomic_update(
-    x::Value,
-    expr::Value;
-    isXBinopExpr=nothing,
-    binop,
-    hint=nothing,
-    memory_order=nothing,
-    location=Location(),
-)
+function atomic_update(x::Value, expr::Value; isXBinopExpr=nothing, binop, hint=nothing, memory_order=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, expr]
+    operands = Value[x, expr, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("binop", binop),]
-    !isnothing(isXBinopExpr) &&
-        push!(attributes, namedattribute("isXBinopExpr", isXBinopExpr))
+    attributes = NamedAttribute[namedattribute("binop", binop), ]
+    !isnothing(isXBinopExpr) && push!(attributes, namedattribute("isXBinopExpr", isXBinopExpr))
     !isnothing(hint) && push!(attributes, namedattribute("hint", hint))
-    !isnothing(memory_order) &&
-        push!(attributes, namedattribute("memory_order", memory_order))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order) && push!(attributes, namedattribute("memory_order", memory_order))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -174,27 +145,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acq_rel`, `release`, `acquire` or `relaxed`.
 """
-function atomic_write(
-    address::Value, value::Value; hint=nothing, memory_order=nothing, location=Location()
-)
+function atomic_write(address::Value, value::Value; hint=nothing, memory_order=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint) && push!(attributes, namedattribute("hint", hint))
-    !isnothing(memory_order) &&
-        push!(attributes, namedattribute("memory_order", memory_order))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order) && push!(attributes, namedattribute("memory_order", memory_order))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -210,16 +174,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,18 +195,14 @@ function critical_declare(; sym_name, hint=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint) && push!(attributes, namedattribute("hint", hint))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -259,20 +215,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -286,20 +238,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -312,19 +260,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,31 +290,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,20 +321,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -433,64 +362,23 @@ that specify the memory allocator to be used to obtain storage for private value
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    private_vars::Vector{Value},
-    firstprivate_vars::Vector{Value},
-    shared_vars::Vector{Value},
-    copyin_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    default_val=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, private_vars::Vector{Value}, firstprivate_vars::Vector{Value}, shared_vars::Vector{Value}, copyin_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, default_val=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        private_vars...,
-        firstprivate_vars...,
-        shared_vars...,
-        copyin_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[private_vars..., firstprivate_vars..., shared_vars..., copyin_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(private_vars)
-            end,
-            length(firstprivate_vars),
-            length(shared_vars),
-            length(copyin_vars),
-            length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(private_vars), length(firstprivate_vars), length(shared_vars), length(copyin_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(default_val) && push!(attributes, namedattribute("default_val", default_val))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -516,31 +404,18 @@ Note that the MLIR type system does not allow for type-polymorphic
 reductions. Separate reduction declarations should be created for different
 element and accumulator types.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,20 +429,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -581,19 +452,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -628,53 +495,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    private_vars::Vector{Value},
-    firstprivate_vars::Vector{Value},
-    lastprivate_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(private_vars::Vector{Value}, firstprivate_vars::Vector{Value}, lastprivate_vars::Vector{Value}, reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        private_vars...,
-        firstprivate_vars...,
-        lastprivate_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[private_vars..., firstprivate_vars..., lastprivate_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(private_vars),
-            length(firstprivate_vars),
-            length(lastprivate_vars),
-            length(reduction_vars),
-            length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(private_vars), length(firstprivate_vars), length(lastprivate_vars), length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -698,44 +533,23 @@ even if the target task is not yet completed.
 
 TODO:  private, map, is_device_ptr, firstprivate, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        elseif 1(thread_limit == nothing)
-            0
-        else
-            1
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -751,16 +565,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -776,16 +586,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -803,16 +609,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -876,83 +678,29 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    private_vars::Vector{Value},
-    firstprivate_vars::Vector{Value},
-    lastprivate_vars::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    collapse_val=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, private_vars::Vector{Value}, firstprivate_vars::Vector{Value}, lastprivate_vars::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, collapse_val=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        private_vars...,
-        firstprivate_vars...,
-        lastprivate_vars...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., private_vars..., firstprivate_vars..., lastprivate_vars..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(private_vars),
-            length(firstprivate_vars),
-            length(lastprivate_vars),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(private_vars), length(firstprivate_vars), length(lastprivate_vars), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
-    !isnothing(collapse_val) &&
-        push!(attributes, namedattribute("collapse_val", collapse_val))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(collapse_val) && push!(attributes, namedattribute("collapse_val", collapse_val))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -965,22 +713,18 @@ defined by the parent operation.
 If \"omp.yield\" has any operands, the operands must match the parent
 operation\'s results.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/PDL.jl
+++ b/src/Dialects/14/PDL.jl
@@ -3,7 +3,6 @@ module pdl
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `apply_native_constraint`

--- a/src/Dialects/14/PDL.jl
+++ b/src/Dialects/14/PDL.jl
@@ -1,9 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_native_constraint`
@@ -22,25 +21,19 @@ valued parameters.
 pdl.apply_native_constraint \"myConstraint\"[42, \"abc\", i32](%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation)
 ```
 """
-function apply_native_constraint(
-    args::Vector{Value}; name, constParams=nothing, location=Location()
-)
+function apply_native_constraint(args::Vector{Value}; name, constParams=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
+    attributes = NamedAttribute[namedattribute("name", name), ]
     !isnothing(constParams) && push!(attributes, namedattribute("constParams", constParams))
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -80,29 +73,19 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    name,
-    constParams=nothing,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, constParams=nothing, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
+    attributes = NamedAttribute[namedattribute("name", name), ]
     !isnothing(constParams) && push!(attributes, namedattribute("constParams", constParams))
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -131,26 +114,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute \"hello\"
 ```
 """
-function attribute(
-    type=nothing::Union{Nothing,Value}; attr::IR.Type, value=nothing, location=Location()
-)
-    results = IR.Type[attr,]
+function attribute(type=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,20 +146,16 @@ pdl.erase %root
 """
 function erase(operation::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -207,28 +180,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
-    results = IR.Type[val,]
+function operand(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
+    results = IR.Type[val, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -248,23 +217,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
-    results = IR.Type[val,]
+function operands_(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
+    results = IR.Type[val, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -365,35 +330,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operands::Vector{Value},
-    attributes::Vector{Value},
-    types::Vector{Value};
-    op::IR.Type,
-    name=nothing,
-    attributeNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operands..., attributes..., types...]
+function operation(operands_::Vector{Value}, attributes_::Vector{Value}, types::Vector{Value}; op::IR.Type, name=nothing, attributeNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operands_..., attributes_..., types..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([length(operands), length(attributes), length(types)]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames), ]
+    push!(attributes, operandsegmentsizes([length(operands), length(attributes), length(types), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -424,20 +374,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -466,32 +412,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    operation::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(operation::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[operation, replValues...]
+    operands = Value[operation, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -518,26 +452,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -565,23 +495,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -625,34 +551,22 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    externalConstParams=nothing,
-    body::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, externalConstParams=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[body,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    !isnothing(externalConstParams) &&
-        push!(attributes, namedattribute("externalConstParams", externalConstParams))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(externalConstParams) && push!(attributes, namedattribute("externalConstParams", externalConstParams))
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -675,22 +589,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, type=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(attributes, namedattribute("type", type))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -713,22 +623,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, types=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(types) && push!(attributes, namedattribute("types", types))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/PDL.jl
+++ b/src/Dialects/14/PDL.jl
@@ -3,6 +3,7 @@ module pdl
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `apply_native_constraint`

--- a/src/Dialects/14/PDLInterp.jl
+++ b/src/Dialects/14/PDLInterp.jl
@@ -1,9 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_constraint`
@@ -22,30 +21,19 @@ false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"[42, \"abc\", i32](%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value};
-    name,
-    constParams=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function apply_constraint(args::Vector{Value}; name, constParams=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
     !isnothing(constParams) && push!(attributes, namedattribute("constParams", constParams))
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,29 +64,19 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.valu
 pdl_interp.apply_rewrite \"rewriter\"[42](%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    name,
-    constParams=nothing,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, constParams=nothing, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
+    attributes = NamedAttribute[namedattribute("name", name), ]
     !isnothing(constParams) && push!(attributes, namedattribute("constParams", constParams))
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,24 +93,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,18 +125,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -181,24 +149,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,31 +183,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    operation::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(operation::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,24 +212,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    operation::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(operation::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -302,31 +246,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    operation::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(operation::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -343,24 +275,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,24 +303,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,16 +337,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -443,21 +359,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -476,36 +388,19 @@ this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> (%type : !pdl.type)
 ```
 """
-function create_operation(
-    operands::Vector{Value},
-    attributes::Vector{Value},
-    types::Vector{Value};
-    operation::IR.Type,
-    name,
-    attributeNames,
-    location=Location(),
-)
-    results = IR.Type[operation,]
-    operands = Value[operands..., attributes..., types...]
+function create_operation(operands_::Vector{Value}, attributes_::Vector{Value}, types::Vector{Value}; operation::IR.Type, name, attributeNames, location=Location())
+    results = IR.Type[operation, ]
+    operands = Value[operands_..., attributes_..., types..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name), namedattribute("attributeNames", attributeNames)
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([length(operands), length(attributes), length(types)]),
-    )
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("attributeNames", attributeNames), ]
+    push!(attributes, operandsegmentsizes([length(operands), length(attributes), length(types), ]))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,21 +417,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -553,21 +444,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -586,20 +473,16 @@ pdl_interp.erase %root
 """
 function erase(operation::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -617,21 +500,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -653,16 +532,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -687,20 +562,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -718,21 +589,17 @@ returned.
 ```
 """
 function get_attribute(operation::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[operation,]
+    results = IR.Type[attribute, ]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -749,21 +616,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -782,21 +645,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; operation::IR.Type, location=Location())
-    results = IR.Type[operation,]
-    operands = Value[value,]
+    results = IR.Type[operation, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -814,21 +673,17 @@ null value is returned.
 ```
 """
 function get_operand(operation::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[operation,]
+    results = IR.Type[value, ]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -856,22 +711,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(operation::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[operation,]
+    results = IR.Type[value, ]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -889,21 +740,17 @@ null value is returned.
 ```
 """
 function get_result(operation::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[operation,]
+    results = IR.Type[value, ]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -931,22 +778,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(operation::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[operation,]
+    results = IR.Type[value, ]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -968,21 +811,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1003,21 +842,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1035,21 +870,17 @@ that should be inferred. This signals to other operations, such as
 ```
 """
 function inferred_types(; type::IR.Type, location=Location())
-    results = IR.Type[type,]
+    results = IR.Type[type, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.inferred_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.inferred_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1069,20 +900,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1101,37 +928,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1152,20 +963,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(operation::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operation, replValues...]
+    operands = Value[operation, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1183,28 +990,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1222,28 +1019,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    operation::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(operation::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1261,28 +1048,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    operation::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(operation::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1300,28 +1077,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    operation::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(operation::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1339,24 +1106,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1374,24 +1135,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/PDLInterp.jl
+++ b/src/Dialects/14/PDLInterp.jl
@@ -3,6 +3,7 @@ module pdl_interp
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `apply_constraint`

--- a/src/Dialects/14/PDLInterp.jl
+++ b/src/Dialects/14/PDLInterp.jl
@@ -3,7 +3,6 @@ module pdl_interp
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `apply_constraint`

--- a/src/Dialects/14/Quant.jl
+++ b/src/Dialects/14/Quant.jl
@@ -3,7 +3,6 @@ module quant
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `const_fake_quant`

--- a/src/Dialects/14/Quant.jl
+++ b/src/Dialects/14/Quant.jl
@@ -1,9 +1,8 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `const_fake_quant`
@@ -13,39 +12,21 @@ same uniform quantization simulation as is done by the TensorFlow
 fake_quant_with_min_max_args op. See the fakeQuantAttrsToType() utility
 method and the quant-convert-simulated-quantization pass for further details.
 """
-function const_fake_quant(
-    inputs::Value;
-    outputs=nothing::Union{Nothing,IR.Type},
-    min,
-    max,
-    num_bits,
-    narrow_range=nothing,
-    is_signed=nothing,
-    location=Location(),
-)
+function const_fake_quant(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[inputs,]
+    operands = Value[inputs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min", min),
-        namedattribute("max", max),
-        namedattribute("num_bits", num_bits),
-    ]
+    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("num_bits", num_bits), ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) &&
-        push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-
-    return IR.create_operation(
-        "quant.const_fake_quant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.const_fake_quant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -58,41 +39,21 @@ fake_quant_with_min_max_vars_per_channel op. See the fakeQuantAttrsToType()
 utility method and the quant-convert-simulated-quantization pass for further
 details.
 """
-function const_fake_quant_per_axis(
-    inputs::Value;
-    outputs=nothing::Union{Nothing,IR.Type},
-    min,
-    max,
-    axis,
-    num_bits,
-    narrow_range=nothing,
-    is_signed=nothing,
-    location=Location(),
-)
+function const_fake_quant_per_axis(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, axis, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[inputs,]
+    operands = Value[inputs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min", min),
-        namedattribute("max", max),
-        namedattribute("axis", axis),
-        namedattribute("num_bits", num_bits),
-    ]
+    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("axis", axis), namedattribute("num_bits", num_bits), ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) &&
-        push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-
-    return IR.create_operation(
-        "quant.const_fake_quant_per_axis",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.const_fake_quant_per_axis", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -106,25 +67,19 @@ external connections. In such a case, during analysis, all coupled_ref
 nodes in a module which share a coupledKey will be considered to be
 directly connected as via an identity op for the purpose of type inference.
 """
-function coupled_ref(
-    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, coupledKey, location=Location()
-)
+function coupled_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, coupledKey, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey),]
+    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "quant.coupled_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.coupled_ref", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -133,21 +88,17 @@ end
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -156,21 +107,17 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -178,34 +125,18 @@ end
 `region`
 
 """
-function region(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    input_specs,
-    output_specs,
-    logical_kernel,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[body,]
+function region(inputs::Vector{Value}; outputs::Vector{IR.Type}, input_specs, output_specs, logical_kernel, body::Region, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_specs", input_specs),
-        namedattribute("output_specs", output_specs),
-        namedattribute("logical_kernel", logical_kernel),
-    ]
-
-    return IR.create_operation(
-        "quant.region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_specs", input_specs), namedattribute("output_specs", output_specs), namedattribute("logical_kernel", logical_kernel), ]
+    
+    IR.create_operation(
+        "quant.region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -213,22 +144,18 @@ end
 `return_`
 
 """
-function return_(results::Vector{Value}; location=Location())
+function return_(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -252,32 +179,21 @@ Currently, only dim=2 is supported, which is interpreted as [min, max].
 <?x?x3x2>, axis=2 => N=6
 ```
 """
-function stats(
-    arg::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    layerStats,
-    axisStats=nothing,
-    axis=nothing,
-    location=Location(),
-)
+function stats(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, layerStats, axisStats=nothing, axis=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layerStats", layerStats),]
+    attributes = NamedAttribute[namedattribute("layerStats", layerStats), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(axisStats) && push!(attributes, namedattribute("axisStats", axisStats))
     !isnothing(axis) && push!(attributes, namedattribute("axis", axis))
-
-    return IR.create_operation(
-        "quant.stats",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.stats", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -290,25 +206,19 @@ Such statistics will be stored with the provided key, allowing this node
 to later be converted to a \'stats\' op if statistics with that key have been
 encountered.
 """
-function stats_ref(
-    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, statsKey, location=Location()
-)
+function stats_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, statsKey, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("statsKey", statsKey),]
+    attributes = NamedAttribute[namedattribute("statsKey", statsKey), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "quant.stats_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.stats_ref", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -317,21 +227,17 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Quant.jl
+++ b/src/Dialects/14/Quant.jl
@@ -3,6 +3,7 @@ module quant
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `const_fake_quant`

--- a/src/Dialects/14/SCF.jl
+++ b/src/Dialects/14/SCF.jl
@@ -1,9 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `condition`
@@ -15,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -74,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -181,30 +172,18 @@ func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -254,28 +233,18 @@ scf.if %b  {
 }
 ```
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,36 +294,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -396,20 +348,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,20 +374,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -557,28 +501,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -595,22 +529,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/SCF.jl
+++ b/src/Dialects/14/SCF.jl
@@ -3,7 +3,6 @@ module scf
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `condition`

--- a/src/Dialects/14/SCF.jl
+++ b/src/Dialects/14/SCF.jl
@@ -3,6 +3,7 @@ module scf
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `condition`

--- a/src/Dialects/14/SPIRV.jl
+++ b/src/Dialects/14/SPIRV.jl
@@ -3,7 +3,6 @@ module spv
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `AccessChain`

--- a/src/Dialects/14/SPIRV.jl
+++ b/src/Dialects/14/SPIRV.jl
@@ -1,9 +1,8 @@
 module spv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `AccessChain`
@@ -47,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spv.AccessChain` ssa-use
 %3 = spv.Load \"Function\" %2 [\"Volatile\"] : !spv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -93,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,31 +137,18 @@ atomic-and-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,35 +198,18 @@ atomic-compare-exchange-op ::=
                                 : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -278,35 +237,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -343,31 +285,18 @@ atomic-exchange-op ::=
                         : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,31 +338,18 @@ atomic-fadd-op ::=
                        !spv.ptr<f32, StorageBuffer>
 ```mlir
 """
-function AtomicFAddEXT(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicFAddEXT(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicFAddEXT",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicFAddEXT", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,31 +386,18 @@ atomic-iadd-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -530,26 +433,18 @@ atomic-idecrement-op ::=
                           !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -584,26 +479,18 @@ atomic-iincrement-op ::=
                          !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,31 +528,18 @@ atomic-isub-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,31 +576,18 @@ atomic-or-op ::=
                   !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -764,31 +625,18 @@ atomic-smax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -826,31 +674,18 @@ atomic-smin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -888,31 +723,18 @@ atomic-umax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -950,31 +772,18 @@ atomic-umin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1012,31 +821,18 @@ atomic-xor-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1072,25 +868,19 @@ Results are computed per component.
     %3 = spv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1136,30 +926,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1205,29 +984,19 @@ The type of Base must be the same as Result Type.
     %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1255,29 +1024,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
 %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1309,25 +1068,19 @@ The type of Base must be the same as Result Type.
     %3 = spv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1371,21 +1124,17 @@ bitcast-op ::= ssa-id `=` `spv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1415,28 +1164,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1466,28 +1206,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1517,28 +1248,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1576,36 +1298,20 @@ spv.BranchConditional %condition, ^true_branch, ^false_branch
 spv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1631,20 +1337,16 @@ spv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1682,24 +1384,18 @@ composite-construct-op ::= ssa-id `=` `spv.CompositeConstruct`
 %0 = spv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1732,24 +1428,18 @@ composite-extract-op ::= ssa-id `=` `spv.CompositeExtract` ssa-use
 %2 = spv.CompositeExtract %1[1 : i32] : !spv.array<4x!spv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1782,24 +1472,18 @@ composite-insert-op ::= ssa-id `=` `spv.CompositeInsert` ssa-use, ssa-use
 %0 = spv.CompositeInsert %object, %composite[1 : i32] : f32 into !spv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1839,21 +1523,17 @@ spv.Constant-op ::= ssa-id `=` `spv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1903,28 +1583,18 @@ spv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1953,21 +1623,17 @@ convert-f-to-s-op ::= ssa-id `=` `spv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1997,21 +1663,17 @@ convert-f-to-u-op ::= ssa-id `=` `spv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2040,21 +1702,17 @@ convert-s-to-f-op ::= ssa-id `=` `spv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2083,21 +1741,17 @@ convert-u-to-f-op ::= ssa-id `=` `spv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2122,25 +1776,19 @@ For example:
 %0 = spv.CooperativeMatrixLengthNV : !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixLengthNV(;
-    result=nothing::Union{Nothing,IR.Type}, type, location=Location()
-)
+function CooperativeMatrixLengthNV(; result=nothing::Union{Nothing, IR.Type}, type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type),]
+    attributes = NamedAttribute[namedattribute("type", type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixLengthNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixLengthNV", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2197,31 +1845,19 @@ For example:
      : !spv.ptr<i32, StorageBuffer> as !spv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function CooperativeMatrixLoadNV(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function CooperativeMatrixLoadNV(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixLoadNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixLoadNV", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2272,29 +1908,19 @@ For example:
   !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixMulAddNV(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CooperativeMatrixMulAddNV(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixMulAddNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixMulAddNV", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2337,31 +1963,19 @@ For example:
     !spv.ptr<i32, StorageBuffer>, !spv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function CooperativeMatrixStoreNV(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function CooperativeMatrixStoreNV(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixStoreNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixStoreNV", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2394,37 +2008,22 @@ copy-memory-op ::= `spv.CopyMemory ` storage-class ssa-use
 spv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2474,21 +2073,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2526,21 +2117,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2568,28 +2151,19 @@ fadd-op ::= ssa-id `=` `spv.FAdd` ssa-use, ssa-use
 %5 = spv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2619,21 +2193,17 @@ f-convert-op ::= ssa-id `=` `spv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2663,28 +2233,19 @@ fdiv-op ::= ssa-id `=` `spv.FDiv` ssa-use, ssa-use
 %5 = spv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2715,28 +2276,19 @@ fmod-op ::= ssa-id `=` `spv.FMod` ssa-use, ssa-use
 %5 = spv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2766,28 +2318,19 @@ fmul-op ::= `spv.FMul` ssa-use, ssa-use
 %5 = spv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2815,25 +2358,19 @@ fmul-op ::= `spv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2864,21 +2401,17 @@ fordequal-op ::= ssa-id `=` `spv.FOrdEqual` ssa-use, ssa-use
 ```
 """
 function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2908,24 +2441,18 @@ fordgte-op ::= ssa-id `=` `spv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2955,24 +2482,18 @@ fordgt-op ::= ssa-id `=` `spv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3002,24 +2523,18 @@ fordlte-op ::= ssa-id `=` `spv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3049,24 +2564,18 @@ fordlt-op ::= ssa-id `=` `spv.FOrdLessThan` ssa-use, ssa-use
 %5 = spv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3096,24 +2605,18 @@ fordneq-op ::= ssa-id `=` `spv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3145,28 +2648,19 @@ frem-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3195,28 +2689,19 @@ fsub-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3247,21 +2732,17 @@ funordequal-op ::= ssa-id `=` `spv.FUnordEqual` ssa-use, ssa-use
 ```
 """
 function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3291,24 +2772,18 @@ funordgte-op ::= ssa-id `=` `spv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3338,24 +2813,18 @@ funordgt-op ::= ssa-id `=` `spv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3385,24 +2854,18 @@ funordlte-op ::= ssa-id `=` `spv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3432,24 +2895,18 @@ funordlt-op ::= ssa-id `=` `spv.FUnordLessThan` ssa-use, ssa-use
 %5 = spv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3479,24 +2936,18 @@ funordneq-op ::= ssa-id `=` `spv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3532,23 +2983,15 @@ spv.func @bar() -> () \"Inline|Pure\" { ... }
 function func(; type, sym_name, function_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
-
-    return IR.create_operation(
-        "spv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
+    
+    IR.create_operation(
+        "spv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3582,28 +3025,19 @@ spv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3637,21 +3071,17 @@ acos-op ::= ssa-id `=` `spv.GLSL.Acos` ssa-use `:`
 ```
 """
 function GLSL_Acos(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3685,21 +3115,17 @@ asin-op ::= ssa-id `=` `spv.GLSL.Asin` ssa-use `:`
 ```
 """
 function GLSL_Asin(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3733,21 +3159,17 @@ atan-op ::= ssa-id `=` `spv.GLSL.Atan` ssa-use `:`
 ```
 """
 function GLSL_Atan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3778,21 +3200,17 @@ ceil-op ::= ssa-id `=` `spv.GLSL.Ceil` ssa-use `:`
 ```
 """
 function GLSL_Ceil(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3824,21 +3242,17 @@ cos-op ::= ssa-id `=` `spv.GLSL.Cos` ssa-use `:`
 ```
 """
 function GLSL_Cos(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3870,21 +3284,17 @@ cosh-op ::= ssa-id `=` `spv.GLSL.Cosh` ssa-use `:`
 ```
 """
 function GLSL_Cosh(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3916,21 +3326,17 @@ exp-op ::= ssa-id `=` `spv.GLSL.Exp` ssa-use `:`
 ```
 """
 function GLSL_Exp(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3960,21 +3366,17 @@ abs-op ::= ssa-id `=` `spv.GLSL.FAbs` ssa-use `:`
 ```
 """
 function GLSL_FAbs(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4004,21 +3406,17 @@ fclamp-op ::= ssa-id `=` `spv.GLSL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GLSL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4049,21 +3447,17 @@ fmax-op ::= ssa-id `=` `spv.GLSL.FMax` ssa-use `:`
 ```
 """
 function GLSL_FMax(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4094,21 +3488,17 @@ fmin-op ::= ssa-id `=` `spv.GLSL.FMin` ssa-use `:`
 ```
 """
 function GLSL_FMin(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4130,29 +3520,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spv.GLSL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GLSL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GLSL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GLSL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4182,21 +3562,17 @@ sign-op ::= ssa-id `=` `spv.GLSL.FSign` ssa-use `:`
 ```
 """
 function GLSL_FSign(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4227,21 +3603,17 @@ floor-op ::= ssa-id `=` `spv.GLSL.Floor` ssa-use `:`
 ```
 """
 function GLSL_Floor(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4281,21 +3653,17 @@ fma-op ::= ssa-id `=` `spv.GLSL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GLSL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4338,21 +3706,17 @@ frexpstruct-op ::= ssa-id `=` `spv.GLSL.FrexpStruct` ssa-use `:`
 ```
 """
 function GLSL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4382,21 +3746,17 @@ rsqrt-op ::= ssa-id `=` `spv.GLSL.InverseSqrt` ssa-use `:`
 ```
 """
 function GLSL_InverseSqrt(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4434,25 +3794,19 @@ component.
 %y = spv.GLSL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GLSL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GLSL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spv.GLSL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4485,21 +3839,17 @@ log-op ::= ssa-id `=` `spv.GLSL.Log` ssa-use `:`
 ```
 """
 function GLSL_Log(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4533,21 +3883,17 @@ pow-op ::= ssa-id `=` `spv.GLSL.Pow` ssa-use `:`
 ```
 """
 function GLSL_Pow(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4577,21 +3923,17 @@ floor-op ::= ssa-id `=` `spv.GLSL.Round` ssa-use `:`
 ```
 """
 function GLSL_Round(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4620,21 +3962,17 @@ abs-op ::= ssa-id `=` `spv.GLSL.SAbs` ssa-use `:`
 ```
 """
 function GLSL_SAbs(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4663,21 +4001,17 @@ uclamp-op ::= ssa-id `=` `spv.GLSL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GLSL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4707,21 +4041,17 @@ smax-op ::= ssa-id `=` `spv.GLSL.SMax` ssa-use `:`
 ```
 """
 function GLSL_SMax(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4751,21 +4081,17 @@ smin-op ::= ssa-id `=` `spv.GLSL.SMin` ssa-use `:`
 ```
 """
 function GLSL_SMin(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4794,21 +4120,17 @@ sign-op ::= ssa-id `=` `spv.GLSL.SSign` ssa-use `:`
 ```
 """
 function GLSL_SSign(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4840,21 +4162,17 @@ sin-op ::= ssa-id `=` `spv.GLSL.Sin` ssa-use `:`
 ```
 """
 function GLSL_Sin(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4886,21 +4204,17 @@ sinh-op ::= ssa-id `=` `spv.GLSL.Sinh` ssa-use `:`
 ```
 """
 function GLSL_Sinh(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4930,21 +4244,17 @@ sqrt-op ::= ssa-id `=` `spv.GLSL.Sqrt` ssa-use `:`
 ```
 """
 function GLSL_Sqrt(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4976,21 +4286,17 @@ tan-op ::= ssa-id `=` `spv.GLSL.Tan` ssa-use `:`
 ```
 """
 function GLSL_Tan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5022,21 +4328,17 @@ tanh-op ::= ssa-id `=` `spv.GLSL.Tanh` ssa-use `:`
 ```
 """
 function GLSL_Tanh(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5065,21 +4367,17 @@ uclamp-op ::= ssa-id `=` `spv.GLSL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GLSL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5109,21 +4407,17 @@ smax-op ::= ssa-id `=` `spv.GLSL.UMax` ssa-use `:`
 ```
 """
 function GLSL_UMax(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5153,21 +4447,17 @@ smin-op ::= ssa-id `=` `spv.GLSL.UMin` ssa-use `:`
 ```
 """
 function GLSL_UMin(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GLSL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GLSL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5211,39 +4501,23 @@ spv.GlobalVariable @var2 bind(1, 2) : !spv.ptr<f32, Uniform>
 spv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptorSet=nothing,
-    builtin=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptorSet=nothing, builtin=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptorSet) &&
-        push!(attributes, namedattribute("descriptorSet", descriptorSet))
+    !isnothing(descriptorSet) && push!(attributes, namedattribute("descriptorSet", descriptorSet))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-
-    return IR.create_operation(
-        "spv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5292,29 +4566,19 @@ group-broadcast-op ::= ssa-id `=` `spv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5347,24 +4611,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spv.GroupNonUniformBallot` scope
 %0 = spv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5409,29 +4667,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5456,25 +4704,19 @@ non-uniform-elect-op ::= ssa-id `=` `spv.GroupNonUniformElect` scope
 %0 = spv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5520,33 +4762,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spv.GroupNonUniformFAdd` scope operation
 %1 = spv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5595,33 +4823,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spv.GroupNonUniformFMax` scope operation
 %1 = spv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5670,33 +4884,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spv.GroupNonUniformFMin` scope operation
 %1 = spv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5742,33 +4942,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spv.GroupNonUniformFMul` scope operation
 %1 = spv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5812,33 +4998,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spv.GroupNonUniformIAdd` scope operation
 %1 = spv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5882,33 +5054,19 @@ non-uniform-imul-op ::= ssa-id `=` `spv.GroupNonUniformIMul` scope operation
 %1 = spv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5952,33 +5110,19 @@ non-uniform-smax-op ::= ssa-id `=` `spv.GroupNonUniformSMax` scope operation
 %1 = spv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6022,33 +5166,19 @@ non-uniform-smin-op ::= ssa-id `=` `spv.GroupNonUniformSMin` scope operation
 %1 = spv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6093,33 +5223,19 @@ non-uniform-umax-op ::= ssa-id `=` `spv.GroupNonUniformUMax` scope operation
 %1 = spv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6164,33 +5280,19 @@ non-uniform-umin-op ::= ssa-id `=` `spv.GroupNonUniformUMin` scope operation
 %1 = spv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6225,28 +5327,19 @@ iadd-op ::= ssa-id `=` `spv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6277,21 +5370,17 @@ iequal-op ::= ssa-id `=` `spv.IEqual` ssa-use, ssa-use
 ```
 """
 function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6326,28 +5415,19 @@ imul-op ::= ssa-id `=` `spv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6378,21 +5458,17 @@ inot-equal-op ::= ssa-id `=` `spv.INotEqual` ssa-use, ssa-use
 ```
 """
 function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6427,28 +5503,19 @@ isub-op ::= `spv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6488,32 +5555,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spv.ImageDrefGather %1 : !spv.sampled_image<!spv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6534,21 +5588,17 @@ same as Result Type.
 ```
 """
 function Image(sampledimage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[sampledimage,]
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Image", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6587,21 +5637,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6627,28 +5673,18 @@ func @inbounds_ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i6
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6679,21 +5715,17 @@ isinf-op ::= ssa-id `=` `spv.IsInf` ssa-use
 ```
 """
 function IsInf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IsInf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6724,21 +5756,17 @@ isnan-op ::= ssa-id `=` `spv.IsNan` ssa-use
 ```
 """
 function IsNan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IsNan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6775,31 +5803,20 @@ load-op ::= ssa-id ` = spv.Load ` storage-class ssa-use
 %3 = spv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6829,21 +5846,17 @@ logical-and ::= `spv.LogicalAnd` ssa-use `,` ssa-use
 ```
 """
 function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6872,24 +5885,18 @@ logical-equal ::= `spv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6918,24 +5925,18 @@ logical-not-equal ::= `spv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6962,21 +5963,17 @@ logical-not ::= `spv.LogicalNot` ssa-use `:` operand-type
 ```
 """
 function LogicalNot(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7006,21 +6003,17 @@ logical-or ::= `spv.LogicalOr` ssa-use `,` ssa-use
 ```
 """
 function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7054,19 +6047,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7099,24 +6088,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7148,24 +6131,18 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[matrix, scalar]
+function MatrixTimesScalar(matrix::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7208,20 +6185,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7240,16 +6210,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7296,34 +6262,20 @@ spv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7353,23 +6305,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7399,21 +6347,17 @@ ceil-op ::= ssa-id `=` `spv.OCL.ceil` ssa-use `:`
 ```
 """
 function OCL_ceil(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7443,21 +6387,17 @@ cos-op ::= ssa-id `=` `spv.OCL.cos` ssa-use `:`
 ```
 """
 function OCL_cos(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7487,21 +6427,17 @@ erf-op ::= ssa-id `=` `spv.OCL.erf` ssa-use `:`
 ```
 """
 function OCL_erf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7531,21 +6467,17 @@ exp-op ::= ssa-id `=` `spv.OCL.exp` ssa-use `:`
 ```
 """
 function OCL_exp(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7575,21 +6507,17 @@ abs-op ::= ssa-id `=` `spv.OCL.fabs` ssa-use `:`
 ```
 """
 function OCL_fabs(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7619,21 +6547,17 @@ floor-op ::= ssa-id `=` `spv.OCL.floor` ssa-use `:`
 ```
 """
 function OCL_floor(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7663,21 +6587,17 @@ log-op ::= ssa-id `=` `spv.OCL.log` ssa-use `:`
 ```
 """
 function OCL_log(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7708,21 +6628,17 @@ pow-op ::= ssa-id `=` `spv.OCL.pow` ssa-use `:`
 ```
 """
 function OCL_pow(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7752,21 +6668,17 @@ rsqrt-op ::= ssa-id `=` `spv.OCL.rsqrt` ssa-use `:`
 ```
 """
 function OCL_rsqrt(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7796,21 +6708,17 @@ abs-op ::= ssa-id `=` `spv.OCL.s_abs` ssa-use `:`
 ```
 """
 function OCL_s_abs(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7840,21 +6748,17 @@ sin-op ::= ssa-id `=` `spv.OCL.sin` ssa-use `:`
 ```
 """
 function OCL_sin(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7884,21 +6788,17 @@ sqrt-op ::= ssa-id `=` `spv.OCL.sqrt` ssa-use `:`
 ```
 """
 function OCL_sqrt(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7928,21 +6828,17 @@ tanh-op ::= ssa-id `=` `spv.OCL.tanh` ssa-use `:`
 ```
 """
 function OCL_tanh(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.OCL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.OCL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7974,21 +6870,17 @@ ordered-op ::= ssa-id `=` `spv.Ordered` ssa-use, ssa-use
 ```
 """
 function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8037,28 +6929,18 @@ func @ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> () 
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8088,21 +6970,17 @@ spv-reference-of-op ::= ssa-id `=` `spv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8123,16 +7001,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8159,20 +7033,16 @@ spv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8202,21 +7072,17 @@ s-convert-op ::= ssa-id `=` `spv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8248,28 +7114,19 @@ sdiv-op ::= ssa-id `=` `spv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8299,24 +7156,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8346,24 +7197,18 @@ sgreater-than-op ::= ssa-id `=` `spv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8393,24 +7238,18 @@ sless-than-equal-op ::= ssa-id `=` `spv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8441,21 +7280,17 @@ sless-than-op ::= ssa-id `=` `spv.SLessThan` ssa-use, ssa-use
 ```
 """
 function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8488,28 +7323,19 @@ smod-op ::= ssa-id `=` `spv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8533,25 +7359,19 @@ must equal the component width in Result Type.
 %3 = spv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8584,28 +7404,19 @@ srem-op ::= ssa-id `=` `spv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8648,29 +7459,19 @@ select-op ::= ssa-id `=` `spv.Select` ssa-use, ssa-use, ssa-use
 %3 = spv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8698,19 +7499,15 @@ The merge block should only contain a `spv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8750,24 +7547,18 @@ shift-left-logical-op ::= ssa-id `=` `spv.ShiftLeftLogical`
 %5 = spv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function ShiftLeftLogical(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8804,24 +7595,18 @@ shift-right-arithmetic-op ::= ssa-id `=` `spv.ShiftRightArithmetic`
 %5 = spv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8859,24 +7644,18 @@ shift-right-logical-op ::= ssa-id `=` `spv.ShiftRightLogical`
 %5 = spv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function ShiftRightLogical(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8921,21 +7700,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8975,19 +7746,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9061,21 +7826,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9108,27 +7869,20 @@ spv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9163,21 +7917,17 @@ subgroup-ballot-op ::= ssa-id `=` `spv.SubgroupBallotKHR`
 ```
 """
 function SubgroupBallotKHR(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBallotKHR",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBallotKHR", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9213,21 +7963,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spv.SubgroupBlockReadINTEL`
 ```
 """
 function SubgroupBlockReadINTEL(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBlockReadINTEL",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBlockReadINTEL", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9263,20 +8009,16 @@ spv.SubgroupBlockWriteINTEL \"StorageBuffer\" %ptr, %value : i32
 """
 function SubgroupBlockWriteINTEL(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBlockWriteINTEL",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBlockWriteINTEL", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9309,21 +8051,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9354,21 +8092,17 @@ u-convert-op ::= ssa-id `=` `spv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9399,28 +8133,19 @@ udiv-op ::= ssa-id `=` `spv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9450,24 +8175,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9497,24 +8216,18 @@ ugreater-than-op ::= ssa-id `=` `spv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9544,24 +8257,18 @@ uless-than-equal-op ::= ssa-id `=` `spv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9592,21 +8299,17 @@ uless-than-op ::= ssa-id `=` `spv.ULessThan` ssa-use, ssa-use
 ```
 """
 function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9637,28 +8340,19 @@ umod-op ::= ssa-id `=` `spv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9685,21 +8379,17 @@ undef-op ::= `spv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9731,21 +8421,17 @@ unordered-op ::= ssa-id `=` `spv.Unordered` ssa-use, ssa-use
 ```
 """
 function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Unordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9766,16 +8452,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9813,28 +8495,19 @@ where `init` specifies initializer.
 %2 = spv.Variable init(%0): !spv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9860,24 +8533,18 @@ or equal to the number of components in Vector.
 %2 = spv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9915,29 +8582,19 @@ vector-insert-dynamic-op ::= `spv.VectorInsertDynamic ` ssa-use `,`
 %2 = spv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9978,24 +8635,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10020,20 +8671,16 @@ spv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/SPIRV.jl
+++ b/src/Dialects/14/SPIRV.jl
@@ -3,6 +3,7 @@ module spv
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `AccessChain`

--- a/src/Dialects/14/Shape.jl
+++ b/src/Dialects/14/Shape.jl
@@ -3,6 +3,7 @@ module shape
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `add`

--- a/src/Dialects/14/Shape.jl
+++ b/src/Dialects/14/Shape.jl
@@ -3,7 +3,6 @@ module shape
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `add`

--- a/src/Dialects/14/Shape.jl
+++ b/src/Dialects/14/Shape.jl
@@ -1,9 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -15,25 +14,19 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -54,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -93,21 +82,17 @@ ready to execute.
 ```
 """
 function assuming_all(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -121,24 +106,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,22 +129,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -192,25 +167,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -225,25 +194,19 @@ concat([2,3], [4,5]) -> [2,3,4,5]
 concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
-function concat(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function concat(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -260,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -289,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -324,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -361,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -396,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -437,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -467,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,25 +429,19 @@ negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,25 +452,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -567,21 +482,17 @@ the shape.
 ```
 """
 function from_extents(extents::Vector{Value}; shape::IR.Type, location=Location())
-    results = IR.Type[shape,]
-    operands = Value[extents...,]
+    results = IR.Type[shape, ]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -607,19 +518,15 @@ shape.function_library {
 function function_library(; mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mapping", mapping),]
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mapping", mapping), ]
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -629,25 +536,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -660,25 +561,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -700,25 +595,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -730,25 +619,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -779,30 +662,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -814,25 +687,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -846,25 +713,19 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -877,25 +738,19 @@ extents. If the argument is of type `shape` then the result will be of type
 is and extent tensor `tensor<?xindex>` then the result will be of type
 `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -904,23 +759,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -957,28 +808,18 @@ func @reduce(%shape : !shape.shape, %init : !shape.size) -> !shape.size {
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -991,25 +832,19 @@ as their equivalent non-error shapes. Error shapes can be tested for
 equality like any other shape value, meaning that the error value is equal
 to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1019,23 +854,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1047,25 +878,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1093,24 +918,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1124,21 +943,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1160,21 +975,17 @@ representing sizes) then this propagages the error shape. E.g.,
 This operation is the compliment of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1213,28 +1024,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1242,22 +1044,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/SparseTensor.jl
+++ b/src/Dialects/14/SparseTensor.jl
@@ -1,9 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `compress`
@@ -27,30 +26,18 @@ sparse_tensor.compress %0, %1, %values, %filled, %added, %2
 	  memref<?xi1>, memref<?xindex>, index
 ```
 """
-function compress(
-    tensor::Value,
-    indices::Value,
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value;
-    location=Location(),
-)
+function compress(tensor::Value, indices::Value, values::Value, filled::Value, added::Value, count::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, values, filled, added, count]
+    operands = Value[tensor, indices, values, filled, added, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -88,21 +75,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -138,29 +121,18 @@ may be refined over time as our sparse abstractions evolve.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>, index
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -182,21 +154,17 @@ a subsequent operation that yields a sparse tensor as the result.
 ```
 """
 function init(sizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[sizes...,]
+    results = IR.Type[result, ]
+    operands = Value[sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,20 +189,16 @@ sparse_tensor.lex_insert %tensor, %indices, %val
 """
 function lex_insert(tensor::Value, indices::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, value]
+    operands = Value[tensor, indices, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.lex_insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.lex_insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -264,29 +228,20 @@ may be refined over time as our sparse abstractions evolve.
 %1 = sparse_tensor.load %0 : tensor<8xf64, #SV>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -309,21 +264,17 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -345,20 +296,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -385,20 +332,16 @@ sparse_tensor.release %tensor : tensor<1024x1024xf64, #CSR>
 """
 function release(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.release",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.release", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -421,21 +364,17 @@ indices array.
 ```
 """
 function indices(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor, dim]
+    results = IR.Type[result, ]
+    operands = Value[tensor, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.indices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.indices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -458,21 +397,17 @@ pointers array.
 ```
 """
 function pointers(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor, dim]
+    results = IR.Type[result, ]
+    operands = Value[tensor, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.pointers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.pointers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -494,21 +429,17 @@ values array.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/SparseTensor.jl
+++ b/src/Dialects/14/SparseTensor.jl
@@ -3,6 +3,7 @@ module sparse_tensor
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `compress`

--- a/src/Dialects/14/SparseTensor.jl
+++ b/src/Dialects/14/SparseTensor.jl
@@ -3,7 +3,6 @@ module sparse_tensor
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `compress`

--- a/src/Dialects/14/StandardOps.jl
+++ b/src/Dialects/14/StandardOps.jl
@@ -1,9 +1,8 @@
 module std
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assert`
@@ -21,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "std.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "std.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -57,20 +52,16 @@ the block successor.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "std.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "std.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,27 +83,18 @@ Function values can be created with the
         : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "std.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "std.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,24 +112,18 @@ symbol reference attribute named \"callee\".
 %2 = call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "std.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "std.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -179,33 +155,19 @@ func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "std.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "std.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,21 +207,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "std.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "std.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -280,22 +238,18 @@ func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "std.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "std.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,29 +286,19 @@ to implement `min` and `max` with signed or unsigned comparison semantics.
 %vx = std.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "std.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "std.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -385,21 +329,17 @@ tensors in the same way dynamically shaped memrefs are handled.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "std.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "std.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -422,37 +362,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "std.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "std.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/StandardOps.jl
+++ b/src/Dialects/14/StandardOps.jl
@@ -3,7 +3,6 @@ module std
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `assert`

--- a/src/Dialects/14/StandardOps.jl
+++ b/src/Dialects/14/StandardOps.jl
@@ -3,6 +3,7 @@ module std
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `assert`

--- a/src/Dialects/14/Tensor.jl
+++ b/src/Dialects/14/Tensor.jl
@@ -3,6 +3,7 @@ module tensor
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `cast`

--- a/src/Dialects/14/Tensor.jl
+++ b/src/Dialects/14/Tensor.jl
@@ -3,7 +3,6 @@ module tensor
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `cast`

--- a/src/Dialects/14/Tensor.jl
+++ b/src/Dialects/14/Tensor.jl
@@ -1,9 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `cast`
@@ -29,21 +28,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +68,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -116,25 +107,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -164,21 +149,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -200,24 +181,18 @@ indices should all be of `index` type.
 %6 = tensor.extract %ut[%1, %2] : tensor<*xi32>
 ```
 """
-function extract(
-    tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,40 +238,19 @@ between different flavors of ops on that operate on tensors.
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -319,21 +273,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -359,24 +309,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -401,24 +345,18 @@ indices should all be of `index` type.
 %6 = tensor.insert %ut into %dest[%1, %2] : tensor<*xi32>
 ```
 """
-function insert(
-    scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -472,41 +410,19 @@ behavior of tensor.extract_slice.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,36 +498,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -627,23 +527,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -682,21 +578,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,20 +601,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Tosa.jl
+++ b/src/Dialects/14/Tosa.jl
@@ -1,9 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -11,21 +10,17 @@ import ...API
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -121,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,36 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -213,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -305,21 +242,17 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,21 +262,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -356,29 +285,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,21 +306,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,21 +327,17 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1...,]
+    results = IR.Type[output, ]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,23 +347,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -463,38 +369,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -503,38 +390,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -546,24 +414,18 @@ that are not expressed in the existing TOSA operations. These operators are
 not expected to be portable across TOSA implementations. The input and
 output signatures must be expressed in the corresponding TOSA node.
 """
-function custom(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("identifier", identifier),]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -573,38 +435,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -615,21 +458,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -639,21 +478,17 @@ end
 Elementwise comparison operation
 """
 function equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,21 +498,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -687,21 +518,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,31 +537,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -745,21 +560,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -769,21 +580,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -793,21 +600,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -818,21 +621,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -842,29 +641,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -874,21 +662,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -899,21 +683,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -923,24 +703,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -950,21 +724,17 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -975,21 +745,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -999,24 +765,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1027,21 +787,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1052,26 +808,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1084,25 +833,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1113,21 +854,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1138,21 +875,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1163,21 +896,17 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1186,26 +915,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1214,32 +936,20 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1250,21 +960,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1275,21 +981,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1299,21 +1001,17 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1323,21 +1021,17 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1347,21 +1041,17 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1371,21 +1061,17 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1395,21 +1081,17 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1419,21 +1101,17 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1443,23 +1121,17 @@ end
 ReLU with a scalar maximum value.
 """
 function reluN(input::Value; output::IR.Type, max_int, max_fp, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("max_int", max_int), namedattribute("max_fp", max_fp)
-    ]
-
-    return IR.create_operation(
-        "tosa.reluN",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("max_int", max_int), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.reluN", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1483,41 +1155,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1529,21 +1178,17 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1555,41 +1200,18 @@ expected use, stride_y is approximately (IH<<shift)/OH and stride_x is
 approximately (IW<<shift)/OW.  OH and OW are also supplied as inputs since
 there may be off by one errors if calculating OH and OW from the strides.
 """
-function resize(
-    input::Value;
-    output::IR.Type,
-    output_size,
-    stride,
-    offset,
-    shift,
-    stride_fp,
-    offset_fp,
-    mode,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, output_size, stride, offset, shift, stride_fp, offset_fp, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("output_size", output_size),
-        namedattribute("stride", stride),
-        namedattribute("offset", offset),
-        namedattribute("shift", shift),
-        namedattribute("stride_fp", stride_fp),
-        namedattribute("offset_fp", offset_fp),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("output_size", output_size), namedattribute("stride", stride), namedattribute("offset", offset), namedattribute("shift", shift), namedattribute("stride_fp", stride_fp), namedattribute("offset_fp", offset_fp), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1601,21 +1223,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1626,21 +1244,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1650,24 +1264,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1676,24 +1284,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    input1::Value, input2::Value, input3::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2, input3]
+function select(input1::Value, input2::Value, input3::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, input3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1707,21 +1309,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1733,23 +1331,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1760,21 +1352,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1797,21 +1385,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1824,21 +1408,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1848,21 +1428,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1872,40 +1448,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    dilation,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, dilation, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("dilation", dilation), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1915,21 +1470,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1941,28 +1492,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1975,20 +1516,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Tosa.jl
+++ b/src/Dialects/14/Tosa.jl
@@ -3,7 +3,6 @@ module tosa
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `abs`

--- a/src/Dialects/14/Tosa.jl
+++ b/src/Dialects/14/Tosa.jl
@@ -3,6 +3,7 @@ module tosa
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `abs`

--- a/src/Dialects/14/Vector.jl
+++ b/src/Dialects/14/Vector.jl
@@ -1,9 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `vscale`
@@ -20,21 +19,17 @@ Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
 function vscale(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,21 +58,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -113,21 +104,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,28 +149,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -219,21 +196,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,36 +327,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value,
-    masks::Vector{Value};
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc, masks...]
+function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, masks..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,22 +373,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -467,29 +419,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -515,28 +456,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -584,24 +516,18 @@ For instance:
   to vector<4x4x2xf32>
 ```
 """
-function extract_map(
-    vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector, ids...]
+function extract_map(vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ids..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.extract_map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract_map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,21 +545,17 @@ the proper position. Degenerates to an element type in the 0-D case.
 ```
 """
 function extract(vector::Value; result_0::IR.Type, position, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,28 +585,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -706,21 +618,17 @@ to the `llvm.fma.*` intrinsic.
 ```
 """
 function fma(lhs::Value, rhs::Value, acc::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -750,23 +658,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -801,30 +703,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -849,29 +739,19 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest]
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -921,24 +801,18 @@ For instance:
   into vector<64x4x32xf32>
 ```
 """
-function insert_map(
-    vector::Value, dest::Value, ids::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, dest, ids...]
+function insert_map(vector::Value, dest::Value, ids::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, dest, ids..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.insert_map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -957,21 +831,17 @@ position. Degenerates to a scalar source type when n = 0.
 ```
 """
 function insert(source::Value, dest::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[source, dest]
+    results = IR.Type[res, ]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -997,26 +867,18 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value, dest::Value; res::IR.Type, offsets, strides, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[source, dest]
+function insert_strided_slice(source::Value, dest::Value; res::IR.Type, offsets, strides, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1077,21 +939,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1123,29 +981,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1177,28 +1024,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1229,34 +1066,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1276,26 +1097,18 @@ int only).
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value; dest::IR.Type, kind, reduction_dims, location=Location()
-)
-    results = IR.Type[dest,]
-    operands = Value[source,]
+function multi_reduction(source::Value; dest::IR.Type, kind, reduction_dims, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,30 +1162,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1402,20 +1204,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1442,24 +1240,18 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction \"mul\", %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value, acc::Vector{Value}; dest::IR.Type, kind, location=Location()
-)
-    results = IR.Type[dest,]
-    operands = Value[vector, acc...]
+function reduction(vector::Value, acc::Vector{Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, acc..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1547,30 +1339,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1591,35 +1372,18 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest::IR.Type,
-    accumulated_value::IR.Type,
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
-    results = IR.Type[dest, accumulated_value]
-    operands = Value[source, initial_value]
+function scan(source::Value, initial_value::Value; dest::IR.Type, accumulated_value::IR.Type, kind, reduction_dim, inclusive, location=Location())
+    results = IR.Type[dest, accumulated_value, ]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1656,29 +1420,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1718,21 +1471,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1768,21 +1517,17 @@ according to the given mask. The legality rules are:
 ```
 """
 function shuffle(v1::Value, v2::Value; vector::IR.Type, mask, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[v1, v2]
+    results = IR.Type[vector, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1840,24 +1585,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2021,36 +1760,21 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2144,37 +1868,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2204,21 +1913,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2245,21 +1950,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/14/Vector.jl
+++ b/src/Dialects/14/Vector.jl
@@ -3,7 +3,6 @@ module vector
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `vscale`

--- a/src/Dialects/14/Vector.jl
+++ b/src/Dialects/14/Vector.jl
@@ -3,6 +3,7 @@ module vector
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `vscale`

--- a/src/Dialects/14/X86Vector.jl
+++ b/src/Dialects/14/X86Vector.jl
@@ -3,7 +3,6 @@ module x86vector
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
 
 """
 `avx_intr_dp_ps_256`

--- a/src/Dialects/14/X86Vector.jl
+++ b/src/Dialects/14/X86Vector.jl
@@ -3,6 +3,7 @@ module x86vector
 import ...IR:
     IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+import ...API
 
 """
 `avx_intr_dp_ps_256`

--- a/src/Dialects/14/X86Vector.jl
+++ b/src/Dialects/14/X86Vector.jl
@@ -1,33 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -49,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -75,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -112,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -156,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -188,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -220,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -262,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -294,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -326,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -358,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -384,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -408,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -445,24 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location()
-)
-    results = IR.Type[k1, k2]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/AMDGPU.jl
+++ b/src/Dialects/15/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `lds_barrier`
@@ -25,12 +25,16 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amdgpu.lds_barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.lds_barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -54,22 +58,37 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_atomic_fadd(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -105,22 +124,37 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[memref, indices..., ]
+function raw_buffer_load(
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    value::IR.Type,
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -144,22 +178,37 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_store(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/AMDGPU.jl
+++ b/src/Dialects/15/AMDGPU.jl
@@ -1,9 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `lds_barrier`
@@ -26,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -59,37 +54,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -125,37 +105,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -179,37 +144,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/AMDGPU.jl
+++ b/src/Dialects/15/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `lds_barrier`
@@ -25,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -58,37 +54,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -124,37 +105,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -178,37 +144,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/AMX.jl
+++ b/src/Dialects/15/AMX.jl
@@ -1,38 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -40,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -104,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -296,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/AMX.jl
+++ b/src/Dialects/15/AMX.jl
@@ -1,25 +1,38 @@
 module amx
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbf16ps(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbf16ps", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbf16ps",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -27,18 +40,31 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbssd(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbssd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbssd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -46,18 +72,31 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbsud(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbsud", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbsud",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -65,18 +104,31 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbusd(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbusd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbusd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -84,18 +136,31 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbuud(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbuud", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbuud",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -103,18 +168,29 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+function tileloadd64(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tileloadd64", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tileloadd64",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -122,18 +198,29 @@ end
 `tilestored64`
 
 """
-function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function tilestored64(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tilestored64", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tilestored64",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -142,17 +229,21 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, ]
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tilezero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tilezero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -171,17 +262,21 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[base, indices..., ]
+    results = IR.Type[res,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -201,17 +296,21 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, acc, ]
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -233,20 +332,32 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, acc, ]
+function tile_muli(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    res::IR.Type,
+    isZextLhs=nothing,
+    isZextRhs=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-    
-    IR.create_operation(
-        "amx.tile_muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -266,16 +377,20 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val, ]
+    operands = Value[base, indices..., val]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -293,17 +408,21 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_zero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_zero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/AMX.jl
+++ b/src/Dialects/15/AMX.jl
@@ -1,39 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -41,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -105,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -230,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Affine.jl
+++ b/src/Dialects/15/Affine.jl
@@ -1,9 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -28,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,24 +148,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,28 +233,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -292,21 +271,17 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -322,22 +297,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -363,22 +334,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -447,40 +414,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,33 +447,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -556,20 +486,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -612,24 +538,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -674,24 +594,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,22 +623,18 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Affine.jl
+++ b/src/Dialects/15/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -27,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,24 +148,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -243,28 +233,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -291,21 +271,17 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -321,22 +297,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -362,22 +334,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -446,40 +414,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,33 +447,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,20 +486,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -611,24 +538,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -673,24 +594,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -708,22 +623,18 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Affine.jl
+++ b/src/Dialects/15/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply`
@@ -27,17 +27,21 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[mapOperands..., ]
+    results = IR.Type[result_0,]
+    operands = Value[mapOperands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.apply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.apply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -148,18 +152,24 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operand_0..., ]
-    owned_regions = Region[region, ]
+function for_(
+    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[operand_0...,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -233,18 +243,28 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operand_0..., ]
-    owned_regions = Region[thenRegion, elseRegion, ]
+function if_(
+    operand_0::Vector{Value};
+    results::Vector{IR.Type},
+    thenRegion::Region,
+    elseRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[operand_0...,]
+    owned_regions = Region[thenRegion, elseRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -271,17 +291,21 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -297,18 +321,22 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.max", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -334,18 +362,22 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.min", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -414,18 +446,40 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[mapOperands..., ]
-    owned_regions = Region[region, ]
+function parallel(
+    mapOperands::Vector{Value};
+    results::Vector{IR.Type},
+    reductions,
+    lowerBoundsMap,
+    lowerBoundsGroups,
+    upperBoundsMap,
+    upperBoundsGroups,
+    steps,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[mapOperands...,]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
-    
-    IR.create_operation(
-        "affine.parallel", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("reductions", reductions),
+        namedattribute("lowerBoundsMap", lowerBoundsMap),
+        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
+        namedattribute("upperBoundsMap", upperBoundsMap),
+        namedattribute("upperBoundsGroups", upperBoundsGroups),
+        namedattribute("steps", steps),
+    ]
+
+    return IR.create_operation(
+        "affine.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -447,18 +501,33 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
+function prefetch(
+    memref::Value,
+    indices::Vector{Value};
+    isWrite,
+    localityHint,
+    isDataCache,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memref, indices..., ]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
-    
-    IR.create_operation(
-        "affine.prefetch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("isWrite", isWrite),
+        namedattribute("localityHint", localityHint),
+        namedattribute("isDataCache", isDataCache),
+    ]
+
+    return IR.create_operation(
+        "affine.prefetch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -486,16 +555,20 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -538,18 +611,24 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+function vector_load(
+    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.vector_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.vector_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -594,18 +673,24 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
+function vector_store(
+    value::Value, memref::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.vector_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.vector_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -623,18 +708,22 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Arithmetic.jl
+++ b/src/Dialects/15/Arithmetic.jl
@@ -1,9 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `addf`
@@ -29,25 +28,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -72,25 +65,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -115,25 +102,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -156,21 +137,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,25 +166,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -228,25 +199,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -278,21 +243,17 @@ attribute by the parser.
 ```
 """
 function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -362,21 +323,17 @@ complement or large positives
 ```
 """
 function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -397,23 +354,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -421,25 +374,19 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -465,25 +412,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -510,25 +451,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -540,21 +475,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -579,21 +510,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -617,21 +544,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -643,21 +566,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -669,21 +588,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -703,25 +618,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -734,21 +643,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -771,25 +676,19 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -797,25 +696,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -823,25 +716,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -864,25 +751,19 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -890,25 +771,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -916,25 +791,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -962,25 +831,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -988,25 +851,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1031,23 +888,19 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1072,25 +925,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1098,25 +945,19 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1142,25 +983,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1186,25 +1021,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1217,21 +1046,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1249,25 +1074,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1289,25 +1108,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1326,25 +1139,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1372,25 +1179,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1398,25 +1199,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1429,21 +1224,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1466,21 +1257,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1493,21 +1280,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1532,25 +1315,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1584,29 +1361,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/15/Arithmetic.jl
+++ b/src/Dialects/15/Arithmetic.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `addf`
@@ -28,19 +28,25 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function addf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.addf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -65,19 +71,25 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function addi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.addi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -102,19 +114,25 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function andi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.andi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.andi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -137,17 +155,21 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -166,19 +188,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ceildivsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ceildivsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -199,19 +227,25 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ceildivui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ceildivui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -243,17 +277,21 @@ attribute by the parser.
 ```
 """
 function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "arith.cmpf", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+
+    return IR.create_operation(
+        "arith.cmpf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -323,17 +361,21 @@ complement or large positives
 ```
 """
 function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "arith.cmpi", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+
+    return IR.create_operation(
+        "arith.cmpi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -354,19 +396,23 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -374,19 +420,25 @@ end
 `divf`
 
 """
-function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -412,19 +464,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -451,19 +509,25 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -475,17 +539,21 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -510,17 +578,21 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -544,17 +616,21 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -566,17 +642,21 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.fptosi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.fptosi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -588,17 +668,21 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.fptoui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.fptoui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -618,19 +702,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function floordivsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.floordivsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.floordivsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -643,17 +733,21 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.index_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.index_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -676,19 +770,25 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -696,19 +796,25 @@ end
 `maxsi`
 
 """
-function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -716,19 +822,25 @@ end
 `maxui`
 
 """
-function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -751,19 +863,25 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -771,19 +889,25 @@ end
 `minsi`
 
 """
-function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -791,19 +915,25 @@ end
 `minui`
 
 """
-function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -831,19 +961,25 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mulf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -851,19 +987,25 @@ end
 `muli`
 
 """
-function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function muli(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -888,19 +1030,23 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function negf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.negf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.negf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -925,19 +1071,25 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ori(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ori", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ori",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -945,19 +1097,25 @@ end
 `remf`
 
 """
-function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -983,19 +1141,25 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1021,19 +1185,25 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1046,17 +1216,21 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.sitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.sitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1074,19 +1248,25 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shli(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1108,19 +1288,25 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shrsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shrsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1139,19 +1325,25 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shrui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shrui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1179,19 +1371,25 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.subf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.subf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1199,19 +1397,25 @@ end
 `subi`
 
 """
-function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.subi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.subi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1224,17 +1428,21 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.truncf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.truncf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1257,17 +1465,21 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.trunci", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.trunci",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1280,17 +1492,21 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.uitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.uitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1315,19 +1531,25 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function xori(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.xori", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.xori",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1361,19 +1583,29 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function select(
+    condition::Value,
+    true_value::Value,
+    false_value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value, ]
+    operands = Value[condition, true_value, false_value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/15/Arithmetic.jl
+++ b/src/Dialects/15/Arithmetic.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `addf`
@@ -28,25 +28,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -71,25 +65,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -114,25 +102,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -155,21 +137,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,25 +166,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -227,25 +199,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -277,21 +243,17 @@ attribute by the parser.
 ```
 """
 function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -361,21 +323,17 @@ complement or large positives
 ```
 """
 function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -396,23 +354,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -420,25 +374,19 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -464,25 +412,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -509,25 +451,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -539,21 +475,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,21 +510,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -616,21 +544,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -642,21 +566,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -668,21 +588,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,25 +618,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -733,21 +643,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -770,25 +676,19 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -796,25 +696,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -822,25 +716,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -863,25 +751,19 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -889,25 +771,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -915,25 +791,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -961,25 +831,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -987,25 +851,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1030,23 +888,19 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1071,25 +925,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1097,25 +945,19 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1141,25 +983,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1185,25 +1021,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1216,21 +1046,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1248,25 +1074,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1288,25 +1108,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1325,25 +1139,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1371,25 +1179,19 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1397,25 +1199,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1428,21 +1224,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1465,21 +1257,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1492,21 +1280,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1531,25 +1315,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1583,29 +1361,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/15/ArmNeon.jl
+++ b/src/Dialects/15/ArmNeon.jl
@@ -1,9 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_smull`
@@ -17,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -48,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/ArmNeon.jl
+++ b/src/Dialects/15/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_smull`
@@ -16,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -47,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/ArmNeon.jl
+++ b/src/Dialects/15/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `intr_smull`
@@ -16,17 +16,21 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.intr.smull", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.intr.smull",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -43,17 +47,21 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, c, ]
+    results = IR.Type[res,]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.2d.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.2d.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -68,17 +76,21 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, c, ]
+    results = IR.Type[res,]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.intr.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.intr.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/ArmSVE.jl
+++ b/src/Dialects/15/ArmSVE.jl
@@ -1,25 +1,31 @@
 module arm_sve
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fadd(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fadd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -30,18 +36,24 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_addf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.addf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.addf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -49,18 +61,24 @@ end
 `intr_add`
 
 """
-function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_add(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -71,18 +89,24 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_addi(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.addi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.addi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -90,18 +114,24 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fdiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -112,18 +142,24 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -131,18 +167,24 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fmul(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fmul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -153,18 +195,24 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_mulf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -172,18 +220,24 @@ end
 `intr_mul`
 
 """
-function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_mul(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,18 +248,24 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_muli(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -213,18 +273,24 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sdiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -235,18 +301,24 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divi_signed(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divi_signed", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divi_signed",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -254,18 +326,24 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fsub(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fsub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fsub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -276,18 +354,24 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_subf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.subf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.subf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -295,18 +379,24 @@ end
 `intr_sub`
 
 """
-function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sub(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,18 +407,24 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_subi(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.subi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.subi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -336,18 +432,24 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_udiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.udiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.udiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -358,18 +460,24 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divi_unsigned(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divi_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divi_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -377,18 +485,24 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sdot(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -407,17 +521,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -425,18 +543,24 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_smmla(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.smmla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.smmla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,17 +582,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.smmla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.smmla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -476,18 +604,24 @@ end
 `intr_udot`
 
 """
-function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_udot(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.udot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.udot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -506,17 +640,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.udot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.udot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -524,18 +662,24 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_ummla(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.ummla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.ummla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -557,17 +701,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.ummla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.ummla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/ArmSVE.jl
+++ b/src/Dialects/15/ArmSVE.jl
@@ -1,32 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -37,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -90,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -143,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -196,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -249,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -274,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -302,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -327,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -380,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -433,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -461,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -486,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -544,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/ArmSVE.jl
+++ b/src/Dialects/15/ArmSVE.jl
@@ -1,31 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -89,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -142,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -379,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -460,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -485,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -543,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -662,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -701,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Async.jl
+++ b/src/Dialects/15/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add_to_group`
@@ -19,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -122,23 +108,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -151,20 +133,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -176,20 +154,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,23 +172,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -223,25 +193,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -257,28 +221,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -299,25 +253,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -362,30 +310,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    operands::Vector{Value};
-    token::IR.Type,
-    results::Vector{IR.Type},
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[token, results...]
-    operands = Value[dependencies..., operands...]
-    owned_regions = Region[body,]
+function execute(dependencies::Vector{Value}, operands_::Vector{Value}; token::IR.Type, results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[token, results_..., ]
+    operands = Value[dependencies..., operands_..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(operands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(operands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -397,20 +334,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -420,25 +353,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -451,20 +378,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -476,20 +399,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -499,25 +418,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -528,21 +441,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,20 +463,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -579,25 +484,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -608,21 +507,17 @@ The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
 function runtime_load(storage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[storage,]
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -632,25 +527,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -662,20 +551,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -687,20 +572,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -712,20 +593,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -737,20 +614,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -760,22 +633,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Async.jl
+++ b/src/Dialects/15/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add_to_group`
@@ -19,19 +19,25 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function add_to_group(
+    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, group, ]
+    operands = Value[operand, group]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "async.add_to_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.add_to_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -57,16 +63,20 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.await_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.await_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,19 +96,23 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.await", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.await",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -108,19 +122,23 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id, ]
+    operands = Value[id,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-    
-    IR.create_operation(
-        "async.coro.begin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.begin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -133,16 +151,20 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.end", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.end",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -154,16 +176,20 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle, ]
+    operands = Value[id, handle]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.free", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.free",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -172,19 +198,23 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-    
-    IR.create_operation(
-        "async.coro.id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -193,19 +223,25 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_save(
+    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-    
-    IR.create_operation(
-        "async.coro.save", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.save",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -221,18 +257,28 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
+function coro_suspend(
+    state::Value;
+    suspendDest::Block,
+    resumeDest::Block,
+    cleanupDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[state, ]
+    operands = Value[state,]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest, ]
+    successors = Block[suspendDest, resumeDest, cleanupDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.suspend", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.suspend",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -253,19 +299,25 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function create_group(
+    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[size, ]
+    operands = Value[size,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -310,19 +362,30 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(dependencies::Vector{Value}, operands_::Vector{Value}; token::IR.Type, results_::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[token, results_..., ]
-    operands = Value[dependencies..., operands_..., ]
-    owned_regions = Region[body, ]
+function execute(
+    dependencies::Vector{Value},
+    operands::Vector{Value};
+    token::IR.Type,
+    results::Vector{IR.Type},
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[token, results...]
+    operands = Value[dependencies..., operands...]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(operands), ]))
-    
-    IR.create_operation(
-        "async.execute", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(operands)]))
+
+    return IR.create_operation(
+        "async.execute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -334,16 +397,20 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    
-    IR.create_operation(
-        "async.runtime.add_ref", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("count", count),]
+
+    return IR.create_operation(
+        "async.runtime.add_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -353,19 +420,25 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_add_to_group(
+    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, group, ]
+    operands = Value[operand, group]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "async.runtime.add_to_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.add_to_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -378,16 +451,20 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle, ]
+    operands = Value[operand, handle]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.await_and_resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.await_and_resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -399,16 +476,20 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.await", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.await",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -418,19 +499,25 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_create_group(
+    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[size, ]
+    operands = Value[size,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.runtime.create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -441,17 +528,21 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -463,16 +554,20 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    
-    IR.create_operation(
-        "async.runtime.drop_ref", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("count", count),]
+
+    return IR.create_operation(
+        "async.runtime.drop_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -484,19 +579,25 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_is_error(
+    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-    
-    IR.create_operation(
-        "async.runtime.is_error", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.is_error",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -507,17 +608,21 @@ The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
 function runtime_load(storage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[storage, ]
+    results = IR.Type[result,]
+    operands = Value[storage,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -527,19 +632,25 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_num_worker_threads(;
+    result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.runtime.num_worker_threads", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.num_worker_threads",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -551,16 +662,20 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -572,16 +687,20 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.set_available", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.set_available",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -593,16 +712,20 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.set_error", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.set_error",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -614,16 +737,20 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage, ]
+    operands = Value[value, storage]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -633,18 +760,22 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Async.jl
+++ b/src/Dialects/15/Async.jl
@@ -1,9 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add_to_group`
@@ -20,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -123,23 +108,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -152,20 +133,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -177,20 +154,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,23 +172,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -224,25 +193,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -258,28 +221,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -300,25 +253,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -363,30 +310,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    operands::Vector{Value};
-    token::IR.Type,
-    results::Vector{IR.Type},
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[token, results...]
-    operands = Value[dependencies..., operands...]
-    owned_regions = Region[body,]
+function execute(dependencies::Vector{Value}, operands_::Vector{Value}; token::IR.Type, results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[token, results_..., ]
+    operands = Value[dependencies..., operands_..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(operands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(operands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -398,20 +334,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -421,25 +353,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -452,20 +378,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -477,20 +399,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -500,25 +418,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -529,21 +441,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,20 +463,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -580,25 +484,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -609,21 +507,17 @@ The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
 function runtime_load(storage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[storage,]
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -633,25 +527,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -663,20 +551,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -688,20 +572,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -713,20 +593,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -738,20 +614,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -761,22 +633,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Bufferization.jl
+++ b/src/Dialects/15/Bufferization.jl
@@ -1,8 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alloc_tensor`
@@ -45,34 +45,21 @@ construction operation and never escape the function boundary directly.
 return %0 : tensor<?x?xf32, #SparseMatrix>
 ```
 """
-function alloc_tensor(
-    dynamic_sizes::Vector{Value},
-    copy=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    memory_space=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[dynamic_sizes...,]
+function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; result::IR.Type, memory_space=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
-    push!(
-        attributes, operandsegmentsizes([length(dynamic_sizes), (copy == nothing) ? 0 : 1])
-    )
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
-
-    return IR.create_operation(
-        "bufferization.alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1]))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    
+    IR.create_operation(
+        "bufferization.alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -93,21 +80,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -139,20 +122,16 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.dealloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -174,21 +153,17 @@ This operation is a specialized variant of the built-in
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -214,21 +189,17 @@ If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
 function to_tensor(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Bufferization.jl
+++ b/src/Dialects/15/Bufferization.jl
@@ -1,9 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `alloc_tensor`
@@ -46,34 +45,21 @@ construction operation and never escape the function boundary directly.
 return %0 : tensor<?x?xf32, #SparseMatrix>
 ```
 """
-function alloc_tensor(
-    dynamic_sizes::Vector{Value},
-    copy=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    memory_space=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[dynamic_sizes...,]
+function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; result::IR.Type, memory_space=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
-    push!(
-        attributes, operandsegmentsizes([length(dynamic_sizes), (copy == nothing) ? 0 : 1])
-    )
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
-
-    return IR.create_operation(
-        "bufferization.alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1]))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    
+    IR.create_operation(
+        "bufferization.alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -94,21 +80,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,20 +122,16 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.dealloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -175,21 +153,17 @@ This operation is a specialized variant of the built-in
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -215,21 +189,17 @@ If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
 function to_tensor(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Bufferization.jl
+++ b/src/Dialects/15/Bufferization.jl
@@ -1,8 +1,8 @@
 module bufferization
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `alloc_tensor`
@@ -45,21 +45,34 @@ construction operation and never escape the function boundary directly.
 return %0 : tensor<?x?xf32, #SparseMatrix>
 ```
 """
-function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; result::IR.Type, memory_space=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamic_sizes..., ]
+function alloc_tensor(
+    dynamic_sizes::Vector{Value},
+    copy=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    memory_space=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[dynamic_sizes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
-    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1]))
-    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
-    
-    IR.create_operation(
-        "bufferization.alloc_tensor", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes, operandsegmentsizes([length(dynamic_sizes), (copy == nothing) ? 0 : 1])
+    )
+    !isnothing(memory_space) &&
+        push!(attributes, namedattribute("memory_space", memory_space))
+
+    return IR.create_operation(
+        "bufferization.alloc_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -80,17 +93,21 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "bufferization.clone", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.clone",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -122,16 +139,20 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "bufferization.dealloc_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.dealloc_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -153,17 +174,21 @@ This operation is a specialized variant of the built-in
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[tensor, ]
+    results = IR.Type[memref,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "bufferization.to_memref", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.to_memref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -189,17 +214,21 @@ If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
 function to_tensor(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, ]
+    results = IR.Type[result,]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "bufferization.to_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.to_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Builtin.jl
+++ b/src/Dialects/15/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `module_`
@@ -23,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -81,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Builtin.jl
+++ b/src/Dialects/15/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `module_`
@@ -23,20 +23,27 @@ module {
 }
 ```
 """
-function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
+function module_(;
+    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "builtin.module", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "builtin.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -74,18 +81,24 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
+function unrealized_conversion_cast(
+    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "builtin.unrealized_conversion_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "builtin.unrealized_conversion_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Builtin.jl
+++ b/src/Dialects/15/Builtin.jl
@@ -1,9 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `module_`
@@ -24,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -82,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Complex.jl
+++ b/src/Dialects/15/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -16,17 +16,21 @@ The `abs` op takes a single complex number and computes its absolute value.
 ```
 """
 function abs(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[complex, ]
+    results = IR.Type[result,]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -41,19 +45,25 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -69,17 +79,21 @@ The `angle` op takes a single complex number and computes its argument value wit
 ```
 """
 function angle(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[complex, ]
+    results = IR.Type[result,]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.angle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.angle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -95,19 +109,25 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function atan2(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.atan2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.atan2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -123,19 +143,23 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.conj", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.conj",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -152,17 +176,21 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex, ]
+    results = IR.Type[complex,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "complex.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "complex.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -178,19 +206,23 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -207,17 +239,21 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex, ]
-    operands = Value[real, imaginary, ]
+    results = IR.Type[complex,]
+    operands = Value[real, imaginary]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -231,19 +267,25 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function div(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -258,19 +300,25 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function eq(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -287,19 +335,23 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -320,19 +372,23 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.expm1", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.expm1",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -348,17 +404,21 @@ The `im` op takes a single complex number and extracts the imaginary part.
 ```
 """
 function im(complex::Value; imaginary::IR.Type, location=Location())
-    results = IR.Type[imaginary, ]
-    operands = Value[complex, ]
+    results = IR.Type[imaginary,]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.im", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.im",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -376,19 +436,23 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.log1p", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.log1p",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -405,19 +469,23 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -430,19 +498,25 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -457,19 +531,23 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.neg", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.neg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -485,19 +563,25 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function neq(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.neq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.neq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -513,19 +597,25 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -541,17 +631,21 @@ The `re` op takes a single complex number and extracts the real part.
 ```
 """
 function re(complex::Value; real::IR.Type, location=Location())
-    results = IR.Type[real, ]
-    operands = Value[complex, ]
+    results = IR.Type[real,]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.re", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.re",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -566,19 +660,23 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -594,19 +692,23 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -622,19 +724,23 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -649,19 +755,23 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -676,19 +786,25 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -704,19 +820,23 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -732,19 +852,23 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/15/Complex.jl
+++ b/src/Dialects/15/Complex.jl
@@ -1,9 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -17,21 +16,17 @@ The `abs` op takes a single complex number and computes its absolute value.
 ```
 """
 function abs(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[complex,]
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -46,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,21 +69,17 @@ The `angle` op takes a single complex number and computes its argument value wit
 ```
 """
 function angle(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[complex,]
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -110,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -144,23 +123,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -177,21 +152,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -207,23 +178,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -240,21 +207,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -268,25 +231,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -301,25 +258,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -336,23 +287,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -373,23 +320,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -405,21 +348,17 @@ The `im` op takes a single complex number and extracts the imaginary part.
 ```
 """
 function im(complex::Value; imaginary::IR.Type, location=Location())
-    results = IR.Type[imaginary,]
-    operands = Value[complex,]
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,23 +376,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -470,23 +405,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -499,25 +430,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -532,23 +457,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -564,25 +485,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -598,25 +513,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -632,21 +541,17 @@ The `re` op takes a single complex number and extracts the real part.
 ```
 """
 function re(complex::Value; real::IR.Type, location=Location())
-    results = IR.Type[real,]
-    operands = Value[complex,]
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -661,23 +566,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -693,23 +594,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -725,23 +622,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -756,23 +649,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -787,25 +676,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -821,23 +704,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -853,23 +732,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/15/Complex.jl
+++ b/src/Dialects/15/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -16,21 +16,17 @@ The `abs` op takes a single complex number and computes its absolute value.
 ```
 """
 function abs(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[complex,]
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -45,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -79,21 +69,17 @@ The `angle` op takes a single complex number and computes its argument value wit
 ```
 """
 function angle(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[complex,]
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -109,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -143,23 +123,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -176,21 +152,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -206,23 +178,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -239,21 +207,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -267,25 +231,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -300,25 +258,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -335,23 +287,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -372,23 +320,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -404,21 +348,17 @@ The `im` op takes a single complex number and extracts the imaginary part.
 ```
 """
 function im(complex::Value; imaginary::IR.Type, location=Location())
-    results = IR.Type[imaginary,]
-    operands = Value[complex,]
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,23 +376,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -469,23 +405,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -498,25 +430,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,23 +457,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -563,25 +485,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -597,25 +513,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -631,21 +541,17 @@ The `re` op takes a single complex number and extracts the real part.
 ```
 """
 function re(complex::Value; real::IR.Type, location=Location())
-    results = IR.Type[real,]
-    operands = Value[complex,]
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,23 +566,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -692,23 +594,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -724,23 +622,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -755,23 +649,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -786,25 +676,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -820,23 +704,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -852,23 +732,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/15/ControlFlow.jl
+++ b/src/Dialects/15/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `assert`
@@ -20,16 +20,20 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg), ]
-    
-    IR.create_operation(
-        "cf.assert", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg),]
+
+    return IR.create_operation(
+        "cf.assert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -52,16 +56,20 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands..., ]
+    operands = Value[destOperands...,]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "cf.br", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "cf.br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -93,19 +101,33 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
+function cond_br(
+    condition::Value,
+    trueDestOperands::Vector{Value},
+    falseDestOperands::Vector{Value};
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
+    operands = Value[condition, trueDestOperands..., falseDestOperands...]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
-    
-    IR.create_operation(
-        "cf.cond_br", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
+    )
+
+    return IR.create_operation(
+        "cf.cond_br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -128,20 +150,37 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
+function switch(
+    flag::Value,
+    defaultOperands::Vector{Value},
+    caseOperands::Vector{Value};
+    case_values=nothing,
+    case_operand_segments,
+    defaultDestination::Block,
+    caseDestinations::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands..., ]
+    operands = Value[flag, defaultOperands..., caseOperands...]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations..., ]
-    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
-    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
+    successors = Block[defaultDestination, caseDestinations...]
+    attributes = NamedAttribute[namedattribute(
+        "case_operand_segments", case_operand_segments
+    ),]
+    push!(
+        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
+    )
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    
-    IR.create_operation(
-        "cf.switch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "cf.switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/ControlFlow.jl
+++ b/src/Dialects/15/ControlFlow.jl
@@ -1,9 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assert`
@@ -21,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -57,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -151,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/ControlFlow.jl
+++ b/src/Dialects/15/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assert`
@@ -20,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -56,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -101,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/EmitC.jl
+++ b/src/Dialects/15/EmitC.jl
@@ -1,9 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -24,21 +23,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,32 +56,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -109,21 +92,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,21 +129,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,19 +170,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -246,21 +216,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/EmitC.jl
+++ b/src/Dialects/15/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply`
@@ -23,17 +23,21 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
-    
-    IR.create_operation(
-        "emitc.apply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
+
+    return IR.create_operation(
+        "emitc.apply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -56,20 +60,32 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee,
+    args=nothing,
+    template_args=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    attributes = NamedAttribute[namedattribute("callee", callee),]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
-    
-    IR.create_operation(
-        "emitc.call", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(template_args) &&
+        push!(attributes, namedattribute("template_args", template_args))
+
+    return IR.create_operation(
+        "emitc.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -92,17 +108,21 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -129,17 +149,21 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "emitc.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "emitc.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -170,14 +194,19 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_), ]
-    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
-    
-    IR.create_operation(
-        "emitc.include", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("include", include_),]
+    !isnothing(is_standard_include) &&
+        push!(attributes, namedattribute("is_standard_include", is_standard_include))
+
+    return IR.create_operation(
+        "emitc.include",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -216,17 +245,21 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "emitc.variable", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "emitc.variable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/EmitC.jl
+++ b/src/Dialects/15/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -23,21 +23,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -60,32 +56,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -108,21 +92,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,21 +129,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,19 +170,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,21 +216,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Func.jl
+++ b/src/Dialects/15/Func.jl
@@ -1,9 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `call_indirect`
@@ -22,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -60,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -103,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,28 +140,19 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -202,22 +173,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Func.jl
+++ b/src/Dialects/15/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `call_indirect`
@@ -21,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -59,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,28 +140,19 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -201,22 +173,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Func.jl
+++ b/src/Dialects/15/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `call_indirect`
@@ -21,18 +21,27 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[callee, callee_operands..., ]
+function call_indirect(
+    callee::Value,
+    callee_operands::Vector{Value};
+    results::Vector{IR.Type},
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[callee, callee_operands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "func.call_indirect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.call_indirect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -50,18 +59,24 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
-    
-    IR.create_operation(
-        "func.call", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee),]
+
+    return IR.create_operation(
+        "func.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -87,17 +102,21 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "func.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "func.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -140,19 +159,28 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
+function func_(;
+    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "func.func", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "func.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -173,18 +201,22 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "func.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/GPU.jl
+++ b/src/Dialects/15/GPU.jl
@@ -1,9 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `all_reduce`
@@ -30,30 +29,20 @@ accumulation as code region. The accumulation operation must be one of:
 Either none or all work items of a workgroup need to execute this op
 in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,36 +65,20 @@ that case, it also returns a !gpu.async.token.
 %memref, %token = gpu.alloc async [%dep] (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -134,16 +107,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,25 +128,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -193,25 +156,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -235,28 +192,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -322,19 +270,15 @@ attribution.
 function func(; function_type, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -367,19 +311,15 @@ or not intended to be run on the separate device.
 function module_(; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -396,25 +336,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -430,25 +364,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -466,20 +394,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -493,23 +417,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -594,59 +514,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    operands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; operands_::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        operands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(operands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(operands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -724,57 +606,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -796,29 +642,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -840,29 +676,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -877,16 +703,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -901,23 +723,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -932,20 +750,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -956,22 +770,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -984,20 +794,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1022,32 +828,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; result=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(result) && push!(results, result)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1063,23 +857,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1105,29 +895,19 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1155,21 +935,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1193,24 +969,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, operation, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, operation, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operation", operation),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operation", operation), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1238,28 +1008,18 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1285,24 +1045,18 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location()
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1317,23 +1071,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1350,16 +1100,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1375,25 +1121,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1430,27 +1170,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1468,20 +1200,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/GPU.jl
+++ b/src/Dialects/15/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `all_reduce`
@@ -29,20 +29,30 @@ accumulation as code region. The accumulation operation must be one of:
 Either none or all work items of a workgroup need to execute this op
 in convergence.
 """
-function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, body::Region, location=Location())
+function all_reduce(
+    value::Value;
+    result_0=nothing::Union{Nothing,IR.Type},
+    op=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, ]
-    owned_regions = Region[body, ]
+    operands = Value[value,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
-    
-    IR.create_operation(
-        "gpu.all_reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.all_reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -65,20 +75,36 @@ that case, it also returns a !gpu.async.token.
 %memref, %token = gpu.alloc async [%dep] (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
+function alloc(
+    asyncDependencies::Vector{Value},
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.alloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.alloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -107,12 +133,16 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -128,19 +158,25 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function block_dim(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.block_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.block_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -156,19 +192,25 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function block_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.block_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.block_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -192,19 +234,28 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function dealloc(
+    asyncDependencies::Vector{Value},
+    memref::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref, ]
+    operands = Value[asyncDependencies..., memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -270,15 +321,19 @@ attribution.
 function func(; function_type, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
-    
-    IR.create_operation(
-        "gpu.func", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+
+    return IR.create_operation(
+        "gpu.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -311,15 +366,19 @@ or not intended to be run on the separate device.
 function module_(; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.module", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -336,19 +395,25 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function global_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.global_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.global_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -364,19 +429,25 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function grid_dim(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.grid_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.grid_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -394,16 +465,20 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.host_register", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.host_register",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -417,19 +492,23 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.lane_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.lane_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -514,21 +593,59 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; operands_::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
+function launch_func(
+    asyncDependencies::Vector{Value},
+    gridSizeX::Value,
+    gridSizeY::Value,
+    gridSizeZ::Value,
+    blockSizeX::Value,
+    blockSizeY::Value,
+    blockSizeZ::Value,
+    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
+    operands::Vector{Value},
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    kernel,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, operands_..., ]
+    operands = Value[
+        asyncDependencies...,
+        gridSizeX,
+        gridSizeY,
+        gridSizeZ,
+        blockSizeX,
+        blockSizeY,
+        blockSizeZ,
+        operands...,
+    ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
+    attributes = NamedAttribute[namedattribute("kernel", kernel),]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(operands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies),
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            (dynamicSharedMemorySize == nothing) ? 0 : 1length(operands),
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.launch_func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.launch_func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -606,21 +723,57 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
+function launch(
+    asyncDependencies::Vector{Value},
+    gridSizeX::Value,
+    gridSizeY::Value,
+    gridSizeZ::Value,
+    blockSizeX::Value,
+    blockSizeY::Value,
+    blockSizeZ::Value,
+    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
-    owned_regions = Region[body, ]
+    operands = Value[
+        asyncDependencies...,
+        gridSizeX,
+        gridSizeY,
+        gridSizeZ,
+        blockSizeX,
+        blockSizeY,
+        blockSizeZ,
+    ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies),
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            (dynamicSharedMemorySize == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.launch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.launch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -642,19 +795,29 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function memcpy(
+    asyncDependencies::Vector{Value},
+    dst::Value,
+    src::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src, ]
+    operands = Value[asyncDependencies..., dst, src]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.memcpy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.memcpy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -676,19 +839,29 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function memset(
+    asyncDependencies::Vector{Value},
+    dst::Value,
+    value::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value, ]
+    operands = Value[asyncDependencies..., dst, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.memset", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.memset",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -703,12 +876,16 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.module_end", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.module_end",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -723,19 +900,23 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.num_subgroups", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.num_subgroups",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -750,16 +931,20 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format), ]
-    
-    IR.create_operation(
-        "gpu.printf", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("format", format),]
+
+    return IR.create_operation(
+        "gpu.printf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -770,18 +955,22 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -794,16 +983,20 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex, ]
+    operands = Value[devIndex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.set_default_device", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.set_default_device",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -828,20 +1021,32 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(value::Value, offset::Value, width::Value; result=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
+function shuffle(
+    value::Value,
+    offset::Value,
+    width::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    valid=nothing::Union{Nothing,IR.Type},
+    mode,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, offset, width, ]
+    operands = Value[value, offset, width]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode), ]
+    attributes = NamedAttribute[namedattribute("mode", mode),]
     !isnothing(result) && push!(results, result)
     !isnothing(valid) && push!(results, valid)
-    
-    IR.create_operation(
-        "gpu.shuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.shuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -857,19 +1062,23 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.subgroup_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -895,19 +1104,29 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_mma_compute(
+    opA::Value,
+    opB::Value,
+    opC::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[opA, opB, opC, ]
+    operands = Value[opA, opB, opC]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_compute", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_compute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -935,17 +1154,21 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[value, ]
+    results = IR.Type[res,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -969,18 +1192,24 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, operation, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[args..., ]
+function subgroup_mma_elementwise(
+    args::Vector{Value}; res::IR.Type, operation, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operation", operation), ]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_elementwise", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("operation", operation),]
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_elementwise",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1008,18 +1237,28 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[srcMemref, indices..., ]
+function subgroup_mma_load_matrix(
+    srcMemref::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    leadDimension,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[srcMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_load_matrix", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_load_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1045,18 +1284,24 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location())
+function subgroup_mma_store_matrix(
+    src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location()
+)
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices..., ]
+    operands = Value[src, dstMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_store_matrix", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_store_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1071,19 +1316,23 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.subgroup_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1100,12 +1349,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1121,19 +1374,25 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function thread_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.thread_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.thread_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1170,19 +1429,27 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function wait(
+    asyncDependencies::Vector{Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., ]
+    operands = Value[asyncDependencies...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1200,16 +1467,20 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values..., ]
+    operands = Value[values...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/GPU.jl
+++ b/src/Dialects/15/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `all_reduce`
@@ -29,30 +29,20 @@ accumulation as code region. The accumulation operation must be one of:
 Either none or all work items of a workgroup need to execute this op
 in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -75,36 +65,20 @@ that case, it also returns a !gpu.async.token.
 %memref, %token = gpu.alloc async [%dep] (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -133,16 +107,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -158,25 +128,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -192,25 +156,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -234,28 +192,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -321,19 +270,15 @@ attribution.
 function func(; function_type, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -366,19 +311,15 @@ or not intended to be run on the separate device.
 function module_(; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -395,25 +336,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -429,25 +364,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -465,20 +394,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -492,23 +417,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -593,59 +514,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    operands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; operands_::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        operands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(operands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(operands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -723,57 +606,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -795,29 +642,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -839,29 +676,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -876,16 +703,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -900,23 +723,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -931,20 +750,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -955,22 +770,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -983,20 +794,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1021,32 +828,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; result=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(result) && push!(results, result)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1062,23 +857,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1104,29 +895,19 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1154,21 +935,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1192,24 +969,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, operation, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, operation, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operation", operation),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operation", operation), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1237,28 +1008,18 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1284,24 +1045,18 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location()
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1316,23 +1071,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1349,16 +1100,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1374,25 +1121,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1429,27 +1170,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1467,20 +1200,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/LLVMIR.jl
+++ b/src/Dialects/15/LLVMIR.jl
@@ -1,26 +1,32 @@
 module llvm
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `ashr`
 
 """
-function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function ashr(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.ashr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.ashr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -41,13 +47,17 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "llvm.access_group", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "llvm.access_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -55,19 +65,25 @@ end
 `add`
 
 """
-function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -76,17 +92,21 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.addrspacecast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.addrspacecast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -120,17 +140,21 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
-    
-    IR.create_operation(
-        "llvm.mlir.addressof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name),]
+
+    return IR.create_operation(
+        "llvm.mlir.addressof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -147,14 +171,18 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-    
-    IR.create_operation(
-        "llvm.alias_scope_domain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alias_scope_domain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -196,14 +224,20 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
+    ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-    
-    IR.create_operation(
-        "llvm.alias_scope", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alias_scope",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -211,20 +245,30 @@ end
 `alloca`
 
 """
-function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arraySize, ]
+function alloca(
+    arraySize::Value;
+    res::IR.Type,
+    alignment=nothing,
+    elem_type=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[arraySize,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-    
-    IR.create_operation(
-        "llvm.alloca", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alloca",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -232,19 +276,25 @@ end
 `and`
 
 """
-function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function and(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -252,18 +302,33 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[ptr, cmp, val, ]
+function cmpxchg(
+    ptr::Value,
+    cmp::Value,
+    val::Value;
+    res::IR.Type,
+    success_ordering,
+    failure_ordering,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[ptr, cmp, val]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
-    
-    IR.create_operation(
-        "llvm.cmpxchg", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("success_ordering", success_ordering),
+        namedattribute("failure_ordering", failure_ordering),
+    ]
+
+    return IR.create_operation(
+        "llvm.cmpxchg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -271,18 +336,26 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[ptr, val, ]
+function atomicrmw(
+    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[ptr, val]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
-    
-    IR.create_operation(
-        "llvm.atomicrmw", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
+    ]
+
+    return IR.create_operation(
+        "llvm.atomicrmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -291,17 +364,21 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -311,16 +388,20 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands..., ]
+    operands = Value[destOperands...,]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.br", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -354,20 +435,31 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(operand_0::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, fastmathFlags=nothing, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operand_0..., ]
+function call(
+    operand_0::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee=nothing,
+    fastmathFlags=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operand_0...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.call", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -375,20 +467,36 @@ end
 `cond_br`
 
 """
-function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
+function cond_br(
+    condition::Value,
+    trueDestOperands::Vector{Value},
+    falseDestOperands::Vector{Value};
+    branch_weights=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
+    operands = Value[condition, trueDestOperands..., falseDestOperands...]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.cond_br", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
+    )
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.cond_br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -423,17 +531,21 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "llvm.mlir.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "llvm.mlir.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -442,17 +554,21 @@ end
 
 """
 function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[vector, position, ]
+    results = IR.Type[res,]
+    operands = Value[vector, position]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.extractelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.extractelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -461,17 +577,21 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[container, ]
+    results = IR.Type[res,]
+    operands = Value[container,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
-    
-    IR.create_operation(
-        "llvm.extractvalue", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("position", position),]
+
+    return IR.create_operation(
+        "llvm.extractvalue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -479,20 +599,31 @@ end
 `fadd`
 
 """
-function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fadd(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fadd", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -500,19 +631,31 @@ end
 `fcmp`
 
 """
-function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function fcmp(
+    lhs::Value,
+    rhs::Value;
+    res::IR.Type,
+    predicate,
+    fastmathFlags=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fcmp", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fcmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -520,20 +663,31 @@ end
 `fdiv`
 
 """
-function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fdiv(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fdiv", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -541,20 +695,31 @@ end
 `fmul`
 
 """
-function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fmul(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fmul", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -562,20 +727,30 @@ end
 `fneg`
 
 """
-function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fneg(
+    operand::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fneg", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fneg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -584,17 +759,21 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fpext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fpext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -603,17 +782,21 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptosi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptosi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -622,17 +805,21 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptoui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptoui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -641,17 +828,21 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptrunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptrunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -659,20 +850,31 @@ end
 `frem`
 
 """
-function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function frem(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.frem", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.frem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -680,20 +882,31 @@ end
 `fsub`
 
 """
-function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fsub(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fsub", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fsub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -706,13 +919,19 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
-    
-    IR.create_operation(
-        "llvm.fence", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
+    ]
+
+    return IR.create_operation(
+        "llvm.fence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -720,19 +939,23 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val, ]
+    operands = Value[val,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.freeze", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.freeze",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -740,19 +963,30 @@ end
 `getelementptr`
 
 """
-function getelementptr(base::Value, indices::Vector{Value}; res::IR.Type, structIndices, elem_type=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[base, indices..., ]
+function getelementptr(
+    base::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    structIndices,
+    elem_type=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("structIndices", structIndices), ]
+    attributes = NamedAttribute[namedattribute("structIndices", structIndices),]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-    
-    IR.create_operation(
-        "llvm.getelementptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.getelementptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -783,13 +1017,19 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
-    
-    IR.create_operation(
-        "llvm.mlir.global_ctors", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
+    ]
+
+    return IR.create_operation(
+        "llvm.mlir.global_ctors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -817,13 +1057,19 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
-    
-    IR.create_operation(
-        "llvm.mlir.global_dtors", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
+    ]
+
+    return IR.create_operation(
+        "llvm.mlir.global_dtors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -924,26 +1170,50 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
+function mlir_global(;
+    global_type,
+    constant=nothing,
+    sym_name,
+    linkage,
+    dso_local=nothing,
+    thread_local_=nothing,
+    value=nothing,
+    alignment=nothing,
+    addr_space=nothing,
+    unnamed_addr=nothing,
+    section=nothing,
+    initializer::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer, ]
+    owned_regions = Region[initializer,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
+    attributes = NamedAttribute[
+        namedattribute("global_type", global_type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("linkage", linkage),
+    ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) &&
+        push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) &&
+        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-    
-    IR.create_operation(
-        "llvm.mlir.global", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -952,17 +1222,21 @@ end
 
 """
 function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "llvm.icmp", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+
+    return IR.create_operation(
+        "llvm.icmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -976,23 +1250,42 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
+function inline_asm(
+    operands::Vector{Value};
+    res=nothing::Union{Nothing,IR.Type},
+    asm_string,
+    constraints,
+    has_side_effects=nothing,
+    is_align_stack=nothing,
+    asm_dialect=nothing,
+    operand_attrs=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
+    attributes = NamedAttribute[
+        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
+    ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) &&
+        push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) &&
+        push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
-    
-    IR.create_operation(
-        "llvm.inline_asm", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(operand_attrs) &&
+        push!(attributes, namedattribute("operand_attrs", operand_attrs))
+
+    return IR.create_operation(
+        "llvm.inline_asm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1000,18 +1293,24 @@ end
 `insertelement`
 
 """
-function insertelement(vector::Value, value::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[vector, value, position, ]
+function insertelement(
+    vector::Value, value::Value, position::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[vector, value, position]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.insertelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.insertelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1019,18 +1318,24 @@ end
 `insertvalue`
 
 """
-function insertvalue(container::Value, value::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[container, value, ]
+function insertvalue(
+    container::Value, value::Value; res::IR.Type, position, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[container, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
-    
-    IR.create_operation(
-        "llvm.insertvalue", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("position", position),]
+
+    return IR.create_operation(
+        "llvm.insertvalue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1039,17 +1344,21 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.inttoptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.inttoptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1057,20 +1366,38 @@ end
 `invoke`
 
 """
-function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, normalDest::Block, unwindDest::Block, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
+function invoke(
+    callee_operands::Vector{Value},
+    normalDestOperands::Vector{Value},
+    unwindDestOperands::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee=nothing,
+    normalDest::Block,
+    unwindDest::Block,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest, ]
+    successors = Block[normalDest, unwindDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
+        ]),
+    )
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    
-    IR.create_operation(
-        "llvm.invoke", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.invoke",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1103,24 +1430,39 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(; function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, body::Region, location=Location())
+function func(;
+    function_type,
+    linkage=nothing,
+    dso_local=nothing,
+    CConv=nothing,
+    personality=nothing,
+    garbageCollector=nothing,
+    passthrough=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type),]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) &&
+        push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
-    
-    IR.create_operation(
-        "llvm.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1128,19 +1470,25 @@ end
 `lshr`
 
 """
-function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function lshr(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.lshr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.lshr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1148,19 +1496,25 @@ end
 `landingpad`
 
 """
-function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0..., ]
+function landingpad(
+    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-    
-    IR.create_operation(
-        "llvm.landingpad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.landingpad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1168,24 +1522,41 @@ end
 `load`
 
 """
-function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[addr, ]
+function load(
+    addr::Value;
+    res::IR.Type,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    alignment=nothing,
+    volatile_=nothing,
+    nontemporal=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[addr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-    
-    IR.create_operation(
-        "llvm.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1204,15 +1575,19 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "llvm.metadata", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "llvm.metadata",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1220,19 +1595,25 @@ end
 `mul`
 
 """
-function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1255,17 +1636,21 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.null", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.null",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1273,19 +1658,25 @@ end
 `or`
 
 """
-function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function or(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1294,17 +1685,21 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.ptrtoint", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.ptrtoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1314,16 +1709,20 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1333,16 +1732,20 @@ end
 """
 function return_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1350,19 +1753,25 @@ end
 `sdiv`
 
 """
-function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function sdiv(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.sdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1371,17 +1780,21 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.sext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1390,17 +1803,21 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.sitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1408,19 +1825,25 @@ end
 `srem`
 
 """
-function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function srem(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.srem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.srem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1428,19 +1851,29 @@ end
 `select`
 
 """
-function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function select(
+    condition::Value,
+    trueValue::Value,
+    falseValue::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue, ]
+    operands = Value[condition, trueValue, falseValue]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1448,19 +1881,25 @@ end
 `shl`
 
 """
-function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function shl(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.shl", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.shl",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1469,17 +1908,21 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[v1, v2, ]
+    results = IR.Type[res,]
+    operands = Value[v1, v2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask), ]
-    
-    IR.create_operation(
-        "llvm.shufflevector", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask),]
+
+    return IR.create_operation(
+        "llvm.shufflevector",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1487,24 +1930,41 @@ end
 `store`
 
 """
-function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+function store(
+    value::Value,
+    addr::Value;
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    alignment=nothing,
+    volatile_=nothing,
+    nontemporal=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, addr, ]
+    operands = Value[value, addr]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-    
-    IR.create_operation(
-        "llvm.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1512,19 +1972,25 @@ end
 `sub`
 
 """
-function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1532,21 +1998,40 @@ end
 `switch`
 
 """
-function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
+function switch(
+    value::Value,
+    defaultOperands::Vector{Value},
+    caseOperands::Vector{Value};
+    case_values=nothing,
+    case_operand_segments,
+    branch_weights=nothing,
+    defaultDestination::Block,
+    caseDestinations::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands..., ]
+    operands = Value[value, defaultOperands..., caseOperands...]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations..., ]
-    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
-    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
+    successors = Block[defaultDestination, caseDestinations...]
+    attributes = NamedAttribute[namedattribute(
+        "case_operand_segments", case_operand_segments
+    ),]
+    push!(
+        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
+    )
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.switch", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1555,17 +2040,21 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.trunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.trunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1573,19 +2062,25 @@ end
 `udiv`
 
 """
-function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function udiv(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.udiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.udiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1594,17 +2089,21 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.uitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.uitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1612,19 +2111,25 @@ end
 `urem`
 
 """
-function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function urem(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.urem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.urem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1644,17 +2149,21 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.undef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.undef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1668,12 +2177,16 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.unreachable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.unreachable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1681,19 +2194,25 @@ end
 `xor`
 
 """
-function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function xor(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1702,17 +2221,21 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.zext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.zext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/LLVMIR.jl
+++ b/src/Dialects/15/LLVMIR.jl
@@ -1,33 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,17 +41,13 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.access_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.access_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -66,25 +55,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -93,21 +76,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,21 +120,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -172,18 +147,14 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope_domain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope_domain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -225,20 +196,14 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -246,30 +211,20 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -277,25 +232,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -303,33 +252,18 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res::IR.Type,
-    success_ordering,
-    failure_ordering,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -337,26 +271,18 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -365,21 +291,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -389,20 +311,16 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,31 +354,20 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operand_0...,]
+function call(operand_0::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, fastmathFlags=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,36 +375,20 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -532,21 +423,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,21 +442,17 @@ end
 
 """
 function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[vector, position]
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,21 +461,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -600,31 +479,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -632,31 +500,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -664,31 +520,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -696,31 +541,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -728,30 +562,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,21 +584,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -783,21 +603,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -806,21 +622,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -829,21 +641,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -851,31 +659,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -883,31 +680,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -920,19 +706,13 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
-    ]
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -940,23 +720,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -964,30 +740,19 @@ end
 `getelementptr`
 
 """
-function getelementptr(
-    base::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    structIndices,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+function getelementptr(base::Value, indices::Vector{Value}; res::IR.Type, structIndices, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("structIndices", structIndices),]
+    attributes = NamedAttribute[namedattribute("structIndices", structIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1018,19 +783,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1058,19 +817,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1171,50 +924,26 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1223,21 +952,17 @@ end
 
 """
 function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1251,42 +976,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1294,24 +1000,18 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value, value::Value, position::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[vector, value, position]
+function insertelement(vector::Value, value::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1319,24 +1019,18 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value, value::Value; res::IR.Type, position, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[container, value]
+function insertvalue(container::Value, value::Value; res::IR.Type, position, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1345,21 +1039,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1367,38 +1057,20 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1431,39 +1103,24 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1471,25 +1128,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1497,25 +1148,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1523,41 +1168,24 @@ end
 `load`
 
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1576,19 +1204,15 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1596,25 +1220,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1637,21 +1255,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1659,25 +1273,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1686,21 +1294,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1710,20 +1314,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1733,20 +1333,16 @@ end
 """
 function return_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1754,25 +1350,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1781,21 +1371,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1804,21 +1390,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1826,25 +1408,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1852,29 +1428,19 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1882,25 +1448,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1909,21 +1469,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1931,41 +1487,24 @@ end
 `store`
 
 """
-function store(
-    value::Value,
-    addr::Value;
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1973,25 +1512,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1999,40 +1532,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2041,21 +1555,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2063,25 +1573,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2090,21 +1594,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2112,25 +1612,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2150,21 +1644,17 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2178,16 +1668,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2195,25 +1681,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2222,21 +1702,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/LLVMIR.jl
+++ b/src/Dialects/15/LLVMIR.jl
@@ -1,32 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -47,17 +41,13 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.access_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.access_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,25 +55,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -92,21 +76,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,21 +120,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -171,18 +147,14 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope_domain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope_domain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -224,20 +196,14 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,30 +211,20 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -276,25 +232,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -302,33 +252,18 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res::IR.Type,
-    success_ordering,
-    failure_ordering,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -336,26 +271,18 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -364,21 +291,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,20 +311,16 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -435,31 +354,20 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operand_0...,]
+function call(operand_0::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, fastmathFlags=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -467,36 +375,20 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -531,21 +423,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,21 +442,17 @@ end
 
 """
 function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[vector, position]
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -577,21 +461,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -599,31 +479,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -631,31 +500,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,31 +520,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -695,31 +541,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -727,30 +562,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -759,21 +584,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -782,21 +603,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -805,21 +622,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -828,21 +641,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -850,31 +659,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -882,31 +680,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -919,19 +706,13 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
-    ]
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -939,23 +720,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -963,30 +740,19 @@ end
 `getelementptr`
 
 """
-function getelementptr(
-    base::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    structIndices,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+function getelementptr(base::Value, indices::Vector{Value}; res::IR.Type, structIndices, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("structIndices", structIndices),]
+    attributes = NamedAttribute[namedattribute("structIndices", structIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1017,19 +783,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1057,19 +817,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1170,50 +924,26 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1222,21 +952,17 @@ end
 
 """
 function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1250,42 +976,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1293,24 +1000,18 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value, value::Value, position::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[vector, value, position]
+function insertelement(vector::Value, value::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1318,24 +1019,18 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value, value::Value; res::IR.Type, position, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[container, value]
+function insertvalue(container::Value, value::Value; res::IR.Type, position, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1344,21 +1039,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1366,38 +1057,20 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1430,39 +1103,24 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1470,25 +1128,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1496,25 +1148,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1522,41 +1168,24 @@ end
 `load`
 
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1575,19 +1204,15 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1595,25 +1220,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1636,21 +1255,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1658,25 +1273,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1685,21 +1294,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1709,20 +1314,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1732,20 +1333,16 @@ end
 """
 function return_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1753,25 +1350,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1780,21 +1371,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1803,21 +1390,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1825,25 +1408,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1851,29 +1428,19 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1881,25 +1448,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1908,21 +1469,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1930,41 +1487,24 @@ end
 `store`
 
 """
-function store(
-    value::Value,
-    addr::Value;
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1972,25 +1512,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1998,40 +1532,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2040,21 +1555,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2062,25 +1573,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2089,21 +1594,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2111,25 +1612,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2149,21 +1644,17 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2177,16 +1668,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2194,25 +1681,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2221,21 +1702,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Linalg.jl
+++ b/src/Dialects/15/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `index`
@@ -41,19 +41,23 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim), ]
+    attributes = NamedAttribute[namedattribute("dim", dim),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "linalg.index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -68,18 +72,24 @@ specified shape in IR and make it available to other transformations.
 Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
-function init_tensor(sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sizes..., ]
+function init_tensor(
+    sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[sizes...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes), ]
-    
-    IR.create_operation(
-        "linalg.init_tensor", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes),]
+
+    return IR.create_operation(
+        "linalg.init_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -98,22 +108,26 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values..., ]
+    operands = Value[values...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "linalg.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `batch_matmul`
@@ -121,19 +135,29 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -143,19 +167,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matvec(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matvec", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matvec",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -165,21 +199,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d_nwc_wcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_1d_nwc_wcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_1d_nwc_wcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -189,19 +235,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_1d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_1d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -215,21 +271,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nchw_fchw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nchw_fchw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nchw_fchw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -243,21 +311,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_ngchw_fgchw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -271,21 +351,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_fhwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -299,21 +391,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_hwcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -328,21 +432,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_hwcf_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -352,19 +468,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_2d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -374,21 +500,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d_ndhwc_dhwcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -398,19 +536,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_3d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_3d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -420,20 +568,31 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function copy(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -444,21 +603,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_nwc_wc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -468,21 +639,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_nwc_wcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -493,21 +676,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nchw_chw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -518,21 +713,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -542,21 +749,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwc_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -566,21 +785,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -590,21 +821,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwcm_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -615,21 +858,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ndhwc_dhwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -639,21 +894,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ndhwc_dhwcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -663,19 +930,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function dot(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.dot", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.dot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -685,21 +962,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function elemwise_binary(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    fun=nothing,
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.elemwise_binary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.elemwise_binary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -709,21 +998,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function elemwise_unary(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    fun=nothing,
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.elemwise_unary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.elemwise_unary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -734,19 +1035,29 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function fill(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.fill", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.fill",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -761,19 +1072,29 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function fill_rng_2d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.fill_rng_2d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.fill_rng_2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -876,21 +1197,39 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function generic(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    indexing_maps,
+    iterator_types,
+    doc=nothing,
+    library_call=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    attributes = NamedAttribute[
+        namedattribute("indexing_maps", indexing_maps),
+        namedattribute("iterator_types", iterator_types),
+    ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
-    
-    IR.create_operation(
-        "linalg.generic", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(library_call) &&
+        push!(attributes, namedattribute("library_call", library_call))
+
+    return IR.create_operation(
+        "linalg.generic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -900,20 +1239,31 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.matmul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -923,19 +1273,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.matmul_unsigned", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.matmul_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -945,19 +1305,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matvec(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.matvec", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.matvec",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -972,19 +1342,29 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function mmt4d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.mmt4d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.mmt4d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -994,21 +1374,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nchw_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nchw_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nchw_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1022,21 +1414,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nchw_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nchw_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nchw_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1046,21 +1450,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1070,21 +1486,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1094,21 +1522,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1118,21 +1558,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1142,21 +1594,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_max_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1166,21 +1630,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1190,21 +1666,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_min_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1218,21 +1706,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1244,19 +1744,29 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function quantized_batch_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.quantized_batch_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.quantized_batch_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1268,19 +1778,29 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function quantized_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.quantized_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.quantized_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1290,19 +1810,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function vecmat(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.vecmat", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.vecmat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Linalg.jl
+++ b/src/Dialects/15/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `index`
@@ -41,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -72,24 +68,18 @@ specified shape in IR and make it available to other transformations.
 Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
-function init_tensor(
-    sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[sizes...,]
+function init_tensor(sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sizes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes),]
-
-    return IR.create_operation(
-        "linalg.init_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes), ]
+    
+    IR.create_operation(
+        "linalg.init_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -108,26 +98,22 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `batch_matmul`
@@ -135,29 +121,19 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,29 +143,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,33 +165,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,29 +189,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -271,33 +215,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -311,33 +243,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -351,33 +271,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -391,33 +299,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,33 +328,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,29 +352,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -500,33 +374,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -536,29 +398,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -568,31 +420,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -603,33 +444,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -639,33 +468,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -676,33 +493,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -713,33 +518,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -749,33 +542,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -785,33 +566,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,33 +590,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -858,33 +615,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,33 +639,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -930,29 +663,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -962,33 +685,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -998,33 +709,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1035,29 +734,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1072,29 +761,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1197,39 +876,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1239,31 +900,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1273,29 +923,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1305,29 +945,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1342,29 +972,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1374,33 +994,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,33 +1022,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1450,33 +1046,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1486,33 +1070,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1522,33 +1094,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1558,33 +1118,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1594,33 +1142,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1630,33 +1166,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1666,33 +1190,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1706,33 +1218,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1744,29 +1244,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1778,29 +1268,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1810,29 +1290,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Linalg.jl
+++ b/src/Dialects/15/Linalg.jl
@@ -1,9 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `index`
@@ -42,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -73,24 +68,18 @@ specified shape in IR and make it available to other transformations.
 Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
-function init_tensor(
-    sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[sizes...,]
+function init_tensor(sizes::Vector{Value}; result::IR.Type, static_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sizes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes),]
-
-    return IR.create_operation(
-        "linalg.init_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_sizes", static_sizes), ]
+    
+    IR.create_operation(
+        "linalg.init_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -109,27 +98,22 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `batch_matmul`
@@ -137,29 +121,19 @@ import ...API
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +143,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -201,33 +165,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -237,29 +189,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,33 +215,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -313,33 +243,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -353,33 +271,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -393,33 +299,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -434,33 +328,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,29 +352,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,33 +374,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -538,29 +398,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -570,31 +420,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,33 +444,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,33 +468,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -678,33 +493,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -715,33 +518,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -751,33 +542,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -787,33 +566,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -823,33 +590,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -860,33 +615,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -896,33 +639,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -932,29 +663,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -964,33 +685,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1000,33 +709,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1037,29 +734,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1074,29 +761,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1199,39 +876,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1241,31 +900,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1275,29 +923,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1307,29 +945,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1344,29 +972,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1376,33 +994,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1416,33 +1022,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1452,33 +1046,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1488,33 +1070,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1524,33 +1094,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1560,33 +1118,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1596,33 +1142,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1632,33 +1166,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1668,33 +1190,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1708,33 +1218,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1746,29 +1244,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1780,29 +1268,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1812,29 +1290,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/MLProgram.jl
+++ b/src/Dialects/15/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `func`
@@ -24,19 +24,28 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
+function func(;
+    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.func", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -55,17 +64,21 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load_const", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load_const",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -89,18 +102,28 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
-    results = IR.Type[result, produceToken, ]
-    operands = Value[consumeTokens..., ]
+function global_load_graph(
+    consumeTokens::Vector{Value};
+    result::IR.Type,
+    produceToken::IR.Type,
+    global_,
+    location=Location(),
+)
+    results = IR.Type[result, produceToken]
+    operands = Value[consumeTokens...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load_graph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load_graph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -125,17 +148,21 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -169,21 +196,35 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
+function global_(;
+    sym_name,
+    type,
+    is_mutable=nothing,
+    value=nothing,
+    sym_visibility=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.global", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -207,18 +248,28 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
-    results = IR.Type[produceToken, ]
-    operands = Value[value, consumeTokens..., ]
+function global_store_graph(
+    value::Value,
+    consumeTokens::Vector{Value};
+    produceToken::IR.Type,
+    global_,
+    location=Location(),
+)
+    results = IR.Type[produceToken,]
+    operands = Value[value, consumeTokens...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_store_graph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_store_graph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -244,16 +295,20 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_store", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -266,18 +321,22 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands_::Vector{Value}; location=Location())
+function output(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.output", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.output",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -290,18 +349,22 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -325,19 +388,28 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
+function subgraph(;
+    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.subgraph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.subgraph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -348,17 +420,21 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token, ]
+    results = IR.Type[token,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.token", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.token",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/MLProgram.jl
+++ b/src/Dialects/15/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `func`
@@ -24,28 +24,19 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function func(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,21 +55,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,28 +89,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,21 +125,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -196,35 +169,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,28 +207,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -295,20 +244,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -321,22 +266,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -349,22 +290,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,28 +325,19 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function subgraph(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -420,21 +348,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/MLProgram.jl
+++ b/src/Dialects/15/MLProgram.jl
@@ -1,9 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `func`
@@ -25,28 +24,19 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function func(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,21 +55,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -103,28 +89,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,21 +125,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -197,35 +169,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -249,28 +207,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -296,20 +244,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -322,22 +266,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -350,22 +290,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -389,28 +325,19 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function subgraph(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -421,21 +348,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Math.jl
+++ b/src/Dialects/15/Math.jl
@@ -1,9 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -19,23 +18,19 @@ the same type.
 %a = math.abs %b : f64
 ```
 """
-function abs(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -66,25 +61,19 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -108,23 +97,19 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -148,23 +133,19 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -189,25 +170,19 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -231,23 +206,19 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -264,23 +235,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -297,23 +264,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -330,23 +293,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -370,23 +329,19 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -410,23 +365,19 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -452,23 +403,19 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -492,23 +439,19 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -532,23 +475,19 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64 
 ```
 """
-function floor(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -577,29 +516,19 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -617,23 +546,19 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -653,23 +578,19 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -687,23 +608,19 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -721,23 +638,19 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -761,25 +674,19 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -806,23 +713,19 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -840,23 +743,19 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -880,23 +779,19 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -914,23 +809,19 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -948,23 +839,19 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -982,23 +869,19 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/15/Math.jl
+++ b/src/Dialects/15/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -18,23 +18,19 @@ the same type.
 %a = math.abs %b : f64
 ```
 """
-function abs(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -65,25 +61,19 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -107,23 +97,19 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -147,23 +133,19 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -188,25 +170,19 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -230,23 +206,19 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -263,23 +235,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -296,23 +264,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -329,23 +293,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -369,23 +329,19 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -409,23 +365,19 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -451,23 +403,19 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -491,23 +439,19 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,23 +475,19 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64 
 ```
 """
-function floor(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -576,29 +516,19 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -616,23 +546,19 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -652,23 +578,19 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -686,23 +608,19 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -720,23 +638,19 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,25 +674,19 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -805,23 +713,19 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -839,23 +743,19 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -879,23 +779,19 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -913,23 +809,19 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -947,23 +839,19 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -981,23 +869,19 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/15/Math.jl
+++ b/src/Dialects/15/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -18,19 +18,23 @@ the same type.
 %a = math.abs %b : f64
 ```
 """
-function abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function abs(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -61,19 +65,25 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function atan2(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.atan2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.atan2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -97,19 +107,23 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function atan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.atan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.atan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -133,19 +147,23 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceil(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -170,19 +188,25 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function copysign(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.copysign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.copysign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -206,19 +230,23 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -235,19 +263,23 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ctlz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ctlz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -264,19 +296,23 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.cttz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cttz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -293,19 +329,23 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ctpop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ctpop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -329,19 +369,23 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -365,19 +409,23 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function exp2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.exp2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.exp2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -403,19 +451,23 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function expm1(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.expm1", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.expm1",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -439,19 +491,23 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -475,19 +531,23 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64 
 ```
 """
-function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function floor(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -516,19 +576,29 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function fma(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -546,19 +616,23 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log10(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.log10", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log10",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -578,19 +652,23 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log1p(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.log1p", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log1p",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -608,19 +686,23 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log2(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.log2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -638,19 +720,23 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -674,19 +760,25 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function powf(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.powf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.powf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -713,19 +805,23 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function round(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -743,19 +839,23 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function rsqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -779,19 +879,23 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -809,19 +913,23 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sqrt(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -839,19 +947,23 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -869,19 +981,23 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tanh(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/15/MemRef.jl
+++ b/src/Dialects/15/MemRef.jl
@@ -1,9 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assume_alignment`
@@ -17,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -51,29 +46,18 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value, memref, indices...]
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result::IR.Type, kind, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -85,20 +69,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,20 +98,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,28 +135,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -223,21 +189,17 @@ techniques. This is possible because of the
 in these contexts.
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -282,30 +244,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,30 +298,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,22 +349,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -438,22 +376,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -514,21 +448,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -576,21 +506,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -611,20 +537,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -654,21 +576,17 @@ The specified memref type is that of the first operand.
 ```
 """
 function dim(source::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, index]
+    results = IR.Type[result, ]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -719,22 +637,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -758,24 +672,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -822,21 +730,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -855,21 +759,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -911,38 +811,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -964,33 +848,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1007,21 +876,17 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 ```
 """
 function rank(memref::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[memref,]
+    results = IR.Type[result_0, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1045,40 +910,19 @@ memref.reinterpret_cast %unranked to
 : memref<*xf32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1118,21 +962,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1168,20 +1008,16 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1199,21 +1035,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1255,28 +1087,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1415,40 +1237,19 @@ Example 5:
 ```
 }
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1469,20 +1270,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/MemRef.jl
+++ b/src/Dialects/15/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assume_alignment`
@@ -16,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -50,29 +46,18 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value, memref, indices...]
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result::IR.Type, kind, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -84,20 +69,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -117,20 +98,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -158,28 +135,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,21 +189,17 @@ techniques. This is possible because of the
 in these contexts.
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -281,30 +244,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -345,30 +298,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -406,22 +349,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,22 +376,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -513,21 +448,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -575,21 +506,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -610,20 +537,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -653,21 +576,17 @@ The specified memref type is that of the first operand.
 ```
 """
 function dim(source::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, index]
+    results = IR.Type[result, ]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -718,22 +637,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -757,24 +672,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,21 +730,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -854,21 +759,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -910,38 +811,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -963,33 +848,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1006,21 +876,17 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 ```
 """
 function rank(memref::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[memref,]
+    results = IR.Type[result_0, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1044,40 +910,19 @@ memref.reinterpret_cast %unranked to
 : memref<*xf32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1117,21 +962,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1167,20 +1008,16 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1198,21 +1035,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1254,28 +1087,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,40 +1237,19 @@ Example 5:
 ```
 }
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1468,20 +1270,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/MemRef.jl
+++ b/src/Dialects/15/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `assume_alignment`
@@ -16,16 +16,20 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
-    
-    IR.create_operation(
-        "memref.assume_alignment", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment),]
+
+    return IR.create_operation(
+        "memref.assume_alignment",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -46,18 +50,29 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result::IR.Type, kind, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, memref, indices..., ]
+function atomic_rmw(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    kind,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), ]
-    
-    IR.create_operation(
-        "memref.atomic_rmw", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("kind", kind),]
+
+    return IR.create_operation(
+        "memref.atomic_rmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,16 +84,20 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.atomic_yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.atomic_yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -98,16 +117,20 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target, ]
+    operands = Value[source, target]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -135,18 +158,28 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
-    owned_regions = Region[atomic_body, ]
+function generic_atomic_rmw(
+    memref::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    atomic_body::Region,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
+    owned_regions = Region[atomic_body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.generic_atomic_rmw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.generic_atomic_rmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -189,17 +222,21 @@ techniques. This is possible because of the
 in these contexts.
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -244,20 +281,30 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[dynamicSizes..., symbolOperands..., ]
+function alloc(
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.alloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -298,20 +345,30 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[dynamicSizes..., symbolOperands..., ]
+function alloca(
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.alloca", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -349,18 +406,22 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
+function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.alloca_scope", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca_scope",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -376,18 +437,22 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results_::Vector{Value}; location=Location())
+function alloca_scope_return(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.alloca_scope.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca_scope.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -448,17 +513,21 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -506,17 +575,21 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "memref.collapse_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "memref.collapse_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -537,16 +610,20 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -576,17 +653,21 @@ The specified memref type is that of the first operand.
 ```
 """
 function dim(source::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, index, ]
+    results = IR.Type[result,]
+    operands = Value[source, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -637,18 +718,22 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands_::Vector{Value}; location=Location())
+function dma_start(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dma_start", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dma_start",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -672,18 +757,24 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
+function dma_wait(
+    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
+)
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements, ]
+    operands = Value[tagMemRef, tagIndices..., numElements]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dma_wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dma_wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -730,17 +821,21 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "memref.expand_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "memref.expand_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -759,17 +854,21 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "memref.get_global", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "memref.get_global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -811,22 +910,38 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
+function global_(;
+    sym_name,
+    sym_visibility=nothing,
+    type,
+    initial_value=nothing,
+    constant=nothing,
+    alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) &&
+        push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.global", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -848,18 +963,33 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
+function prefetch(
+    memref::Value,
+    indices::Vector{Value};
+    isWrite,
+    localityHint,
+    isDataCache,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memref, indices..., ]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
-    
-    IR.create_operation(
-        "memref.prefetch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("isWrite", isWrite),
+        namedattribute("localityHint", localityHint),
+        namedattribute("isDataCache", isDataCache),
+    ]
+
+    return IR.create_operation(
+        "memref.prefetch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -876,17 +1006,21 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 ```
 """
 function rank(memref::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[memref, ]
+    results = IR.Type[result_0,]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -910,19 +1044,40 @@ memref.reinterpret_cast %unranked to
 : memref<*xf32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function reinterpret_cast(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "memref.reinterpret_cast", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "memref.reinterpret_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -962,17 +1117,21 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, shape, ]
+    results = IR.Type[result,]
+    operands = Value[source, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1008,16 +1167,20 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1035,17 +1198,21 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[in, ]
+    results = IR.Type[result_0,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
-    
-    IR.create_operation(
-        "memref.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation),]
+
+    return IR.create_operation(
+        "memref.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1087,18 +1254,28 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[source, byte_shift, sizes..., ]
+function view(
+    source::Value,
+    byte_shift::Value,
+    sizes::Vector{Value};
+    result_0::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[source, byte_shift, sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.view", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.view",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1237,19 +1414,40 @@ Example 5:
 ```
 }
 """
-function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function subview(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "memref.subview", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "memref.subview",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1270,16 +1468,20 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref, ]
+    operands = Value[tensor, memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.tensor_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.tensor_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/NVGPU.jl
+++ b/src/Dialects/15/NVGPU.jl
@@ -1,8 +1,8 @@
 module nvgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `device_async_copy`
@@ -46,33 +46,20 @@ gpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(
-    dst::Value,
-    dstIndices::Vector{Value},
-    src::Value,
-    srcIndices::Vector{Value};
-    asyncToken::IR.Type,
-    numElements,
-    bypassL1=nothing,
-    location=Location(),
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[dst, dstIndices..., src, srcIndices...]
+function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}; asyncToken::IR.Type, numElements, bypassL1=nothing, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[dst, dstIndices..., src, srcIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("numElements", numElements),]
-    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices)]))
+    attributes = NamedAttribute[namedattribute("numElements", numElements), ]
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), ]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-
-    return IR.create_operation(
-        "nvgpu.device_async_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,24 +83,18 @@ Groups are executed in the order they are created.
 %0 = gpu.device_async_create_group
 ```
 """
-function device_async_create_group(
-    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[inputTokens...,]
+function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[inputTokens..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.device_async_create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_create_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -133,21 +114,17 @@ gpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies,]
+    operands = Value[asyncDependencies, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-
-    return IR.create_operation(
-        "nvgpu.device_async_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,31 +146,18 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    transpose,
-    numTiles,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
-    ]
-
-    return IR.create_operation(
-        "nvgpu.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
+    
+    IR.create_operation(
+        "nvgpu.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,29 +184,18 @@ nvgpu.mma.sync (%a, %b, %c) :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value;
-    res::IR.Type,
-    mmaShape,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC]
+function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
-
-    return IR.create_operation(
-        "nvgpu.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    
+    IR.create_operation(
+        "nvgpu.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/NVGPU.jl
+++ b/src/Dialects/15/NVGPU.jl
@@ -1,9 +1,8 @@
 module nvgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `device_async_copy`
@@ -47,33 +46,20 @@ gpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(
-    dst::Value,
-    dstIndices::Vector{Value},
-    src::Value,
-    srcIndices::Vector{Value};
-    asyncToken::IR.Type,
-    numElements,
-    bypassL1=nothing,
-    location=Location(),
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[dst, dstIndices..., src, srcIndices...]
+function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}; asyncToken::IR.Type, numElements, bypassL1=nothing, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[dst, dstIndices..., src, srcIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("numElements", numElements),]
-    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices)]))
+    attributes = NamedAttribute[namedattribute("numElements", numElements), ]
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), ]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-
-    return IR.create_operation(
-        "nvgpu.device_async_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,24 +83,18 @@ Groups are executed in the order they are created.
 %0 = gpu.device_async_create_group
 ```
 """
-function device_async_create_group(
-    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[inputTokens...,]
+function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[inputTokens..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.device_async_create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_create_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -134,21 +114,17 @@ gpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies,]
+    operands = Value[asyncDependencies, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-
-    return IR.create_operation(
-        "nvgpu.device_async_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -170,31 +146,18 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    transpose,
-    numTiles,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
-    ]
-
-    return IR.create_operation(
-        "nvgpu.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
+    
+    IR.create_operation(
+        "nvgpu.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,29 +184,18 @@ nvgpu.mma.sync (%a, %b, %c) :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value;
-    res::IR.Type,
-    mmaShape,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC]
+function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
-
-    return IR.create_operation(
-        "nvgpu.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    
+    IR.create_operation(
+        "nvgpu.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/NVGPU.jl
+++ b/src/Dialects/15/NVGPU.jl
@@ -1,8 +1,8 @@
 module nvgpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `device_async_copy`
@@ -46,20 +46,33 @@ gpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}; asyncToken::IR.Type, numElements, bypassL1=nothing, location=Location())
-    results = IR.Type[asyncToken, ]
-    operands = Value[dst, dstIndices..., src, srcIndices..., ]
+function device_async_copy(
+    dst::Value,
+    dstIndices::Vector{Value},
+    src::Value,
+    srcIndices::Vector{Value};
+    asyncToken::IR.Type,
+    numElements,
+    bypassL1=nothing,
+    location=Location(),
+)
+    results = IR.Type[asyncToken,]
+    operands = Value[dst, dstIndices..., src, srcIndices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("numElements", numElements), ]
-    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), ]))
+    attributes = NamedAttribute[namedattribute("numElements", numElements),]
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices)]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-    
-    IR.create_operation(
-        "nvgpu.device_async_copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -83,18 +96,24 @@ Groups are executed in the order they are created.
 %0 = gpu.device_async_create_group
 ```
 """
-function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
-    results = IR.Type[asyncToken, ]
-    operands = Value[inputTokens..., ]
+function device_async_create_group(
+    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
+)
+    results = IR.Type[asyncToken,]
+    operands = Value[inputTokens...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.device_async_create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -114,17 +133,21 @@ gpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies, ]
+    operands = Value[asyncDependencies,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-    
-    IR.create_operation(
-        "nvgpu.device_async_wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -146,18 +169,31 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[srcMemref, indices..., ]
+function ldmatrix(
+    srcMemref::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    transpose,
+    numTiles,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[srcMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
-    
-    IR.create_operation(
-        "nvgpu.ldmatrix", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
+    ]
+
+    return IR.create_operation(
+        "nvgpu.ldmatrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -184,18 +220,29 @@ nvgpu.mma.sync (%a, %b, %c) :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrixA, matrixB, matrixC, ]
+function mma_sync(
+    matrixA::Value,
+    matrixB::Value,
+    matrixC::Value;
+    res::IR.Type,
+    mmaShape,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[matrixA, matrixB, matrixC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
-    
-    IR.create_operation(
-        "nvgpu.mma.sync", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+
+    return IR.create_operation(
+        "nvgpu.mma.sync",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/OpenACC.jl
+++ b/src/Dialects/15/OpenACC.jl
@@ -1,8 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `data`
@@ -22,68 +22,21 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    deviceptrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        deviceptrOperands...,
-        attachOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (ifCond == nothing) ? 0 : 1length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(deviceptrOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,63 +51,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        copyinOperands...,
-        createOperands...,
-        createZeroOperands...,
-        attachOperands...,
-    ]
+    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyinOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,59 +83,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    deleteOperands::Vector{Value},
-    detachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
-    ]
+    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyoutOperands),
-            length(deleteOperands),
-            length(detachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,42 +118,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,68 +156,29 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    reductionOp=nothing,
-    exec_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) &&
-        push!(attributes, namedattribute("exec_mapping", exec_mapping))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,55 +197,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs=nothing::Union{Nothing,Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    devicePtrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionOp=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        devicePtrOperands...,
-        attachOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -434,53 +209,18 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (numGangs == nothing)
-                0
-            elseif 1(numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(devicePtrOperands),
-            length(attachOperands),
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -497,42 +237,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -550,16 +269,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -577,59 +292,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    hostOperands::Vector{Value},
-    deviceOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
-    ]
+    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(hostOperands),
-            length(deviceOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,48 +327,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -698,22 +354,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/OpenACC.jl
+++ b/src/Dialects/15/OpenACC.jl
@@ -1,8 +1,8 @@
 module acc
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `data`
@@ -22,21 +22,68 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
+function data(
+    ifCond=nothing::Union{Nothing,Value};
+    copyOperands::Vector{Value},
+    copyinOperands::Vector{Value},
+    copyinReadonlyOperands::Vector{Value},
+    copyoutOperands::Vector{Value},
+    copyoutZeroOperands::Vector{Value},
+    createOperands::Vector{Value},
+    createZeroOperands::Vector{Value},
+    noCreateOperands::Vector{Value},
+    presentOperands::Vector{Value},
+    deviceptrOperands::Vector{Value},
+    attachOperands::Vector{Value},
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        copyOperands...,
+        copyinOperands...,
+        copyinReadonlyOperands...,
+        copyoutOperands...,
+        copyoutZeroOperands...,
+        createOperands...,
+        createZeroOperands...,
+        noCreateOperands...,
+        presentOperands...,
+        deviceptrOperands...,
+        attachOperands...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (ifCond == nothing) ? 0 : 1length(copyOperands),
+            length(copyinOperands),
+            length(copyinReadonlyOperands),
+            length(copyoutOperands),
+            length(copyoutZeroOperands),
+            length(createOperands),
+            length(createZeroOperands),
+            length(noCreateOperands),
+            length(presentOperands),
+            length(deviceptrOperands),
+            length(attachOperands),
+        ]),
+    )
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -51,24 +98,63 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
+function enter_data(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    copyinOperands::Vector{Value},
+    createOperands::Vector{Value},
+    createZeroOperands::Vector{Value},
+    attachOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
+    operands = Value[
+        waitOperands...,
+        copyinOperands...,
+        createOperands...,
+        createZeroOperands...,
+        attachOperands...,
+    ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(copyinOperands),
+            length(createOperands),
+            length(createZeroOperands),
+            length(attachOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-    
-    IR.create_operation(
-        "acc.enter_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.enter_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -83,25 +169,59 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
+function exit_data(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    copyoutOperands::Vector{Value},
+    deleteOperands::Vector{Value},
+    detachOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    finalize=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
+    operands = Value[
+        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
+    ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(copyoutOperands),
+            length(deleteOperands),
+            length(detachOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-    
-    IR.create_operation(
-        "acc.exit_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.exit_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -118,21 +238,42 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
+function init(
+    deviceTypeOperands::Vector{Value},
+    deviceNumOperand=nothing::Union{Nothing,Value};
+    ifCond=nothing::Union{Nothing,Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[deviceTypeOperands..., ]
+    operands = Value[deviceTypeOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
-    
-    IR.create_operation(
-        "acc.init", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(deviceTypeOperands),
+            if (deviceNumOperand == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+
+    return IR.create_operation(
+        "acc.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -156,29 +297,68 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
-    owned_regions = Region[region, ]
+function loop(
+    gangNum=nothing::Union{Nothing,Value};
+    gangStatic=nothing::Union{Nothing,Value},
+    workerNum=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    tileOperands::Vector{Value},
+    privateOperands::Vector{Value},
+    reductionOperands::Vector{Value},
+    results::Vector{IR.Type},
+    collapse=nothing,
+    seq=nothing,
+    independent=nothing,
+    auto_=nothing,
+    reductionOp=nothing,
+    exec_mapping=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (gangNum == nothing)
+                0
+            elseif 1(gangStatic == nothing)
+                0
+            elseif 1(workerNum == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            else
+                1length(tileOperands)
+            end,
+            length(privateOperands),
+            length(reductionOperands),
+        ]),
+    )
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
-    
-    IR.create_operation(
-        "acc.loop", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(exec_mapping) &&
+        push!(attributes, namedattribute("exec_mapping", exec_mapping))
+
+    return IR.create_operation(
+        "acc.loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -197,10 +377,55 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
+function parallel(
+    async=nothing::Union{Nothing,Value};
+    waitOperands::Vector{Value},
+    numGangs=nothing::Union{Nothing,Value},
+    numWorkers=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    selfCond=nothing::Union{Nothing,Value},
+    reductionOperands::Vector{Value},
+    copyOperands::Vector{Value},
+    copyinOperands::Vector{Value},
+    copyinReadonlyOperands::Vector{Value},
+    copyoutOperands::Vector{Value},
+    copyoutZeroOperands::Vector{Value},
+    createOperands::Vector{Value},
+    createZeroOperands::Vector{Value},
+    noCreateOperands::Vector{Value},
+    presentOperands::Vector{Value},
+    devicePtrOperands::Vector{Value},
+    attachOperands::Vector{Value},
+    gangPrivateOperands::Vector{Value},
+    gangFirstPrivateOperands::Vector{Value},
+    asyncAttr=nothing,
+    waitAttr=nothing,
+    selfAttr=nothing,
+    reductionOp=nothing,
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        waitOperands...,
+        reductionOperands...,
+        copyOperands...,
+        copyinOperands...,
+        copyinReadonlyOperands...,
+        copyoutOperands...,
+        copyoutZeroOperands...,
+        createOperands...,
+        createZeroOperands...,
+        noCreateOperands...,
+        presentOperands...,
+        devicePtrOperands...,
+        attachOperands...,
+        gangPrivateOperands...,
+        gangFirstPrivateOperands...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -209,18 +434,53 @@ function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Val
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (async == nothing) ? 0 : 1length(waitOperands),
+            if (numGangs == nothing)
+                0
+            elseif 1(numWorkers == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            elseif 1(selfCond == nothing)
+                0
+            else
+                1length(reductionOperands)
+            end,
+            length(copyOperands),
+            length(copyinOperands),
+            length(copyinReadonlyOperands),
+            length(copyoutOperands),
+            length(copyoutZeroOperands),
+            length(createOperands),
+            length(createZeroOperands),
+            length(noCreateOperands),
+            length(presentOperands),
+            length(devicePtrOperands),
+            length(attachOperands),
+            length(gangPrivateOperands),
+            length(gangFirstPrivateOperands),
+        ]),
+    )
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.parallel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -237,21 +497,42 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
+function shutdown(
+    deviceTypeOperands::Vector{Value},
+    deviceNumOperand=nothing::Union{Nothing,Value};
+    ifCond=nothing::Union{Nothing,Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[deviceTypeOperands..., ]
+    operands = Value[deviceTypeOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
-    
-    IR.create_operation(
-        "acc.shutdown", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(deviceTypeOperands),
+            if (deviceNumOperand == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+
+    return IR.create_operation(
+        "acc.shutdown",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -269,12 +550,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -292,25 +577,59 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
+function update(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    deviceTypeOperands::Vector{Value},
+    hostOperands::Vector{Value},
+    deviceOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    ifPresent=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
+    operands = Value[
+        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
+    ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(deviceTypeOperands),
+            length(hostOperands),
+            length(deviceOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-    
-    IR.create_operation(
-        "acc.update", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.update",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,23 +646,48 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
+function wait(
+    waitOperands::Vector{Value},
+    asyncOperand=nothing::Union{Nothing,Value};
+    waitDevnum=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    async=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., ]
+    operands = Value[waitOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(waitOperands),
+            if (asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-    
-    IR.create_operation(
-        "acc.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -354,18 +698,22 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/OpenACC.jl
+++ b/src/Dialects/15/OpenACC.jl
@@ -1,9 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `data`
@@ -23,68 +22,21 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    deviceptrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        deviceptrOperands...,
-        attachOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (ifCond == nothing) ? 0 : 1length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(deviceptrOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -99,63 +51,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        copyinOperands...,
-        createOperands...,
-        createZeroOperands...,
-        attachOperands...,
-    ]
+    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyinOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -170,59 +83,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    deleteOperands::Vector{Value},
-    detachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
-    ]
+    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyoutOperands),
-            length(deleteOperands),
-            length(detachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -239,42 +118,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -298,68 +156,29 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    reductionOp=nothing,
-    exec_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) &&
-        push!(attributes, namedattribute("exec_mapping", exec_mapping))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,55 +197,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs=nothing::Union{Nothing,Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    devicePtrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionOp=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        devicePtrOperands...,
-        attachOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -435,53 +209,18 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (numGangs == nothing)
-                0
-            elseif 1(numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(devicePtrOperands),
-            length(attachOperands),
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -498,42 +237,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -551,16 +269,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,59 +292,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    hostOperands::Vector{Value},
-    deviceOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
-    ]
+    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(hostOperands),
-            length(deviceOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -647,48 +327,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -699,22 +354,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/OpenMP.jl
+++ b/src/Dialects/15/OpenMP.jl
@@ -1,9 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `atomic_capture`
@@ -38,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,27 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
-)
+function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -131,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -176,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -216,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -412,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -454,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -503,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -576,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -614,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -684,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -743,41 +589,21 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step...]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            (if_expr == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -790,30 +616,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -837,44 +653,23 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        elseif 1(thread_limit == nothing)
-            0
-        else
-            1
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -902,37 +697,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1034,39 +812,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1074,48 +823,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1161,55 +881,25 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1225,16 +915,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1250,16 +936,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1277,16 +959,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1309,21 +987,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1388,71 +1062,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1463,22 +1094,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/OpenMP.jl
+++ b/src/Dialects/15/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `atomic_capture`
@@ -37,20 +37,27 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
+function atomic_capture(;
+    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.capture", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.capture",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,20 +76,27 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
+function atomic_read(
+    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, v, ]
+    operands = Value[x, v]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.read", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.read",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -116,20 +130,31 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
+function atomic_update(
+    x::Value;
+    hint_val=nothing,
+    memory_order_val=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
-    owned_regions = Region[region, ]
+    operands = Value[x,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.update", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.update",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -150,20 +175,31 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
+function atomic_write(
+    address::Value,
+    value::Value;
+    hint_val=nothing,
+    memory_order_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[address, value, ]
+    operands = Value[address, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.write", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.write",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -179,12 +215,16 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,19 +234,29 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
+function cancel(
+    if_expr=nothing::Union{Nothing,Value};
+    cancellation_construct_type_val,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    attributes = NamedAttribute[namedattribute(
+        "cancellation_construct_type_val", cancellation_construct_type_val
+    ),]
     !isnothing(if_expr) && push!(operands, if_expr)
-    
-    IR.create_operation(
-        "omp.cancel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.cancel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -222,13 +272,19 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
-    
-    IR.create_operation(
-        "omp.cancellationpoint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute(
+        "cancellation_construct_type_val", cancellation_construct_type_val
+    ),]
+
+    return IR.create_operation(
+        "omp.cancellationpoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -244,14 +300,18 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    
-    IR.create_operation(
-        "omp.critical.declare", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.critical.declare",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -264,16 +324,20 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "omp.critical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.critical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -287,16 +351,20 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList..., ]
+    operands = Value[varList...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.flush", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.flush",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,15 +377,19 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.master", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.master",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -339,20 +411,31 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
+function ordered(
+    depend_vec_vars::Vector{Value};
+    depend_type_val=nothing,
+    num_loops_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[depend_vec_vars..., ]
+    operands = Value[depend_vec_vars...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
-    
-    IR.create_operation(
-        "omp.ordered", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(depend_type_val) &&
+        push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) &&
+        push!(attributes, namedattribute("num_loops_val", num_loops_val))
+
+    return IR.create_operation(
+        "omp.ordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -370,16 +453,20 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-    
-    IR.create_operation(
-        "omp.ordered_region", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.ordered_region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -415,23 +502,51 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
+function parallel(
+    if_expr_var=nothing::Union{Nothing,Value};
+    num_threads_var=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    reductions=nothing,
+    proc_bind_val=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr_var == nothing)
+                0
+            elseif 1(num_threads_var == nothing)
+                0
+            else
+                1length(allocate_vars)
+            end,
+            length(allocators_vars),
+            length(reduction_vars),
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-    
-    IR.create_operation(
-        "omp.parallel", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(proc_bind_val) &&
+        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+
+    return IR.create_operation(
+        "omp.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -460,18 +575,31 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
+function reduction_declare(;
+    sym_name,
+    type,
+    initializerRegion::Region,
+    reductionRegion::Region,
+    atomicReductionRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "omp.reduction.declare", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+
+    return IR.create_operation(
+        "omp.reduction.declare",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -485,16 +613,20 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator, ]
+    operands = Value[operand, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -508,15 +640,19 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.section", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.section",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -547,21 +683,38 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
+function sections(
+    reduction_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    reductions=nothing,
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(reduction_vars), length(allocate_vars), length(allocators_vars)
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.sections", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.sections",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -589,21 +742,41 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; inclusive=nothing, region::Region, location=Location())
+function simdloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    if_expr=nothing::Union{Nothing,Value};
+    inclusive=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., ]
-    owned_regions = Region[region, ]
+    operands = Value[lowerBound..., upperBound..., step...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            (if_expr == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-    
-    IR.create_operation(
-        "omp.simdloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.simdloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -616,20 +789,30 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
+function single(
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.single", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.single",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -653,23 +836,47 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
+function target(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    thread_limit=nothing::Union{Nothing,Value},
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            elseif 1(thread_limit == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.target", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -697,20 +904,37 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
+function taskgroup(
+    task_reduction_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    task_reductions=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
-    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
-    
-    IR.create_operation(
-        "omp.taskgroup", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
+        ]),
+    )
+    !isnothing(task_reductions) &&
+        push!(attributes, namedattribute("task_reductions", task_reductions))
+
+    return IR.create_operation(
+        "omp.taskgroup",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -812,10 +1036,39 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
+function taskloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    if_expr=nothing::Union{Nothing,Value};
+    final_expr=nothing::Union{Nothing,Value},
+    in_reduction_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    priority=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    grain_size=nothing::Union{Nothing,Value},
+    num_tasks=nothing::Union{Nothing,Value},
+    inclusive=nothing,
+    untied=nothing,
+    mergeable=nothing,
+    in_reductions=nothing,
+    reductions=nothing,
+    nogroup=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound...,
+        upperBound...,
+        step...,
+        in_reduction_vars...,
+        reduction_vars...,
+        allocate_vars...,
+        allocators_vars...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -823,19 +1076,48 @@ function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Ve
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            if (if_expr == nothing)
+                0
+            elseif 1(final_expr == nothing)
+                0
+            else
+                1length(in_reduction_vars)
+            end,
+            length(reduction_vars),
+            (priority == nothing) ? 0 : 1length(allocate_vars),
+            length(allocators_vars),
+            if (grain_size == nothing)
+                0
+            elseif 1(num_tasks == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) &&
+        push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-    
-    IR.create_operation(
-        "omp.taskloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -881,25 +1163,55 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
+function task(
+    if_expr=nothing::Union{Nothing,Value};
+    final_expr=nothing::Union{Nothing,Value},
+    in_reduction_vars::Vector{Value},
+    priority=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    untied=nothing,
+    mergeable=nothing,
+    in_reductions=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(final_expr == nothing)
+                0
+            else
+                1length(in_reduction_vars)
+            end,
+            (priority == nothing) ? 0 : 1length(allocate_vars),
+            length(allocators_vars),
+        ]),
+    )
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
-    
-    IR.create_operation(
-        "omp.task", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(in_reductions) &&
+        push!(attributes, namedattribute("in_reductions", in_reductions))
+
+    return IR.create_operation(
+        "omp.task",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -915,12 +1227,16 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.taskwait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskwait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -936,12 +1252,16 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.taskyield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskyield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -959,12 +1279,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -987,17 +1311,21 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr, ]
-    operands = Value[sym_addr, ]
+    results = IR.Type[tls_addr,]
+    operands = Value[sym_addr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.threadprivate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.threadprivate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1062,28 +1390,71 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
+function wsloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    linear_vars::Vector{Value},
+    linear_step_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    schedule_chunk_var=nothing::Union{Nothing,Value};
+    reductions=nothing,
+    schedule_val=nothing,
+    schedule_modifier=nothing,
+    simd_modifier=nothing,
+    nowait=nothing,
+    ordered_val=nothing,
+    order_val=nothing,
+    inclusive=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound...,
+        upperBound...,
+        step...,
+        linear_vars...,
+        linear_step_vars...,
+        reduction_vars...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            length(linear_vars),
+            length(linear_step_vars),
+            length(reduction_vars),
+            (schedule_chunk_var == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) &&
+        push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) &&
+        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) &&
+        push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-    
-    IR.create_operation(
-        "omp.wsloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.wsloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1094,18 +1465,22 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results_::Vector{Value}; location=Location())
+function yield(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/OpenMP.jl
+++ b/src/Dialects/15/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `atomic_capture`
@@ -37,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,27 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
-)
+function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -175,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -215,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -234,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -272,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -300,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -324,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -351,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -411,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -453,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -575,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -613,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -683,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -742,41 +589,21 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step...]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            (if_expr == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -789,30 +616,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -836,47 +653,23 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            elseif 1(thread_limit == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -904,37 +697,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1036,39 +812,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1076,48 +823,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1163,55 +881,25 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1227,16 +915,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1252,16 +936,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1279,16 +959,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1311,21 +987,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1390,71 +1062,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1465,22 +1094,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/PDL.jl
+++ b/src/Dialects/15/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_native_constraint`
@@ -20,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,26 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    type=nothing::Union{Nothing,Value}; attr::IR.Type, value=nothing, location=Location()
-)
-    results = IR.Type[attr,]
+function attribute(type=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,20 +133,16 @@ pdl.erase %root
 """
 function erase(operation::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -187,28 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
-    results = IR.Type[val,]
+function operand(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
+    results = IR.Type[val, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -228,23 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
-    results = IR.Type[val,]
+function operands_(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
+    results = IR.Type[val, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -345,35 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operands::Vector{Value},
-    attributes::Vector{Value},
-    types::Vector{Value};
-    op::IR.Type,
-    name=nothing,
-    attributeNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operands..., attributes..., types...]
+function operation(operands_::Vector{Value}, attributes_::Vector{Value}, types::Vector{Value}; op::IR.Type, name=nothing, attributeNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operands_..., attributes_..., types..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([length(operands), length(attributes), length(types)]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames), ]
+    push!(attributes, operandsegmentsizes([length(operands), length(attributes), length(types), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -404,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -446,32 +399,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    operation::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(operation::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[operation, replValues...]
+    operands = Value[operation, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -498,26 +439,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -545,23 +482,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,31 +537,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    body::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[body,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -651,22 +574,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, type=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(attributes, namedattribute("type", type))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -689,22 +608,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, types=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(types) && push!(attributes, namedattribute("types", types))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/PDL.jl
+++ b/src/Dialects/15/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_native_constraint`
@@ -20,16 +20,20 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl.apply_native_constraint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl.apply_native_constraint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -61,18 +65,24 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[args..., ]
+function apply_native_rewrite(
+    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl.apply_native_rewrite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl.apply_native_rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -101,20 +111,26 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(type=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
-    results = IR.Type[attr, ]
+function attribute(
+    type=nothing::Union{Nothing,Value}; attr::IR.Type, value=nothing, location=Location()
+)
+    results = IR.Type[attr,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    
-    IR.create_operation(
-        "pdl.attribute", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -133,16 +149,20 @@ pdl.erase %root
 """
 function erase(operation::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operation, ]
+    operands = Value[operation,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl.erase", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.erase",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -167,24 +187,28 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
-    results = IR.Type[val, ]
+function operand(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
+    results = IR.Type[val,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-    
-    IR.create_operation(
-        "pdl.operand", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`operands_`
+`operands`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -204,19 +228,23 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands_(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
-    results = IR.Type[val, ]
+function operands(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
+    results = IR.Type[val,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-    
-    IR.create_operation(
-        "pdl.operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,20 +345,35 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(operands_::Vector{Value}, attributes_::Vector{Value}, types::Vector{Value}; op::IR.Type, name=nothing, attributeNames, location=Location())
-    results = IR.Type[op, ]
-    operands = Value[operands_..., attributes_..., types..., ]
+function operation(
+    operands::Vector{Value},
+    attributes::Vector{Value},
+    types::Vector{Value};
+    op::IR.Type,
+    name=nothing,
+    attributeNames,
+    location=Location(),
+)
+    results = IR.Type[op,]
+    operands = Value[operands..., attributes..., types...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames), ]
-    push!(attributes, operandsegmentsizes([length(operands), length(attributes), length(types), ]))
+    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames),]
+    push!(
+        attributes,
+        operandsegmentsizes([length(operands), length(attributes), length(types)]),
+    )
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "pdl.operation", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -361,16 +404,20 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
+    attributes = NamedAttribute[namedattribute("benefit", benefit),]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    
-    IR.create_operation(
-        "pdl.pattern", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.pattern",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -399,20 +446,32 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(operation::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
+function replace(
+    operation::Value,
+    replOperation=nothing::Union{Nothing,Value};
+    replValues::Vector{Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operation, replValues..., ]
+    operands = Value[operation, replValues...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
-    
-    IR.create_operation(
-        "pdl.replace", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
+    )
+
+    return IR.create_operation(
+        "pdl.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -439,22 +498,26 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val, ]
-    operands = Value[parent, ]
+    results = IR.Type[val,]
+    operands = Value[parent,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl.result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl.result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`results_`
+`results`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -482,19 +545,23 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val, ]
-    operands = Value[parent, ]
+function results(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val,]
+    operands = Value[parent,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl.results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -537,21 +604,31 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, body::Region, location=Location())
+function rewrite(
+    root=nothing::Union{Nothing,Value};
+    externalArgs::Vector{Value},
+    name=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[externalArgs..., ]
-    owned_regions = Region[body, ]
+    operands = Value[externalArgs...,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
+    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "pdl.rewrite", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -574,18 +651,22 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, type=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(attributes, namedattribute("type", type))
-    
-    IR.create_operation(
-        "pdl.type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -608,18 +689,22 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, types=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(types) && push!(attributes, namedattribute("types", types))
-    
-    IR.create_operation(
-        "pdl.types", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/PDL.jl
+++ b/src/Dialects/15/PDL.jl
@@ -1,9 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_native_constraint`
@@ -21,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -66,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,26 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    type=nothing::Union{Nothing,Value}; attr::IR.Type, value=nothing, location=Location()
-)
-    results = IR.Type[attr,]
+function attribute(type=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,20 +133,16 @@ pdl.erase %root
 """
 function erase(operation::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operation,]
+    operands = Value[operation, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,28 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
-    results = IR.Type[val,]
+function operand(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
+    results = IR.Type[val, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -229,23 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(type=nothing::Union{Nothing,Value}; val::IR.Type, location=Location())
-    results = IR.Type[val,]
+function operands_(type=nothing::Union{Nothing, Value}; val::IR.Type, location=Location())
+    results = IR.Type[val, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(operands, type)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,35 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operands::Vector{Value},
-    attributes::Vector{Value},
-    types::Vector{Value};
-    op::IR.Type,
-    name=nothing,
-    attributeNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operands..., attributes..., types...]
+function operation(operands_::Vector{Value}, attributes_::Vector{Value}, types::Vector{Value}; op::IR.Type, name=nothing, attributeNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operands_..., attributes_..., types..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([length(operands), length(attributes), length(types)]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeNames", attributeNames), ]
+    push!(attributes, operandsegmentsizes([length(operands), length(attributes), length(types), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -405,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -447,32 +399,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    operation::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(operation::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[operation, replValues...]
+    operands = Value[operation, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -499,26 +439,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -546,23 +482,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,31 +537,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    body::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[body,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -652,22 +574,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, type=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(type) && push!(attributes, namedattribute("type", type))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -690,22 +608,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, types=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(types) && push!(attributes, namedattribute("types", types))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/PDLInterp.jl
+++ b/src/Dialects/15/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_constraint`
@@ -20,18 +20,24 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
+function apply_constraint(
+    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.apply_constraint", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.apply_constraint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,18 +63,24 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[args..., ]
+function apply_rewrite(
+    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.apply_rewrite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.apply_rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -85,18 +97,24 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
+function are_equal(
+    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.are_equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.are_equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -117,14 +135,18 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.branch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -141,18 +163,24 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
+function check_attribute(
+    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[attribute, ]
+    operands = Value[attribute,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_attribute", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
+
+    return IR.create_operation(
+        "pdl_interp.check_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -175,19 +203,31 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
+function check_operand_count(
+    inputOp::Value;
+    count,
+    compareAtLeast=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-    
-    IR.create_operation(
-        "pdl_interp.check_operand_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("count", count),]
+    !isnothing(compareAtLeast) &&
+        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+
+    return IR.create_operation(
+        "pdl_interp.check_operand_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -204,18 +244,24 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
+function check_operation_name(
+    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_operation_name", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.check_operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -238,19 +284,31 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
+function check_result_count(
+    inputOp::Value;
+    count,
+    compareAtLeast=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-    
-    IR.create_operation(
-        "pdl_interp.check_result_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("count", count),]
+    !isnothing(compareAtLeast) &&
+        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+
+    return IR.create_operation(
+        "pdl_interp.check_result_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -267,18 +325,24 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
+function check_type(
+    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_type", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("type", type),]
+
+    return IR.create_operation(
+        "pdl_interp.check_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -295,18 +359,24 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
+function check_types(
+    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("types", types), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_types", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("types", types),]
+
+    return IR.create_operation(
+        "pdl_interp.check_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -329,12 +399,16 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.continue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.continue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -351,17 +425,21 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute, ]
+    results = IR.Type[attribute,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -384,20 +462,42 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
-    results = IR.Type[resultOp, ]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
+function create_operation(
+    inputOperands::Vector{Value},
+    inputAttributes::Vector{Value},
+    inputResultTypes::Vector{Value};
+    resultOp::IR.Type,
+    name,
+    inputAttributeNames,
+    inferredResultTypes=nothing,
+    location=Location(),
+)
+    results = IR.Type[resultOp,]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
-    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
-    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-    
-    IR.create_operation(
-        "pdl_interp.create_operation", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("name", name),
+        namedattribute("inputAttributeNames", inputAttributeNames),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(inputOperands), length(inputAttributes), length(inputResultTypes)
+        ]),
+    )
+    !isnothing(inferredResultTypes) &&
+        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+
+    return IR.create_operation(
+        "pdl_interp.create_operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -414,17 +514,21 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_type", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -441,17 +545,21 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_types", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -470,16 +578,20 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.erase", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.erase",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -497,17 +609,21 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[range, ]
+    results = IR.Type[result,]
+    operands = Value[range,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.extract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -529,12 +645,16 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.finalize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.finalize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -559,16 +679,20 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values, ]
-    owned_regions = Region[region, ]
-    successors = Block[successor, ]
+    operands = Value[values,]
+    owned_regions = Region[region,]
+    successors = Block[successor,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -593,15 +717,21 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 function func(; sym_name, function_type, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    
-    IR.create_operation(
-        "pdl_interp.func", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+
+    return IR.create_operation(
+        "pdl_interp.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -619,17 +749,21 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[attribute,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.get_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -646,17 +780,21 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_attribute_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_attribute_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -675,17 +813,21 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp, ]
-    operands = Value[value, ]
+    results = IR.Type[inputOp,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_defining_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_defining_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -703,17 +845,21 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_operand", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.get_operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -741,18 +887,22 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl_interp.get_operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -770,17 +920,21 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.get_result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -808,18 +962,22 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl_interp.get_results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -841,17 +999,21 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations, ]
-    operands = Value[value, ]
+    results = IR.Type[operations,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_users", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_users",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -872,17 +1034,21 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_value_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_value_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -902,16 +1068,20 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.is_not_null", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.is_not_null",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -930,21 +1100,37 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
+function record_match(
+    inputs::Vector{Value},
+    matchedOps::Vector{Value};
+    rewriter,
+    rootKind=nothing,
+    generatedOps=nothing,
+    benefit,
+    dest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps..., ]
+    operands = Value[inputs..., matchedOps...]
     owned_regions = Region[]
-    successors = Block[dest, ]
-    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
+    successors = Block[dest,]
+    attributes = NamedAttribute[
+        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
+    ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
-    
-    IR.create_operation(
-        "pdl_interp.record_match", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(generatedOps) &&
+        push!(attributes, namedattribute("generatedOps", generatedOps))
+
+    return IR.create_operation(
+        "pdl_interp.record_match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -965,16 +1151,20 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues..., ]
+    operands = Value[inputOp, replValues...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.replace", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -992,18 +1182,28 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_attribute(
+    attribute::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[attribute, ]
+    operands = Value[attribute,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_attribute", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1021,18 +1221,28 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_operand_count(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_operand_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_operand_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1050,18 +1260,28 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_operation_name(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_operation_name", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1079,18 +1299,28 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_result_count(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_result_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_result_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1108,18 +1338,24 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_type(
+    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_type", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1137,18 +1373,24 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_types(
+    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_types", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/PDLInterp.jl
+++ b/src/Dialects/15/PDLInterp.jl
@@ -1,9 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_constraint`
@@ -21,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -204,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -285,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -360,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -400,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -515,21 +414,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -546,21 +441,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -579,20 +470,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -610,21 +497,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,16 +529,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -680,20 +559,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -718,21 +593,15 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 function func(; sym_name, function_type, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -750,21 +619,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -781,21 +646,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -814,21 +675,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -846,21 +703,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -888,22 +741,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -921,21 +770,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -963,22 +808,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1000,21 +841,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1035,21 +872,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1069,20 +902,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1101,37 +930,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1152,20 +965,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1183,28 +992,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1222,28 +1021,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1261,28 +1050,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1300,28 +1079,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1339,24 +1108,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1374,24 +1137,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/PDLInterp.jl
+++ b/src/Dialects/15/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_constraint`
@@ -20,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -135,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -163,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -284,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -359,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -399,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -425,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -514,21 +414,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -545,21 +441,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,20 +470,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -609,21 +497,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,16 +529,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -679,20 +559,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -717,21 +593,15 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 function func(; sym_name, function_type, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -749,21 +619,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -780,21 +646,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -813,21 +675,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -845,21 +703,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -887,22 +741,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -920,21 +770,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -962,22 +808,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -999,21 +841,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1034,21 +872,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1068,20 +902,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1100,37 +930,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1151,20 +965,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1182,28 +992,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1221,28 +1021,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1260,28 +1050,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1299,28 +1079,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1338,24 +1108,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1373,24 +1137,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Quant.jl
+++ b/src/Dialects/15/Quant.jl
@@ -1,8 +1,8 @@
 module quant
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `const_fake_quant`
@@ -12,21 +12,39 @@ same uniform quantization simulation as is done by the TensorFlow
 fake_quant_with_min_max_args op. See the fakeQuantAttrsToType() utility
 method and the quant-convert-simulated-quantization pass for further details.
 """
-function const_fake_quant(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
+function const_fake_quant(
+    inputs::Value;
+    outputs=nothing::Union{Nothing,IR.Type},
+    min,
+    max,
+    num_bits,
+    narrow_range=nothing,
+    is_signed=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputs, ]
+    operands = Value[inputs,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("num_bits", num_bits), ]
+    attributes = NamedAttribute[
+        namedattribute("min", min),
+        namedattribute("max", max),
+        namedattribute("num_bits", num_bits),
+    ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) &&
+        push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-    
-    IR.create_operation(
-        "quant.const_fake_quant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.const_fake_quant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -39,21 +57,41 @@ fake_quant_with_min_max_vars_per_channel op. See the fakeQuantAttrsToType()
 utility method and the quant-convert-simulated-quantization pass for further
 details.
 """
-function const_fake_quant_per_axis(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, axis, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
+function const_fake_quant_per_axis(
+    inputs::Value;
+    outputs=nothing::Union{Nothing,IR.Type},
+    min,
+    max,
+    axis,
+    num_bits,
+    narrow_range=nothing,
+    is_signed=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputs, ]
+    operands = Value[inputs,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("axis", axis), namedattribute("num_bits", num_bits), ]
+    attributes = NamedAttribute[
+        namedattribute("min", min),
+        namedattribute("max", max),
+        namedattribute("axis", axis),
+        namedattribute("num_bits", num_bits),
+    ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) &&
+        push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-    
-    IR.create_operation(
-        "quant.const_fake_quant_per_axis", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.const_fake_quant_per_axis",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -67,19 +105,25 @@ external connections. In such a case, during analysis, all coupled_ref
 nodes in a module which share a coupledKey will be considered to be
 directly connected as via an identity op for the purpose of type inference.
 """
-function coupled_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, coupledKey, location=Location())
+function coupled_ref(
+    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, coupledKey, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey), ]
+    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "quant.coupled_ref", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.coupled_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -88,17 +132,21 @@ end
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[arg, ]
+    results = IR.Type[result_0,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.dcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.dcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -107,17 +155,21 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[arg, ]
+    results = IR.Type[result_0,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.qcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.qcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -125,18 +177,34 @@ end
 `region`
 
 """
-function region(inputs::Vector{Value}; outputs::Vector{IR.Type}, input_specs, output_specs, logical_kernel, body::Region, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
-    owned_regions = Region[body, ]
+function region(
+    inputs::Vector{Value};
+    outputs::Vector{IR.Type},
+    input_specs,
+    output_specs,
+    logical_kernel,
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("input_specs", input_specs), namedattribute("output_specs", output_specs), namedattribute("logical_kernel", logical_kernel), ]
-    
-    IR.create_operation(
-        "quant.region", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("input_specs", input_specs),
+        namedattribute("output_specs", output_specs),
+        namedattribute("logical_kernel", logical_kernel),
+    ]
+
+    return IR.create_operation(
+        "quant.region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -144,18 +212,22 @@ end
 `return_`
 
 """
-function return_(results_::Vector{Value}; location=Location())
+function return_(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -179,21 +251,32 @@ Currently, only dim=2 is supported, which is interpreted as [min, max].
 <?x?x3x2>, axis=2 => N=6
 ```
 """
-function stats(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, layerStats, axisStats=nothing, axis=nothing, location=Location())
+function stats(
+    arg::Value;
+    result_0=nothing::Union{Nothing,IR.Type},
+    layerStats,
+    axisStats=nothing,
+    axis=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layerStats", layerStats), ]
+    attributes = NamedAttribute[namedattribute("layerStats", layerStats),]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(axisStats) && push!(attributes, namedattribute("axisStats", axisStats))
     !isnothing(axis) && push!(attributes, namedattribute("axis", axis))
-    
-    IR.create_operation(
-        "quant.stats", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.stats",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -206,19 +289,25 @@ Such statistics will be stored with the provided key, allowing this node
 to later be converted to a \'stats\' op if statistics with that key have been
 encountered.
 """
-function stats_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, statsKey, location=Location())
+function stats_ref(
+    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, statsKey, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("statsKey", statsKey), ]
+    attributes = NamedAttribute[namedattribute("statsKey", statsKey),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "quant.stats_ref", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.stats_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -227,17 +316,21 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[arg, ]
+    results = IR.Type[result_0,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.scast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.scast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Quant.jl
+++ b/src/Dialects/15/Quant.jl
@@ -1,9 +1,8 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `const_fake_quant`
@@ -13,39 +12,21 @@ same uniform quantization simulation as is done by the TensorFlow
 fake_quant_with_min_max_args op. See the fakeQuantAttrsToType() utility
 method and the quant-convert-simulated-quantization pass for further details.
 """
-function const_fake_quant(
-    inputs::Value;
-    outputs=nothing::Union{Nothing,IR.Type},
-    min,
-    max,
-    num_bits,
-    narrow_range=nothing,
-    is_signed=nothing,
-    location=Location(),
-)
+function const_fake_quant(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[inputs,]
+    operands = Value[inputs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min", min),
-        namedattribute("max", max),
-        namedattribute("num_bits", num_bits),
-    ]
+    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("num_bits", num_bits), ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) &&
-        push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-
-    return IR.create_operation(
-        "quant.const_fake_quant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.const_fake_quant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -58,41 +39,21 @@ fake_quant_with_min_max_vars_per_channel op. See the fakeQuantAttrsToType()
 utility method and the quant-convert-simulated-quantization pass for further
 details.
 """
-function const_fake_quant_per_axis(
-    inputs::Value;
-    outputs=nothing::Union{Nothing,IR.Type},
-    min,
-    max,
-    axis,
-    num_bits,
-    narrow_range=nothing,
-    is_signed=nothing,
-    location=Location(),
-)
+function const_fake_quant_per_axis(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, axis, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[inputs,]
+    operands = Value[inputs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min", min),
-        namedattribute("max", max),
-        namedattribute("axis", axis),
-        namedattribute("num_bits", num_bits),
-    ]
+    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("axis", axis), namedattribute("num_bits", num_bits), ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) &&
-        push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-
-    return IR.create_operation(
-        "quant.const_fake_quant_per_axis",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.const_fake_quant_per_axis", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -106,25 +67,19 @@ external connections. In such a case, during analysis, all coupled_ref
 nodes in a module which share a coupledKey will be considered to be
 directly connected as via an identity op for the purpose of type inference.
 """
-function coupled_ref(
-    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, coupledKey, location=Location()
-)
+function coupled_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, coupledKey, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey),]
+    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "quant.coupled_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.coupled_ref", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -133,21 +88,17 @@ end
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -156,21 +107,17 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -178,34 +125,18 @@ end
 `region`
 
 """
-function region(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    input_specs,
-    output_specs,
-    logical_kernel,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[body,]
+function region(inputs::Vector{Value}; outputs::Vector{IR.Type}, input_specs, output_specs, logical_kernel, body::Region, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_specs", input_specs),
-        namedattribute("output_specs", output_specs),
-        namedattribute("logical_kernel", logical_kernel),
-    ]
-
-    return IR.create_operation(
-        "quant.region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_specs", input_specs), namedattribute("output_specs", output_specs), namedattribute("logical_kernel", logical_kernel), ]
+    
+    IR.create_operation(
+        "quant.region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -213,22 +144,18 @@ end
 `return_`
 
 """
-function return_(results::Vector{Value}; location=Location())
+function return_(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -252,32 +179,21 @@ Currently, only dim=2 is supported, which is interpreted as [min, max].
 <?x?x3x2>, axis=2 => N=6
 ```
 """
-function stats(
-    arg::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    layerStats,
-    axisStats=nothing,
-    axis=nothing,
-    location=Location(),
-)
+function stats(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, layerStats, axisStats=nothing, axis=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layerStats", layerStats),]
+    attributes = NamedAttribute[namedattribute("layerStats", layerStats), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(axisStats) && push!(attributes, namedattribute("axisStats", axisStats))
     !isnothing(axis) && push!(attributes, namedattribute("axis", axis))
-
-    return IR.create_operation(
-        "quant.stats",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.stats", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -290,25 +206,19 @@ Such statistics will be stored with the provided key, allowing this node
 to later be converted to a \'stats\' op if statistics with that key have been
 encountered.
 """
-function stats_ref(
-    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, statsKey, location=Location()
-)
+function stats_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, statsKey, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("statsKey", statsKey),]
+    attributes = NamedAttribute[namedattribute("statsKey", statsKey), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "quant.stats_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.stats_ref", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -317,21 +227,17 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Quant.jl
+++ b/src/Dialects/15/Quant.jl
@@ -1,8 +1,8 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `const_fake_quant`
@@ -12,39 +12,21 @@ same uniform quantization simulation as is done by the TensorFlow
 fake_quant_with_min_max_args op. See the fakeQuantAttrsToType() utility
 method and the quant-convert-simulated-quantization pass for further details.
 """
-function const_fake_quant(
-    inputs::Value;
-    outputs=nothing::Union{Nothing,IR.Type},
-    min,
-    max,
-    num_bits,
-    narrow_range=nothing,
-    is_signed=nothing,
-    location=Location(),
-)
+function const_fake_quant(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[inputs,]
+    operands = Value[inputs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min", min),
-        namedattribute("max", max),
-        namedattribute("num_bits", num_bits),
-    ]
+    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("num_bits", num_bits), ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) &&
-        push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-
-    return IR.create_operation(
-        "quant.const_fake_quant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.const_fake_quant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -57,41 +39,21 @@ fake_quant_with_min_max_vars_per_channel op. See the fakeQuantAttrsToType()
 utility method and the quant-convert-simulated-quantization pass for further
 details.
 """
-function const_fake_quant_per_axis(
-    inputs::Value;
-    outputs=nothing::Union{Nothing,IR.Type},
-    min,
-    max,
-    axis,
-    num_bits,
-    narrow_range=nothing,
-    is_signed=nothing,
-    location=Location(),
-)
+function const_fake_quant_per_axis(inputs::Value; outputs=nothing::Union{Nothing, IR.Type}, min, max, axis, num_bits, narrow_range=nothing, is_signed=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[inputs,]
+    operands = Value[inputs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min", min),
-        namedattribute("max", max),
-        namedattribute("axis", axis),
-        namedattribute("num_bits", num_bits),
-    ]
+    attributes = NamedAttribute[namedattribute("min", min), namedattribute("max", max), namedattribute("axis", axis), namedattribute("num_bits", num_bits), ]
     !isnothing(outputs) && push!(results, outputs)
-    !isnothing(narrow_range) &&
-        push!(attributes, namedattribute("narrow_range", narrow_range))
+    !isnothing(narrow_range) && push!(attributes, namedattribute("narrow_range", narrow_range))
     !isnothing(is_signed) && push!(attributes, namedattribute("is_signed", is_signed))
-
-    return IR.create_operation(
-        "quant.const_fake_quant_per_axis",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.const_fake_quant_per_axis", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -105,25 +67,19 @@ external connections. In such a case, during analysis, all coupled_ref
 nodes in a module which share a coupledKey will be considered to be
 directly connected as via an identity op for the purpose of type inference.
 """
-function coupled_ref(
-    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, coupledKey, location=Location()
-)
+function coupled_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, coupledKey, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey),]
+    attributes = NamedAttribute[namedattribute("coupledKey", coupledKey), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "quant.coupled_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.coupled_ref", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -132,21 +88,17 @@ end
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -155,21 +107,17 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -177,34 +125,18 @@ end
 `region`
 
 """
-function region(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    input_specs,
-    output_specs,
-    logical_kernel,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[body,]
+function region(inputs::Vector{Value}; outputs::Vector{IR.Type}, input_specs, output_specs, logical_kernel, body::Region, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_specs", input_specs),
-        namedattribute("output_specs", output_specs),
-        namedattribute("logical_kernel", logical_kernel),
-    ]
-
-    return IR.create_operation(
-        "quant.region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_specs", input_specs), namedattribute("output_specs", output_specs), namedattribute("logical_kernel", logical_kernel), ]
+    
+    IR.create_operation(
+        "quant.region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,22 +144,18 @@ end
 `return_`
 
 """
-function return_(results::Vector{Value}; location=Location())
+function return_(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -251,32 +179,21 @@ Currently, only dim=2 is supported, which is interpreted as [min, max].
 <?x?x3x2>, axis=2 => N=6
 ```
 """
-function stats(
-    arg::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    layerStats,
-    axisStats=nothing,
-    axis=nothing,
-    location=Location(),
-)
+function stats(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, layerStats, axisStats=nothing, axis=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layerStats", layerStats),]
+    attributes = NamedAttribute[namedattribute("layerStats", layerStats), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(axisStats) && push!(attributes, namedattribute("axisStats", axisStats))
     !isnothing(axis) && push!(attributes, namedattribute("axis", axis))
-
-    return IR.create_operation(
-        "quant.stats",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.stats", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -289,25 +206,19 @@ Such statistics will be stored with the provided key, allowing this node
 to later be converted to a \'stats\' op if statistics with that key have been
 encountered.
 """
-function stats_ref(
-    arg::Value; result_0=nothing::Union{Nothing,IR.Type}, statsKey, location=Location()
-)
+function stats_ref(arg::Value; result_0=nothing::Union{Nothing, IR.Type}, statsKey, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("statsKey", statsKey),]
+    attributes = NamedAttribute[namedattribute("statsKey", statsKey), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "quant.stats_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.stats_ref", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -316,21 +227,17 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SCF.jl
+++ b/src/Dialects/15/SCF.jl
@@ -1,9 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `condition`
@@ -15,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -74,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -181,30 +172,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -308,30 +287,19 @@ Example with thread_dim_mapping attribute:
 // Sequential context.
 //
 """
-function foreach_thread(
-    num_threads::Vector{Value};
-    results::Vector{IR.Type},
-    thread_dim_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[num_threads...,]
-    owned_regions = Region[region,]
+function foreach_thread(num_threads::Vector{Value}; results_::Vector{IR.Type}, thread_dim_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[num_threads..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(thread_dim_mapping) &&
-        push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
-
-    return IR.create_operation(
-        "scf.foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(thread_dim_mapping) && push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
+    
+    IR.create_operation(
+        "scf.foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -381,28 +349,18 @@ scf.if %b  {
 }
 ```
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -452,36 +410,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -499,19 +440,15 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.foreach_thread.perform_concurrently",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread.perform_concurrently", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -553,20 +490,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,20 +516,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -714,28 +643,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -752,22 +671,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SCF.jl
+++ b/src/Dialects/15/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `condition`
@@ -14,16 +14,20 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args..., ]
+    operands = Value[condition, args...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.condition", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.condition",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,17 +73,21 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0..., ]
+    results = IR.Type[result_0...,]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.execute_region", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.execute_region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -172,18 +180,30 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[lowerBound, upperBound, step, initArgs..., ]
-    owned_regions = Region[region, ]
+function for_(
+    lowerBound::Value,
+    upperBound::Value,
+    step::Value,
+    initArgs::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[lowerBound, upperBound, step, initArgs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -287,19 +307,30 @@ Example with thread_dim_mapping attribute:
 // Sequential context.
 //
 """
-function foreach_thread(num_threads::Vector{Value}; results_::Vector{IR.Type}, thread_dim_mapping=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[num_threads..., ]
-    owned_regions = Region[region, ]
+function foreach_thread(
+    num_threads::Vector{Value};
+    results::Vector{IR.Type},
+    thread_dim_mapping=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[num_threads...,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(thread_dim_mapping) && push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
-    
-    IR.create_operation(
-        "scf.foreach_thread", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(thread_dim_mapping) &&
+        push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
+
+    return IR.create_operation(
+        "scf.foreach_thread",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -349,18 +380,28 @@ scf.if %b  {
 }
 ```
 """
-function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[condition, ]
-    owned_regions = Region[thenRegion, elseRegion, ]
+function if_(
+    condition::Value;
+    results::Vector{IR.Type},
+    thenRegion::Region,
+    elseRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[condition,]
+    owned_regions = Region[thenRegion, elseRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -410,19 +451,36 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
-    owned_regions = Region[region, ]
+function parallel(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    initVals::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[lowerBound..., upperBound..., step..., initVals...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
-    
-    IR.create_operation(
-        "scf.parallel", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound), length(upperBound), length(step), length(initVals)
+        ]),
+    )
+
+    return IR.create_operation(
+        "scf.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -440,15 +498,19 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.foreach_thread.perform_concurrently", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.foreach_thread.perform_concurrently",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -490,16 +552,20 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
-    owned_regions = Region[reductionOperator, ]
+    operands = Value[operand,]
+    owned_regions = Region[reductionOperator,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -516,16 +582,20 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.reduce.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.reduce.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -643,18 +713,28 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[inits..., ]
-    owned_regions = Region[before, after, ]
+function while_(
+    inits::Vector{Value};
+    results::Vector{IR.Type},
+    before::Region,
+    after::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[inits...,]
+    owned_regions = Region[before, after]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.while", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.while",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -671,18 +751,22 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results_::Vector{Value}; location=Location())
+function yield(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/SCF.jl
+++ b/src/Dialects/15/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `condition`
@@ -14,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -180,30 +172,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -307,30 +287,19 @@ Example with thread_dim_mapping attribute:
 // Sequential context.
 //
 """
-function foreach_thread(
-    num_threads::Vector{Value};
-    results::Vector{IR.Type},
-    thread_dim_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[num_threads...,]
-    owned_regions = Region[region,]
+function foreach_thread(num_threads::Vector{Value}; results_::Vector{IR.Type}, thread_dim_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[num_threads..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(thread_dim_mapping) &&
-        push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
-
-    return IR.create_operation(
-        "scf.foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(thread_dim_mapping) && push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
+    
+    IR.create_operation(
+        "scf.foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -380,28 +349,18 @@ scf.if %b  {
 }
 ```
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -451,36 +410,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -498,19 +440,15 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.foreach_thread.perform_concurrently",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread.perform_concurrently", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -552,20 +490,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,20 +516,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -713,28 +643,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -751,22 +671,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SPIRV.jl
+++ b/src/Dialects/15/SPIRV.jl
@@ -1,8 +1,8 @@
 module spv
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `AccessChain`
@@ -46,18 +46,24 @@ access-chain-op ::= ssa-id `=` `spv.AccessChain` ssa-use
 %3 = spv.Load \"Function\" %2 [\"Volatile\"] : !spv.array<4xf32>
 ```
 """
-function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
-    results = IR.Type[component_ptr, ]
-    operands = Value[base_ptr, indices..., ]
+function AccessChain(
+    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
+)
+    results = IR.Type[component_ptr,]
+    operands = Value[base_ptr, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.AccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.AccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,17 +92,21 @@ spv-address-of-op ::= ssa-id `=` `spv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer, ]
+    results = IR.Type[pointer,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable), ]
-    
-    IR.create_operation(
-        "spv.mlir.addressof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable),]
+
+    return IR.create_operation(
+        "spv.mlir.addressof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -119,16 +129,20 @@ spv.AssumeTrueKHR %arg
 """
 function AssumeTrueKHR(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition, ]
+    operands = Value[condition,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.AssumeTrueKHR", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.AssumeTrueKHR",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -169,18 +183,31 @@ atomic-and-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicAnd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicAnd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -230,18 +257,35 @@ atomic-compare-exchange-op ::=
                                 : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, comparator, ]
+function AtomicCompareExchange(
+    pointer::Value,
+    value::Value,
+    comparator::Value;
+    result::IR.Type,
+    memory_scope,
+    equal_semantics,
+    unequal_semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value, comparator]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicCompareExchange", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("equal_semantics", equal_semantics),
+        namedattribute("unequal_semantics", unequal_semantics),
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicCompareExchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -269,18 +313,35 @@ atomic-compare-exchange-weak-op ::=
                                    : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, comparator, ]
+function AtomicCompareExchangeWeak(
+    pointer::Value,
+    value::Value,
+    comparator::Value;
+    result::IR.Type,
+    memory_scope,
+    equal_semantics,
+    unequal_semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value, comparator]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicCompareExchangeWeak", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("equal_semantics", equal_semantics),
+        namedattribute("unequal_semantics", unequal_semantics),
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicCompareExchangeWeak",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,18 +378,31 @@ atomic-exchange-op ::=
                         : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicExchange(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicExchange", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicExchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -370,18 +444,31 @@ atomic-fadd-op ::=
                        !spv.ptr<f32, StorageBuffer>
 ```mlir
 """
-function AtomicFAddEXT(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicFAddEXT(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicFAddEXT", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicFAddEXT",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -418,18 +505,31 @@ atomic-iadd-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicIAdd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicIAdd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -465,18 +565,26 @@ atomic-idecrement-op ::=
                           !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+function AtomicIDecrement(
+    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicIDecrement", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicIDecrement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -511,18 +619,26 @@ atomic-iincrement-op ::=
                          !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+function AtomicIIncrement(
+    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicIIncrement", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicIIncrement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -560,18 +676,31 @@ atomic-isub-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicISub(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicISub", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicISub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -608,18 +737,31 @@ atomic-or-op ::=
                   !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicOr(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicOr", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -657,18 +799,31 @@ atomic-smax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicSMax(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicSMax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -706,18 +861,31 @@ atomic-smin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicSMin(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicSMin", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -755,18 +923,31 @@ atomic-umax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicUMax(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicUMax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -804,18 +985,31 @@ atomic-umin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicUMin(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicUMin", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -853,18 +1047,31 @@ atomic-xor-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicXor(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spv.AtomicXor", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spv.AtomicXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -900,19 +1107,25 @@ Results are computed per component.
     %3 = spv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitCount(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitCount", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitCount",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -958,19 +1171,30 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldInsert(
+    base::Value,
+    insert::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, insert, offset, count, ]
+    operands = Value[base, insert, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitFieldInsert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitFieldInsert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1016,19 +1240,29 @@ The type of Base must be the same as Result Type.
     %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldSExtract(
+    base::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, offset, count, ]
+    operands = Value[base, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitFieldSExtract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitFieldSExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1056,19 +1290,29 @@ bitfield-extract-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
 %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldUExtract(
+    base::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, offset, count, ]
+    operands = Value[base, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitFieldUExtract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitFieldUExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1100,19 +1344,25 @@ The type of Base must be the same as Result Type.
     %3 = spv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitReverse(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitReverse", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitReverse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1156,17 +1406,21 @@ bitcast-op ::= ssa-id `=` `spv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1196,19 +1450,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseAnd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitwiseAnd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitwiseAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1238,19 +1501,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseOr(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitwiseOr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitwiseOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1280,19 +1552,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseXor(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.BitwiseXor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.BitwiseXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1330,20 +1611,36 @@ spv.BranchConditional %condition, ^true_branch, ^false_branch
 spv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
+function BranchConditional(
+    condition::Value,
+    trueTargetOperands::Vector{Value},
+    falseTargetOperands::Vector{Value};
+    branch_weights=nothing,
+    trueTarget::Block,
+    falseTarget::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget, ]
+    successors = Block[trueTarget, falseTarget]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "spv.BranchConditional", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
+    )
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "spv.BranchConditional",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1369,16 +1666,20 @@ spv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands..., ]
+    operands = Value[targetOperands...,]
     owned_regions = Region[]
-    successors = Block[target, ]
+    successors = Block[target,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Branch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1407,19 +1708,25 @@ ceil-op ::= ssa-id `=` `spv.CL.ceil` ssa-use `:`
 %3 = spv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_ceil(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1448,19 +1755,23 @@ cos-op ::= ssa-id `=` `spv.CL.cos` ssa-use `:`
 %3 = spv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1489,19 +1800,23 @@ erf-op ::= ssa-id `=` `spv.CL.erf` ssa-use `:`
 %3 = spv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1530,19 +1845,23 @@ exp-op ::= ssa-id `=` `spv.CL.exp` ssa-use `:`
 %3 = spv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1571,19 +1890,25 @@ abs-op ::= ssa-id `=` `spv.CL.fabs` ssa-use `:`
 %3 = spv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fabs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.fabs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.fabs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1612,19 +1937,25 @@ floor-op ::= ssa-id `=` `spv.CL.floor` ssa-use `:`
 %3 = spv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_floor(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1649,19 +1980,29 @@ fma-op ::= ssa-id `=` `spv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fma(
+    x::Value,
+    y::Value,
+    z::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, z, ]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1690,19 +2031,23 @@ log-op ::= ssa-id `=` `spv.CL.log` ssa-use `:`
 %3 = spv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1732,19 +2077,25 @@ pow-op ::= ssa-id `=` `spv.CL.pow` ssa-use `:`
 %3 = spv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1772,19 +2123,25 @@ round-op ::= ssa-id `=` `spv.CL.round` ssa-use `:`
 %3 = spv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_round(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1813,19 +2170,25 @@ rsqrt-op ::= ssa-id `=` `spv.CL.rsqrt` ssa-use `:`
 %3 = spv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_rsqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1854,19 +2217,25 @@ abs-op ::= ssa-id `=` `spv.CL.s_abs` ssa-use `:`
 %3 = spv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_abs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.s_abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.s_abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1895,19 +2264,23 @@ sin-op ::= ssa-id `=` `spv.CL.sin` ssa-use `:`
 %3 = spv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1936,19 +2309,25 @@ sqrt-op ::= ssa-id `=` `spv.CL.sqrt` ssa-use `:`
 %3 = spv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_sqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1977,19 +2356,25 @@ tanh-op ::= ssa-id `=` `spv.CL.tanh` ssa-use `:`
 %3 = spv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_tanh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CL.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CL.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2027,18 +2412,24 @@ composite-construct-op ::= ssa-id `=` `spv.CompositeConstruct`
 %0 = spv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[constituents..., ]
+function CompositeConstruct(
+    constituents::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[constituents...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.CompositeConstruct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CompositeConstruct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2071,18 +2462,24 @@ composite-extract-op ::= ssa-id `=` `spv.CompositeExtract` ssa-use
 %2 = spv.CompositeExtract %1[1 : i32] : !spv.array<4x!spv.array<4xf32>>
 ```
 """
-function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
-    results = IR.Type[component, ]
-    operands = Value[composite, ]
+function CompositeExtract(
+    composite::Value; component::IR.Type, indices, location=Location()
+)
+    results = IR.Type[component,]
+    operands = Value[composite,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices), ]
-    
-    IR.create_operation(
-        "spv.CompositeExtract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices),]
+
+    return IR.create_operation(
+        "spv.CompositeExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2115,18 +2512,24 @@ composite-insert-op ::= ssa-id `=` `spv.CompositeInsert` ssa-use, ssa-use
 %0 = spv.CompositeInsert %object, %composite[1 : i32] : f32 into !spv.array<4xf32>
 ```
 """
-function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[object, composite, ]
+function CompositeInsert(
+    object::Value, composite::Value; result::IR.Type, indices, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[object, composite]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices), ]
-    
-    IR.create_operation(
-        "spv.CompositeInsert", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices),]
+
+    return IR.create_operation(
+        "spv.CompositeInsert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2166,17 +2569,21 @@ spv.Constant-op ::= ssa-id `=` `spv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant, ]
+    results = IR.Type[constant,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "spv.Constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "spv.Constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2226,18 +2633,28 @@ spv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
+function ControlBarrier(;
+    execution_scope, memory_scope, memory_semantics, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
-    
-    IR.create_operation(
-        "spv.ControlBarrier", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("memory_semantics", memory_semantics),
+    ]
+
+    return IR.create_operation(
+        "spv.ControlBarrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2266,17 +2683,21 @@ convert-f-to-s-op ::= ssa-id `=` `spv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ConvertFToS", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ConvertFToS",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2306,17 +2727,21 @@ convert-f-to-u-op ::= ssa-id `=` `spv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ConvertFToU", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ConvertFToU",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2345,17 +2770,21 @@ convert-s-to-f-op ::= ssa-id `=` `spv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ConvertSToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ConvertSToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2384,17 +2813,21 @@ convert-u-to-f-op ::= ssa-id `=` `spv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ConvertUToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ConvertUToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2419,19 +2852,25 @@ For example:
 %0 = spv.CooperativeMatrixLengthNV : !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixLengthNV(; result=nothing::Union{Nothing, IR.Type}, type, location=Location())
+function CooperativeMatrixLengthNV(;
+    result=nothing::Union{Nothing,IR.Type}, type, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), ]
+    attributes = NamedAttribute[namedattribute("type", type),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CooperativeMatrixLengthNV", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CooperativeMatrixLengthNV",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2488,19 +2927,31 @@ For example:
      : !spv.ptr<i32, StorageBuffer> as !spv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function CooperativeMatrixLoadNV(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, stride, columnmajor, ]
+function CooperativeMatrixLoadNV(
+    pointer::Value,
+    stride::Value,
+    columnmajor::Value;
+    result::IR.Type,
+    memory_access=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, stride, columnmajor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
-    
-    IR.create_operation(
-        "spv.CooperativeMatrixLoadNV", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
+
+    return IR.create_operation(
+        "spv.CooperativeMatrixLoadNV",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2551,19 +3002,29 @@ For example:
   !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixMulAddNV(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CooperativeMatrixMulAddNV(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.CooperativeMatrixMulAddNV", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.CooperativeMatrixMulAddNV",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2606,19 +3067,31 @@ For example:
     !spv.ptr<i32, StorageBuffer>, !spv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function CooperativeMatrixStoreNV(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
+function CooperativeMatrixStoreNV(
+    pointer::Value,
+    object::Value,
+    stride::Value,
+    columnmajor::Value;
+    memory_access=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor, ]
+    operands = Value[pointer, object, stride, columnmajor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
-    
-    IR.create_operation(
-        "spv.CooperativeMatrixStoreNV", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
+
+    return IR.create_operation(
+        "spv.CooperativeMatrixStoreNV",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2651,22 +3124,37 @@ copy-memory-op ::= `spv.CopyMemory ` storage-class ssa-use
 spv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
+function CopyMemory(
+    target::Value,
+    source::Value;
+    memory_access=nothing,
+    alignment=nothing,
+    source_memory_access=nothing,
+    source_alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, source, ]
+    operands = Value[target, source]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
-    
-    IR.create_operation(
-        "spv.CopyMemory", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(source_memory_access) &&
+        push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) &&
+        push!(attributes, namedattribute("source_alignment", source_alignment))
+
+    return IR.create_operation(
+        "spv.CopyMemory",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2716,13 +3204,21 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
-    
-    IR.create_operation(
-        "spv.EntryPoint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("execution_model", execution_model),
+        namedattribute("fn", fn),
+        namedattribute("interface", interface),
+    ]
+
+    return IR.create_operation(
+        "spv.EntryPoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2760,13 +3256,21 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
-    
-    IR.create_operation(
-        "spv.ExecutionMode", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("fn", fn),
+        namedattribute("execution_mode", execution_mode),
+        namedattribute("values", values),
+    ]
+
+    return IR.create_operation(
+        "spv.ExecutionMode",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2794,19 +3298,28 @@ fadd-op ::= ssa-id `=` `spv.FAdd` ssa-use, ssa-use
 %5 = spv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FAdd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2836,17 +3349,21 @@ f-convert-op ::= ssa-id `=` `spv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2876,19 +3393,28 @@ fdiv-op ::= ssa-id `=` `spv.FDiv` ssa-use, ssa-use
 %5 = spv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2919,19 +3445,28 @@ fmod-op ::= ssa-id `=` `spv.FMod` ssa-use, ssa-use
 %5 = spv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2961,19 +3496,28 @@ fmul-op ::= `spv.FMul` ssa-use, ssa-use
 %5 = spv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FMul(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3001,19 +3545,25 @@ fmul-op ::= `spv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FNegate(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FNegate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FNegate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3044,17 +3594,21 @@ fordequal-op ::= ssa-id `=` `spv.FOrdEqual` ssa-use, ssa-use
 ```
 """
 function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FOrdEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FOrdEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3084,18 +3638,24 @@ fordgte-op ::= ssa-id `=` `spv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdGreaterThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FOrdGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FOrdGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3125,18 +3685,24 @@ fordgt-op ::= ssa-id `=` `spv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdGreaterThan(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FOrdGreaterThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FOrdGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3166,18 +3732,24 @@ fordlte-op ::= ssa-id `=` `spv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdLessThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FOrdLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FOrdLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3207,18 +3779,24 @@ fordlt-op ::= ssa-id `=` `spv.FOrdLessThan` ssa-use, ssa-use
 %5 = spv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdLessThan(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FOrdLessThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FOrdLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3248,18 +3826,24 @@ fordneq-op ::= ssa-id `=` `spv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdNotEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FOrdNotEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FOrdNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3291,19 +3875,28 @@ frem-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FRem(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FRem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FRem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3332,19 +3925,28 @@ fsub-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FSub(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FSub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FSub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3375,17 +3977,21 @@ funordequal-op ::= ssa-id `=` `spv.FUnordEqual` ssa-use, ssa-use
 ```
 """
 function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FUnordEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FUnordEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3415,18 +4021,24 @@ funordgte-op ::= ssa-id `=` `spv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordGreaterThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FUnordGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FUnordGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3456,18 +4068,24 @@ funordgt-op ::= ssa-id `=` `spv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordGreaterThan(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FUnordGreaterThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FUnordGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3497,18 +4115,24 @@ funordlte-op ::= ssa-id `=` `spv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordLessThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FUnordLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FUnordLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3538,18 +4162,24 @@ funordlt-op ::= ssa-id `=` `spv.FUnordLessThan` ssa-use, ssa-use
 %5 = spv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordLessThan(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FUnordLessThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FUnordLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3579,18 +4209,24 @@ funordneq-op ::= ssa-id `=` `spv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordNotEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.FUnordNotEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FUnordNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3623,18 +4259,28 @@ spv.func @foo() -> () \"None\" { ... }
 spv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(; function_type, sym_name, function_control, body::Region, location=Location())
+function func(;
+    function_type, sym_name, function_control, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
-    
-    IR.create_operation(
-        "spv.func", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("function_type", function_type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("function_control", function_control),
+    ]
+
+    return IR.create_operation(
+        "spv.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3668,19 +4314,28 @@ spv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(arguments::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee, location=Location())
+function FunctionCall(
+    arguments::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    callee,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arguments..., ]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    attributes = NamedAttribute[namedattribute("callee", callee),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.FunctionCall", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.FunctionCall",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3713,19 +4368,25 @@ acos-op ::= ssa-id `=` `spv.GL.Acos` ssa-use `:`
 %3 = spv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Acos(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Acos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Acos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3758,19 +4419,25 @@ asin-op ::= ssa-id `=` `spv.GL.Asin` ssa-use `:`
 %3 = spv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Asin(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Asin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Asin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3803,19 +4470,25 @@ atan-op ::= ssa-id `=` `spv.GL.Atan` ssa-use `:`
 %3 = spv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Atan(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Atan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Atan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3845,19 +4518,25 @@ ceil-op ::= ssa-id `=` `spv.GL.Ceil` ssa-use `:`
 %3 = spv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Ceil(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3888,19 +4567,23 @@ cos-op ::= ssa-id `=` `spv.GL.Cos` ssa-use `:`
 %3 = spv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3931,19 +4614,25 @@ cosh-op ::= ssa-id `=` `spv.GL.Cosh` ssa-use `:`
 %3 = spv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Cosh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Cosh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Cosh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3974,19 +4663,23 @@ exp-op ::= ssa-id `=` `spv.GL.Exp` ssa-use `:`
 %3 = spv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4015,19 +4708,25 @@ abs-op ::= ssa-id `=` `spv.GL.FAbs` ssa-use `:`
 %3 = spv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FAbs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.FAbs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FAbs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4057,17 +4756,21 @@ fclamp-op ::= ssa-id `=` `spv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.GL.FClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4097,19 +4800,25 @@ fmax-op ::= ssa-id `=` `spv.GL.FMax` ssa-use `:`
 %3 = spv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.FMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4139,19 +4848,25 @@ fmin-op ::= ssa-id `=` `spv.GL.FMin` ssa-use `:`
 %3 = spv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.FMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4173,19 +4888,29 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMix(
+    x::Value,
+    y::Value,
+    a::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, a, ]
+    operands = Value[x, y, a]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.FMix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FMix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4214,19 +4939,25 @@ sign-op ::= ssa-id `=` `spv.GL.FSign` ssa-use `:`
 %3 = spv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FSign(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.FSign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FSign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4243,19 +4974,25 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FindUMsb(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.FindUMsb", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FindUMsb",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4285,19 +5022,25 @@ floor-op ::= ssa-id `=` `spv.GL.Floor` ssa-use `:`
 %3 = spv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Floor(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4337,17 +5080,21 @@ fma-op ::= ssa-id `=` `spv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.GL.Fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4390,17 +5137,21 @@ frexpstruct-op ::= ssa-id `=` `spv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.GL.FrexpStruct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.FrexpStruct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4429,19 +5180,25 @@ rsqrt-op ::= ssa-id `=` `spv.GL.InverseSqrt` ssa-use `:`
 %3 = spv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_InverseSqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.InverseSqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.InverseSqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4479,19 +5236,25 @@ component.
 %y = spv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Ldexp(
+    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, exp, ]
+    operands = Value[x, exp]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-    
-    IR.create_operation(
-        "spv.GL.Ldexp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Ldexp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4523,19 +5286,23 @@ log-op ::= ssa-id `=` `spv.GL.Log` ssa-use `:`
 %3 = spv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4568,19 +5335,25 @@ pow-op ::= ssa-id `=` `spv.GL.Pow` ssa-use `:`
 %3 = spv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4609,19 +5382,25 @@ floor-op ::= ssa-id `=` `spv.GL.Round` ssa-use `:`
 %3 = spv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Round(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4649,19 +5428,25 @@ abs-op ::= ssa-id `=` `spv.GL.SAbs` ssa-use `:`
 %3 = spv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SAbs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.SAbs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.SAbs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4690,17 +5475,21 @@ uclamp-op ::= ssa-id `=` `spv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.GL.SClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.SClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4729,19 +5518,25 @@ smax-op ::= ssa-id `=` `spv.GL.SMax` ssa-use `:`
 %3 = spv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.SMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.SMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4770,19 +5565,25 @@ smin-op ::= ssa-id `=` `spv.GL.SMin` ssa-use `:`
 %3 = spv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.SMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.SMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4810,19 +5611,25 @@ sign-op ::= ssa-id `=` `spv.GL.SSign` ssa-use `:`
 %3 = spv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SSign(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.SSign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.SSign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4853,19 +5660,23 @@ sin-op ::= ssa-id `=` `spv.GL.Sin` ssa-use `:`
 %3 = spv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4896,19 +5707,25 @@ sinh-op ::= ssa-id `=` `spv.GL.Sinh` ssa-use `:`
 %3 = spv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sinh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Sinh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Sinh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4937,19 +5754,25 @@ sqrt-op ::= ssa-id `=` `spv.GL.Sqrt` ssa-use `:`
 %3 = spv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4980,19 +5803,23 @@ tan-op ::= ssa-id `=` `spv.GL.Tan` ssa-use `:`
 %3 = spv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5023,19 +5850,25 @@ tanh-op ::= ssa-id `=` `spv.GL.Tanh` ssa-use `:`
 %3 = spv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Tanh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.Tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.Tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5064,17 +5897,21 @@ uclamp-op ::= ssa-id `=` `spv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.GL.UClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.UClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5103,19 +5940,25 @@ smax-op ::= ssa-id `=` `spv.GL.UMax` ssa-use `:`
 %3 = spv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_UMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.UMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.UMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5144,19 +5987,25 @@ smin-op ::= ssa-id `=` `spv.GL.UMin` ssa-use `:`
 %3 = spv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_UMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GL.UMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GL.UMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5200,23 +6049,39 @@ spv.GlobalVariable @var2 bind(1, 2) : !spv.ptr<f32, Uniform>
 spv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
+function GlobalVariable(;
+    type,
+    sym_name,
+    initializer=nothing,
+    location_=nothing,
+    binding=nothing,
+    descriptor_set=nothing,
+    builtin=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[
+        namedattribute("type", type), namedattribute("sym_name", sym_name)
+    ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) &&
+        push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-    
-    IR.create_operation(
-        "spv.GlobalVariable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GlobalVariable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5265,19 +6130,29 @@ group-broadcast-op ::= ssa-id `=` `spv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupBroadcast(
+    value::Value,
+    localid::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, localid, ]
+    operands = Value[value, localid]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GroupBroadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupBroadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5310,18 +6185,24 @@ non-uniform-ballot-op ::= ssa-id `=` `spv.GroupNonUniformBallot` scope
 %0 = spv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[predicate, ]
+function GroupNonUniformBallot(
+    predicate::Value; result::IR.Type, execution_scope, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[predicate,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
-    
-    IR.create_operation(
-        "spv.GroupNonUniformBallot", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+
+    return IR.create_operation(
+        "spv.GroupNonUniformBallot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5366,19 +6247,29 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformBroadcast(
+    value::Value,
+    id::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, id, ]
+    operands = Value[value, id]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformBroadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformBroadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5403,19 +6294,25 @@ non-uniform-elect-op ::= ssa-id `=` `spv.GroupNonUniformElect` scope
 %0 = spv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformElect(;
+    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformElect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformElect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5461,19 +6358,33 @@ non-uniform-fadd-op ::= ssa-id `=` `spv.GroupNonUniformFAdd` scope operation
 %1 = spv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFAdd(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformFAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5522,19 +6433,33 @@ non-uniform-fmax-op ::= ssa-id `=` `spv.GroupNonUniformFMax` scope operation
 %1 = spv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformFMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformFMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5583,19 +6508,33 @@ non-uniform-fmin-op ::= ssa-id `=` `spv.GroupNonUniformFMin` scope operation
 %1 = spv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformFMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformFMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5641,19 +6580,33 @@ non-uniform-fmul-op ::= ssa-id `=` `spv.GroupNonUniformFMul` scope operation
 %1 = spv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMul(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformFMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformFMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5697,19 +6650,33 @@ non-uniform-iadd-op ::= ssa-id `=` `spv.GroupNonUniformIAdd` scope operation
 %1 = spv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformIAdd(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformIAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5753,19 +6720,33 @@ non-uniform-imul-op ::= ssa-id `=` `spv.GroupNonUniformIMul` scope operation
 %1 = spv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformIMul(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformIMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformIMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5809,19 +6790,33 @@ non-uniform-smax-op ::= ssa-id `=` `spv.GroupNonUniformSMax` scope operation
 %1 = spv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformSMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformSMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5865,19 +6860,33 @@ non-uniform-smin-op ::= ssa-id `=` `spv.GroupNonUniformSMin` scope operation
 %1 = spv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformSMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformSMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5922,19 +6931,33 @@ non-uniform-umax-op ::= ssa-id `=` `spv.GroupNonUniformUMax` scope operation
 %1 = spv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformUMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformUMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5979,19 +7002,33 @@ non-uniform-umin-op ::= ssa-id `=` `spv.GroupNonUniformUMin` scope operation
 %1 = spv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformUMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spv.GroupNonUniformUMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.GroupNonUniformUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6026,19 +7063,28 @@ iadd-op ::= ssa-id `=` `spv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function IAdd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.IAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.IAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6069,17 +7115,21 @@ iequal-op ::= ssa-id `=` `spv.IEqual` ssa-use, ssa-use
 ```
 """
 function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.IEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.IEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6114,19 +7164,28 @@ imul-op ::= ssa-id `=` `spv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function IMul(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.IMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.IMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6157,17 +7216,21 @@ inot-equal-op ::= ssa-id `=` `spv.INotEqual` ssa-use, ssa-use
 ```
 """
 function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.INotEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.INotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6203,17 +7266,21 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ISubBorrow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ISubBorrow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6248,19 +7315,28 @@ isub-op ::= `spv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ISub(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.ISub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ISub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6300,19 +7376,32 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spv.ImageDrefGather %1 : !spv.sampled_image<!spv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
+function ImageDrefGather(
+    sampledimage::Value,
+    coordinate::Value,
+    dref::Value,
+    operand_arguments::Vector{Value};
+    result::IR.Type,
+    imageoperands=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
-    
-    IR.create_operation(
-        "spv.ImageDrefGather", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(imageoperands) &&
+        push!(attributes, namedattribute("imageoperands", imageoperands))
+
+    return IR.create_operation(
+        "spv.ImageDrefGather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6333,17 +7422,21 @@ same as Result Type.
 ```
 """
 function Image(sampledimage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sampledimage, ]
+    results = IR.Type[result,]
+    operands = Value[sampledimage,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Image", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Image",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6382,17 +7475,21 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[image, ]
+    results = IR.Type[result,]
+    operands = Value[image,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ImageQuerySize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ImageQuerySize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6418,18 +7515,28 @@ func @inbounds_ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i6
 }
 ```
 """
-function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base_ptr, element, indices..., ]
+function InBoundsPtrAccessChain(
+    base_ptr::Value,
+    element::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base_ptr, element, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.InBoundsPtrAccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.InBoundsPtrAccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6460,17 +7567,21 @@ isinf-op ::= ssa-id `=` `spv.IsInf` ssa-use
 ```
 """
 function IsInf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.IsInf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.IsInf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6501,17 +7612,21 @@ isnan-op ::= ssa-id `=` `spv.IsNan` ssa-use
 ```
 """
 function IsNan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.IsNan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.IsNan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6548,20 +7663,31 @@ load-op ::= ssa-id ` = spv.Load ` storage-class ssa-use
 %3 = spv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[ptr, ]
+function Load(
+    ptr::Value;
+    value::IR.Type,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[ptr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spv.Load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6591,17 +7717,21 @@ logical-and ::= `spv.LogicalAnd` ssa-use `,` ssa-use
 ```
 """
 function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.LogicalAnd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.LogicalAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6630,18 +7760,24 @@ logical-equal ::= `spv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.LogicalEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.LogicalEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6670,18 +7806,24 @@ logical-not-equal ::= `spv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalNotEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.LogicalNotEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.LogicalNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6708,17 +7850,21 @@ logical-not ::= `spv.LogicalNot` ssa-use `:` operand-type
 ```
 """
 function LogicalNot(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.LogicalNot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.LogicalNot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6748,17 +7894,21 @@ logical-or ::= `spv.LogicalOr` ssa-use `,` ssa-use
 ```
 """
 function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.LogicalOr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.LogicalOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6792,15 +7942,19 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
-    
-    IR.create_operation(
-        "spv.mlir.loop", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
+
+    return IR.create_operation(
+        "spv.mlir.loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6833,18 +7987,24 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[leftmatrix, rightmatrix, ]
+function MatrixTimesMatrix(
+    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[leftmatrix, rightmatrix]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.MatrixTimesMatrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.MatrixTimesMatrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6876,18 +8036,24 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(matrix::Value, scalar::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[matrix, scalar, ]
+function MatrixTimesScalar(
+    matrix::Value, scalar::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[matrix, scalar]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.MatrixTimesScalar", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.MatrixTimesScalar",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6930,13 +8096,20 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
-    
-    IR.create_operation(
-        "spv.MemoryBarrier", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("memory_semantics", memory_semantics),
+    ]
+
+    return IR.create_operation(
+        "spv.MemoryBarrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6955,12 +8128,16 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.mlir.merge", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.mlir.merge",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7007,20 +8184,34 @@ spv.module Logical Vulkan
 }
 ```
 """
-function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
+function module_(;
+    addressing_model,
+    memory_model,
+    vce_triple=nothing,
+    sym_name=nothing,
+    region_0::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0, ]
+    owned_regions = Region[region_0,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
+    attributes = NamedAttribute[
+        namedattribute("addressing_model", addressing_model),
+        namedattribute("memory_model", memory_model),
+    ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    
-    IR.create_operation(
-        "spv.module", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7050,19 +8241,23 @@ Results are computed per component, and within each component, per bit.
     %3 = spv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.Not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7094,17 +8289,21 @@ ordered-op ::= ssa-id `=` `spv.Ordered` ssa-use, ssa-use
 ```
 """
 function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Ordered", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Ordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7153,18 +8352,28 @@ func @ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> () 
 }
 ```
 """
-function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base_ptr, element, indices..., ]
+function PtrAccessChain(
+    base_ptr::Value,
+    element::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base_ptr, element, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.PtrAccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.PtrAccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7194,17 +8403,21 @@ spv-reference-of-op ::= ssa-id `=` `spv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference, ]
+    results = IR.Type[reference,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
-    
-    IR.create_operation(
-        "spv.mlir.referenceof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
+
+    return IR.create_operation(
+        "spv.mlir.referenceof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7225,12 +8438,16 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7257,16 +8474,20 @@ spv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ReturnValue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ReturnValue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7296,17 +8517,21 @@ s-convert-op ::= ssa-id `=` `spv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7338,19 +8563,28 @@ sdiv-op ::= ssa-id `=` `spv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.SDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7380,18 +8614,24 @@ sgreater-than-equal-op ::= ssa-id `=` `spv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SGreaterThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7421,18 +8661,24 @@ sgreater-than-op ::= ssa-id `=` `spv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SGreaterThan(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SGreaterThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7462,18 +8708,24 @@ sless-than-equal-op ::= ssa-id `=` `spv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SLessThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7504,17 +8756,21 @@ sless-than-op ::= ssa-id `=` `spv.SLessThan` ssa-use, ssa-use
 ```
 """
 function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SLessThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7547,19 +8803,28 @@ smod-op ::= ssa-id `=` `spv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.SMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7583,19 +8848,25 @@ must equal the component width in Result Type.
 %3 = spv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SNegate(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.SNegate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SNegate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7628,19 +8899,28 @@ srem-op ::= ssa-id `=` `spv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SRem(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.SRem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SRem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7683,19 +8963,29 @@ select-op ::= ssa-id `=` `spv.Select` ssa-use, ssa-use, ssa-use
 %3 = spv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function Select(
+    condition::Value,
+    true_value::Value,
+    false_value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value, ]
+    operands = Value[condition, true_value, false_value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.Select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7723,15 +9013,19 @@ The merge block should only contain a `spv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
-    
-    IR.create_operation(
-        "spv.mlir.selection", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
+
+    return IR.create_operation(
+        "spv.mlir.selection",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7771,19 +9065,28 @@ shift-left-logical-op ::= ssa-id `=` `spv.ShiftLeftLogical`
 %5 = spv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftLeftLogical(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.ShiftLeftLogical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ShiftLeftLogical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7820,19 +9123,28 @@ shift-right-arithmetic-op ::= ssa-id `=` `spv.ShiftRightArithmetic`
 %5 = spv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftRightArithmetic(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.ShiftRightArithmetic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ShiftRightArithmetic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7870,19 +9182,28 @@ shift-right-logical-op ::= ssa-id `=` `spv.ShiftRightLogical`
 %5 = spv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftRightLogical(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.ShiftRightLogical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ShiftRightLogical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7927,13 +9248,21 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
-    
-    IR.create_operation(
-        "spv.SpecConstantComposite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("type", type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("constituents", constituents),
+    ]
+
+    return IR.create_operation(
+        "spv.SpecConstantComposite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7973,13 +9302,19 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
-    
-    IR.create_operation(
-        "spv.SpecConstant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
+    ]
+
+    return IR.create_operation(
+        "spv.SpecConstant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8053,17 +9388,21 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SpecConstantOperation", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SpecConstantOperation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8096,20 +9435,27 @@ spv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
+function Store(
+    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[ptr, value, ]
+    operands = Value[ptr, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spv.Store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8144,17 +9490,21 @@ subgroup-ballot-op ::= ssa-id `=` `spv.SubgroupBallotKHR`
 ```
 """
 function SubgroupBallotKHR(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[predicate, ]
+    results = IR.Type[result,]
+    operands = Value[predicate,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SubgroupBallotKHR", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SubgroupBallotKHR",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8190,17 +9540,21 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spv.SubgroupBlockReadINTEL`
 ```
 """
 function SubgroupBlockReadINTEL(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[ptr, ]
+    results = IR.Type[value,]
+    operands = Value[ptr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SubgroupBlockReadINTEL", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SubgroupBlockReadINTEL",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8236,16 +9590,20 @@ spv.SubgroupBlockWriteINTEL \"StorageBuffer\" %ptr, %value : i32
 """
 function SubgroupBlockWriteINTEL(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value, ]
+    operands = Value[ptr, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.SubgroupBlockWriteINTEL", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.SubgroupBlockWriteINTEL",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8278,17 +9636,21 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[matrix, ]
+    results = IR.Type[result,]
+    operands = Value[matrix,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8319,17 +9681,21 @@ u-convert-op ::= ssa-id `=` `spv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.UConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.UConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8360,19 +9726,28 @@ udiv-op ::= ssa-id `=` `spv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function UDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.UDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.UDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8402,18 +9777,24 @@ ugreater-than-equal-op ::= ssa-id `=` `spv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UGreaterThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.UGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.UGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8443,18 +9824,24 @@ ugreater-than-op ::= ssa-id `=` `spv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UGreaterThan(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.UGreaterThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.UGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8484,18 +9871,24 @@ uless-than-equal-op ::= ssa-id `=` `spv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function ULessThanEqual(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ULessThanEqual", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ULessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8526,17 +9919,21 @@ uless-than-op ::= ssa-id `=` `spv.ULessThan` ssa-use, ssa-use
 ```
 """
 function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.ULessThan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.ULessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8567,19 +9964,28 @@ umod-op ::= ssa-id `=` `spv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function UMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.UMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.UMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8606,17 +10012,21 @@ undef-op ::= `spv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Undef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Undef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8648,17 +10058,21 @@ unordered-op ::= ssa-id `=` `spv.Unordered` ssa-use, ssa-use
 ```
 """
 function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Unordered", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Unordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8679,12 +10093,16 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.Unreachable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Unreachable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8722,19 +10140,28 @@ where `init` specifies initializer.
 %2 = spv.Variable init(%0): !spv.ptr<f32, Function>
 ```
 """
-function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
-    results = IR.Type[pointer, ]
+function Variable(
+    initializer=nothing::Union{Nothing,Value};
+    pointer::IR.Type,
+    storage_class,
+    location=Location(),
+)
+    results = IR.Type[pointer,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
     !isnothing(initializer) && push!(operands, initializer)
-    
-    IR.create_operation(
-        "spv.Variable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.Variable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8760,18 +10187,24 @@ or equal to the number of components in Vector.
 %2 = spv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, index, ]
+function VectorExtractDynamic(
+    vector::Value, index::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.VectorExtractDynamic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.VectorExtractDynamic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8809,19 +10242,29 @@ vector-insert-dynamic-op ::= `spv.VectorInsertDynamic ` ssa-use `,`
 %2 = spv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function VectorInsertDynamic(
+    vector::Value,
+    component::Value,
+    index::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, component, index, ]
+    operands = Value[vector, component, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spv.VectorInsertDynamic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.VectorInsertDynamic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8862,18 +10305,24 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function VectorShuffle(
+    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components), ]
-    
-    IR.create_operation(
-        "spv.VectorShuffle", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("components", components),]
+
+    return IR.create_operation(
+        "spv.VectorShuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8895,18 +10344,24 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, scalar, ]
+function VectorTimesScalar(
+    vector::Value, scalar::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector, scalar]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.VectorTimesScalar", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.VectorTimesScalar",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8931,16 +10386,20 @@ spv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spv.mlir.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spv.mlir.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/SPIRV.jl
+++ b/src/Dialects/15/SPIRV.jl
@@ -1,9 +1,8 @@
 module spv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `AccessChain`
@@ -47,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spv.AccessChain` ssa-use
 %3 = spv.Load \"Function\" %2 [\"Volatile\"] : !spv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -93,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,20 +119,16 @@ spv.AssumeTrueKHR %arg
 """
 function AssumeTrueKHR(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.AssumeTrueKHR",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.AssumeTrueKHR", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -184,31 +169,18 @@ atomic-and-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -258,35 +230,18 @@ atomic-compare-exchange-op ::=
                                 : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -314,35 +269,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -379,31 +317,18 @@ atomic-exchange-op ::=
                         : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -445,31 +370,18 @@ atomic-fadd-op ::=
                        !spv.ptr<f32, StorageBuffer>
 ```mlir
 """
-function AtomicFAddEXT(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicFAddEXT(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicFAddEXT",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicFAddEXT", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -506,31 +418,18 @@ atomic-iadd-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -566,26 +465,18 @@ atomic-idecrement-op ::=
                           !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -620,26 +511,18 @@ atomic-iincrement-op ::=
                          !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -677,31 +560,18 @@ atomic-isub-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -738,31 +608,18 @@ atomic-or-op ::=
                   !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -800,31 +657,18 @@ atomic-smax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -862,31 +706,18 @@ atomic-smin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -924,31 +755,18 @@ atomic-umax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -986,31 +804,18 @@ atomic-umin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,31 +853,18 @@ atomic-xor-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1108,25 +900,19 @@ Results are computed per component.
     %3 = spv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1172,30 +958,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1241,29 +1016,19 @@ The type of Base must be the same as Result Type.
     %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1291,29 +1056,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
 %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1345,25 +1100,19 @@ The type of Base must be the same as Result Type.
     %3 = spv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1407,21 +1156,17 @@ bitcast-op ::= ssa-id `=` `spv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1451,28 +1196,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1502,28 +1238,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1553,28 +1280,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1612,36 +1330,20 @@ spv.BranchConditional %condition, ^true_branch, ^false_branch
 spv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1667,20 +1369,16 @@ spv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1709,25 +1407,19 @@ ceil-op ::= ssa-id `=` `spv.CL.ceil` ssa-use `:`
 %3 = spv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1756,23 +1448,19 @@ cos-op ::= ssa-id `=` `spv.CL.cos` ssa-use `:`
 %3 = spv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1801,23 +1489,19 @@ erf-op ::= ssa-id `=` `spv.CL.erf` ssa-use `:`
 %3 = spv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1846,23 +1530,19 @@ exp-op ::= ssa-id `=` `spv.CL.exp` ssa-use `:`
 %3 = spv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1891,25 +1571,19 @@ abs-op ::= ssa-id `=` `spv.CL.fabs` ssa-use `:`
 %3 = spv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1938,25 +1612,19 @@ floor-op ::= ssa-id `=` `spv.CL.floor` ssa-use `:`
 %3 = spv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1981,29 +1649,19 @@ fma-op ::= ssa-id `=` `spv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2032,23 +1690,19 @@ log-op ::= ssa-id `=` `spv.CL.log` ssa-use `:`
 %3 = spv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2078,25 +1732,19 @@ pow-op ::= ssa-id `=` `spv.CL.pow` ssa-use `:`
 %3 = spv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2124,25 +1772,19 @@ round-op ::= ssa-id `=` `spv.CL.round` ssa-use `:`
 %3 = spv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2171,25 +1813,19 @@ rsqrt-op ::= ssa-id `=` `spv.CL.rsqrt` ssa-use `:`
 %3 = spv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2218,25 +1854,19 @@ abs-op ::= ssa-id `=` `spv.CL.s_abs` ssa-use `:`
 %3 = spv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2265,23 +1895,19 @@ sin-op ::= ssa-id `=` `spv.CL.sin` ssa-use `:`
 %3 = spv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2310,25 +1936,19 @@ sqrt-op ::= ssa-id `=` `spv.CL.sqrt` ssa-use `:`
 %3 = spv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2357,25 +1977,19 @@ tanh-op ::= ssa-id `=` `spv.CL.tanh` ssa-use `:`
 %3 = spv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2413,24 +2027,18 @@ composite-construct-op ::= ssa-id `=` `spv.CompositeConstruct`
 %0 = spv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2463,24 +2071,18 @@ composite-extract-op ::= ssa-id `=` `spv.CompositeExtract` ssa-use
 %2 = spv.CompositeExtract %1[1 : i32] : !spv.array<4x!spv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2513,24 +2115,18 @@ composite-insert-op ::= ssa-id `=` `spv.CompositeInsert` ssa-use, ssa-use
 %0 = spv.CompositeInsert %object, %composite[1 : i32] : f32 into !spv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2570,21 +2166,17 @@ spv.Constant-op ::= ssa-id `=` `spv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2634,28 +2226,18 @@ spv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2684,21 +2266,17 @@ convert-f-to-s-op ::= ssa-id `=` `spv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2728,21 +2306,17 @@ convert-f-to-u-op ::= ssa-id `=` `spv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2771,21 +2345,17 @@ convert-s-to-f-op ::= ssa-id `=` `spv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2814,21 +2384,17 @@ convert-u-to-f-op ::= ssa-id `=` `spv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2853,25 +2419,19 @@ For example:
 %0 = spv.CooperativeMatrixLengthNV : !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixLengthNV(;
-    result=nothing::Union{Nothing,IR.Type}, type, location=Location()
-)
+function CooperativeMatrixLengthNV(; result=nothing::Union{Nothing, IR.Type}, type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type),]
+    attributes = NamedAttribute[namedattribute("type", type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixLengthNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixLengthNV", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2928,31 +2488,19 @@ For example:
      : !spv.ptr<i32, StorageBuffer> as !spv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function CooperativeMatrixLoadNV(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function CooperativeMatrixLoadNV(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixLoadNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixLoadNV", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3003,29 +2551,19 @@ For example:
   !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixMulAddNV(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CooperativeMatrixMulAddNV(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixMulAddNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixMulAddNV", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3068,31 +2606,19 @@ For example:
     !spv.ptr<i32, StorageBuffer>, !spv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function CooperativeMatrixStoreNV(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function CooperativeMatrixStoreNV(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixStoreNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixStoreNV", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3125,37 +2651,22 @@ copy-memory-op ::= `spv.CopyMemory ` storage-class ssa-use
 spv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3205,21 +2716,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3257,21 +2760,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3299,28 +2794,19 @@ fadd-op ::= ssa-id `=` `spv.FAdd` ssa-use, ssa-use
 %5 = spv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3350,21 +2836,17 @@ f-convert-op ::= ssa-id `=` `spv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3394,28 +2876,19 @@ fdiv-op ::= ssa-id `=` `spv.FDiv` ssa-use, ssa-use
 %5 = spv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3446,28 +2919,19 @@ fmod-op ::= ssa-id `=` `spv.FMod` ssa-use, ssa-use
 %5 = spv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3497,28 +2961,19 @@ fmul-op ::= `spv.FMul` ssa-use, ssa-use
 %5 = spv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3546,25 +3001,19 @@ fmul-op ::= `spv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3595,21 +3044,17 @@ fordequal-op ::= ssa-id `=` `spv.FOrdEqual` ssa-use, ssa-use
 ```
 """
 function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3639,24 +3084,18 @@ fordgte-op ::= ssa-id `=` `spv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3686,24 +3125,18 @@ fordgt-op ::= ssa-id `=` `spv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3733,24 +3166,18 @@ fordlte-op ::= ssa-id `=` `spv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3780,24 +3207,18 @@ fordlt-op ::= ssa-id `=` `spv.FOrdLessThan` ssa-use, ssa-use
 %5 = spv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3827,24 +3248,18 @@ fordneq-op ::= ssa-id `=` `spv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3876,28 +3291,19 @@ frem-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3926,28 +3332,19 @@ fsub-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3978,21 +3375,17 @@ funordequal-op ::= ssa-id `=` `spv.FUnordEqual` ssa-use, ssa-use
 ```
 """
 function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4022,24 +3415,18 @@ funordgte-op ::= ssa-id `=` `spv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4069,24 +3456,18 @@ funordgt-op ::= ssa-id `=` `spv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4116,24 +3497,18 @@ funordlte-op ::= ssa-id `=` `spv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4163,24 +3538,18 @@ funordlt-op ::= ssa-id `=` `spv.FUnordLessThan` ssa-use, ssa-use
 %5 = spv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4210,24 +3579,18 @@ funordneq-op ::= ssa-id `=` `spv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4260,28 +3623,18 @@ spv.func @foo() -> () \"None\" { ... }
 spv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type, sym_name, function_control, body::Region, location=Location()
-)
+function func(; function_type, sym_name, function_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
-
-    return IR.create_operation(
-        "spv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
+    
+    IR.create_operation(
+        "spv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4315,28 +3668,19 @@ spv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4369,25 +3713,19 @@ acos-op ::= ssa-id `=` `spv.GL.Acos` ssa-use `:`
 %3 = spv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4420,25 +3758,19 @@ asin-op ::= ssa-id `=` `spv.GL.Asin` ssa-use `:`
 %3 = spv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4471,25 +3803,19 @@ atan-op ::= ssa-id `=` `spv.GL.Atan` ssa-use `:`
 %3 = spv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4519,25 +3845,19 @@ ceil-op ::= ssa-id `=` `spv.GL.Ceil` ssa-use `:`
 %3 = spv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4568,23 +3888,19 @@ cos-op ::= ssa-id `=` `spv.GL.Cos` ssa-use `:`
 %3 = spv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4615,25 +3931,19 @@ cosh-op ::= ssa-id `=` `spv.GL.Cosh` ssa-use `:`
 %3 = spv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4664,23 +3974,19 @@ exp-op ::= ssa-id `=` `spv.GL.Exp` ssa-use `:`
 %3 = spv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4709,25 +4015,19 @@ abs-op ::= ssa-id `=` `spv.GL.FAbs` ssa-use `:`
 %3 = spv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4757,21 +4057,17 @@ fclamp-op ::= ssa-id `=` `spv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4801,25 +4097,19 @@ fmax-op ::= ssa-id `=` `spv.GL.FMax` ssa-use `:`
 %3 = spv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4849,25 +4139,19 @@ fmin-op ::= ssa-id `=` `spv.GL.FMin` ssa-use `:`
 %3 = spv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4889,29 +4173,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4940,25 +4214,19 @@ sign-op ::= ssa-id `=` `spv.GL.FSign` ssa-use `:`
 %3 = spv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4975,25 +4243,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5023,25 +4285,19 @@ floor-op ::= ssa-id `=` `spv.GL.Floor` ssa-use `:`
 %3 = spv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5081,21 +4337,17 @@ fma-op ::= ssa-id `=` `spv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5138,21 +4390,17 @@ frexpstruct-op ::= ssa-id `=` `spv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5181,25 +4429,19 @@ rsqrt-op ::= ssa-id `=` `spv.GL.InverseSqrt` ssa-use `:`
 %3 = spv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5237,25 +4479,19 @@ component.
 %y = spv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5287,23 +4523,19 @@ log-op ::= ssa-id `=` `spv.GL.Log` ssa-use `:`
 %3 = spv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5336,25 +4568,19 @@ pow-op ::= ssa-id `=` `spv.GL.Pow` ssa-use `:`
 %3 = spv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5383,25 +4609,19 @@ floor-op ::= ssa-id `=` `spv.GL.Round` ssa-use `:`
 %3 = spv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5429,25 +4649,19 @@ abs-op ::= ssa-id `=` `spv.GL.SAbs` ssa-use `:`
 %3 = spv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5476,21 +4690,17 @@ uclamp-op ::= ssa-id `=` `spv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5519,25 +4729,19 @@ smax-op ::= ssa-id `=` `spv.GL.SMax` ssa-use `:`
 %3 = spv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5566,25 +4770,19 @@ smin-op ::= ssa-id `=` `spv.GL.SMin` ssa-use `:`
 %3 = spv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5612,25 +4810,19 @@ sign-op ::= ssa-id `=` `spv.GL.SSign` ssa-use `:`
 %3 = spv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5661,23 +4853,19 @@ sin-op ::= ssa-id `=` `spv.GL.Sin` ssa-use `:`
 %3 = spv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5708,25 +4896,19 @@ sinh-op ::= ssa-id `=` `spv.GL.Sinh` ssa-use `:`
 %3 = spv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5755,25 +4937,19 @@ sqrt-op ::= ssa-id `=` `spv.GL.Sqrt` ssa-use `:`
 %3 = spv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5804,23 +4980,19 @@ tan-op ::= ssa-id `=` `spv.GL.Tan` ssa-use `:`
 %3 = spv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5851,25 +5023,19 @@ tanh-op ::= ssa-id `=` `spv.GL.Tanh` ssa-use `:`
 %3 = spv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5898,21 +5064,17 @@ uclamp-op ::= ssa-id `=` `spv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5941,25 +5103,19 @@ smax-op ::= ssa-id `=` `spv.GL.UMax` ssa-use `:`
 %3 = spv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5988,25 +5144,19 @@ smin-op ::= ssa-id `=` `spv.GL.UMin` ssa-use `:`
 %3 = spv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6050,39 +5200,23 @@ spv.GlobalVariable @var2 bind(1, 2) : !spv.ptr<f32, Uniform>
 spv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-
-    return IR.create_operation(
-        "spv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6131,29 +5265,19 @@ group-broadcast-op ::= ssa-id `=` `spv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6186,24 +5310,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spv.GroupNonUniformBallot` scope
 %0 = spv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6248,29 +5366,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6295,25 +5403,19 @@ non-uniform-elect-op ::= ssa-id `=` `spv.GroupNonUniformElect` scope
 %0 = spv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6359,33 +5461,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spv.GroupNonUniformFAdd` scope operation
 %1 = spv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6434,33 +5522,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spv.GroupNonUniformFMax` scope operation
 %1 = spv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6509,33 +5583,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spv.GroupNonUniformFMin` scope operation
 %1 = spv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6581,33 +5641,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spv.GroupNonUniformFMul` scope operation
 %1 = spv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6651,33 +5697,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spv.GroupNonUniformIAdd` scope operation
 %1 = spv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6721,33 +5753,19 @@ non-uniform-imul-op ::= ssa-id `=` `spv.GroupNonUniformIMul` scope operation
 %1 = spv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6791,33 +5809,19 @@ non-uniform-smax-op ::= ssa-id `=` `spv.GroupNonUniformSMax` scope operation
 %1 = spv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6861,33 +5865,19 @@ non-uniform-smin-op ::= ssa-id `=` `spv.GroupNonUniformSMin` scope operation
 %1 = spv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6932,33 +5922,19 @@ non-uniform-umax-op ::= ssa-id `=` `spv.GroupNonUniformUMax` scope operation
 %1 = spv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7003,33 +5979,19 @@ non-uniform-umin-op ::= ssa-id `=` `spv.GroupNonUniformUMin` scope operation
 %1 = spv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7064,28 +6026,19 @@ iadd-op ::= ssa-id `=` `spv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7116,21 +6069,17 @@ iequal-op ::= ssa-id `=` `spv.IEqual` ssa-use, ssa-use
 ```
 """
 function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7165,28 +6114,19 @@ imul-op ::= ssa-id `=` `spv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7217,21 +6157,17 @@ inot-equal-op ::= ssa-id `=` `spv.INotEqual` ssa-use, ssa-use
 ```
 """
 function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7267,21 +6203,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7316,28 +6248,19 @@ isub-op ::= `spv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7377,32 +6300,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spv.ImageDrefGather %1 : !spv.sampled_image<!spv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7423,21 +6333,17 @@ same as Result Type.
 ```
 """
 function Image(sampledimage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[sampledimage,]
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Image", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7476,21 +6382,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7516,28 +6418,18 @@ func @inbounds_ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i6
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7568,21 +6460,17 @@ isinf-op ::= ssa-id `=` `spv.IsInf` ssa-use
 ```
 """
 function IsInf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IsInf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7613,21 +6501,17 @@ isnan-op ::= ssa-id `=` `spv.IsNan` ssa-use
 ```
 """
 function IsNan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IsNan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7664,31 +6548,20 @@ load-op ::= ssa-id ` = spv.Load ` storage-class ssa-use
 %3 = spv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7718,21 +6591,17 @@ logical-and ::= `spv.LogicalAnd` ssa-use `,` ssa-use
 ```
 """
 function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7761,24 +6630,18 @@ logical-equal ::= `spv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7807,24 +6670,18 @@ logical-not-equal ::= `spv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7851,21 +6708,17 @@ logical-not ::= `spv.LogicalNot` ssa-use `:` operand-type
 ```
 """
 function LogicalNot(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7895,21 +6748,17 @@ logical-or ::= `spv.LogicalOr` ssa-use `,` ssa-use
 ```
 """
 function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7943,19 +6792,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7988,24 +6833,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8037,24 +6876,18 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[matrix, scalar]
+function MatrixTimesScalar(matrix::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8097,20 +6930,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8129,16 +6955,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8185,34 +7007,20 @@ spv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8242,23 +7050,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8290,21 +7094,17 @@ ordered-op ::= ssa-id `=` `spv.Ordered` ssa-use, ssa-use
 ```
 """
 function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8353,28 +7153,18 @@ func @ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> () 
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8404,21 +7194,17 @@ spv-reference-of-op ::= ssa-id `=` `spv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8439,16 +7225,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8475,20 +7257,16 @@ spv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8518,21 +7296,17 @@ s-convert-op ::= ssa-id `=` `spv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8564,28 +7338,19 @@ sdiv-op ::= ssa-id `=` `spv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8615,24 +7380,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8662,24 +7421,18 @@ sgreater-than-op ::= ssa-id `=` `spv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8709,24 +7462,18 @@ sless-than-equal-op ::= ssa-id `=` `spv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8757,21 +7504,17 @@ sless-than-op ::= ssa-id `=` `spv.SLessThan` ssa-use, ssa-use
 ```
 """
 function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8804,28 +7547,19 @@ smod-op ::= ssa-id `=` `spv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8849,25 +7583,19 @@ must equal the component width in Result Type.
 %3 = spv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8900,28 +7628,19 @@ srem-op ::= ssa-id `=` `spv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8964,29 +7683,19 @@ select-op ::= ssa-id `=` `spv.Select` ssa-use, ssa-use, ssa-use
 %3 = spv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9014,19 +7723,15 @@ The merge block should only contain a `spv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9066,28 +7771,19 @@ shift-left-logical-op ::= ssa-id `=` `spv.ShiftLeftLogical`
 %5 = spv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9124,28 +7820,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spv.ShiftRightArithmetic`
 %5 = spv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9183,28 +7870,19 @@ shift-right-logical-op ::= ssa-id `=` `spv.ShiftRightLogical`
 %5 = spv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9249,21 +7927,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9303,19 +7973,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9389,21 +8053,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9436,27 +8096,20 @@ spv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9491,21 +8144,17 @@ subgroup-ballot-op ::= ssa-id `=` `spv.SubgroupBallotKHR`
 ```
 """
 function SubgroupBallotKHR(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBallotKHR",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBallotKHR", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9541,21 +8190,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spv.SubgroupBlockReadINTEL`
 ```
 """
 function SubgroupBlockReadINTEL(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBlockReadINTEL",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBlockReadINTEL", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9591,20 +8236,16 @@ spv.SubgroupBlockWriteINTEL \"StorageBuffer\" %ptr, %value : i32
 """
 function SubgroupBlockWriteINTEL(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBlockWriteINTEL",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBlockWriteINTEL", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9637,21 +8278,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9682,21 +8319,17 @@ u-convert-op ::= ssa-id `=` `spv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9727,28 +8360,19 @@ udiv-op ::= ssa-id `=` `spv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9778,24 +8402,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9825,24 +8443,18 @@ ugreater-than-op ::= ssa-id `=` `spv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9872,24 +8484,18 @@ uless-than-equal-op ::= ssa-id `=` `spv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9920,21 +8526,17 @@ uless-than-op ::= ssa-id `=` `spv.ULessThan` ssa-use, ssa-use
 ```
 """
 function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9965,28 +8567,19 @@ umod-op ::= ssa-id `=` `spv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10013,21 +8606,17 @@ undef-op ::= `spv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10059,21 +8648,17 @@ unordered-op ::= ssa-id `=` `spv.Unordered` ssa-use, ssa-use
 ```
 """
 function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Unordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10094,16 +8679,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10141,28 +8722,19 @@ where `init` specifies initializer.
 %2 = spv.Variable init(%0): !spv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10188,24 +8760,18 @@ or equal to the number of components in Vector.
 %2 = spv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10243,29 +8809,19 @@ vector-insert-dynamic-op ::= `spv.VectorInsertDynamic ` ssa-use `,`
 %2 = spv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10306,24 +8862,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10345,24 +8895,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10387,20 +8931,16 @@ spv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SPIRV.jl
+++ b/src/Dialects/15/SPIRV.jl
@@ -1,8 +1,8 @@
 module spv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `AccessChain`
@@ -46,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spv.AccessChain` ssa-use
 %3 = spv.Load \"Function\" %2 [\"Volatile\"] : !spv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -129,20 +119,16 @@ spv.AssumeTrueKHR %arg
 """
 function AssumeTrueKHR(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.AssumeTrueKHR",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.AssumeTrueKHR", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -183,31 +169,18 @@ atomic-and-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -257,35 +230,18 @@ atomic-compare-exchange-op ::=
                                 : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -313,35 +269,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,31 +317,18 @@ atomic-exchange-op ::=
                         : !spv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,31 +370,18 @@ atomic-fadd-op ::=
                        !spv.ptr<f32, StorageBuffer>
 ```mlir
 """
-function AtomicFAddEXT(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicFAddEXT(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicFAddEXT",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicFAddEXT", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -505,31 +418,18 @@ atomic-iadd-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -565,26 +465,18 @@ atomic-idecrement-op ::=
                           !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,26 +511,18 @@ atomic-iincrement-op ::=
                          !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -676,31 +560,18 @@ atomic-isub-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -737,31 +608,18 @@ atomic-or-op ::=
                   !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -799,31 +657,18 @@ atomic-smax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -861,31 +706,18 @@ atomic-smin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -923,31 +755,18 @@ atomic-umax-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -985,31 +804,18 @@ atomic-umin-op ::=
                     !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1047,31 +853,18 @@ atomic-xor-op ::=
                    !spv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1107,25 +900,19 @@ Results are computed per component.
     %3 = spv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1171,30 +958,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1240,29 +1016,19 @@ The type of Base must be the same as Result Type.
     %0 = spv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1290,29 +1056,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spv.BitFieldUExtract` ssa-use
 %0 = spv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1344,25 +1100,19 @@ The type of Base must be the same as Result Type.
     %3 = spv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1406,21 +1156,17 @@ bitcast-op ::= ssa-id `=` `spv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1450,28 +1196,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1501,28 +1238,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1552,28 +1280,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1611,36 +1330,20 @@ spv.BranchConditional %condition, ^true_branch, ^false_branch
 spv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1666,20 +1369,16 @@ spv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1708,25 +1407,19 @@ ceil-op ::= ssa-id `=` `spv.CL.ceil` ssa-use `:`
 %3 = spv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1755,23 +1448,19 @@ cos-op ::= ssa-id `=` `spv.CL.cos` ssa-use `:`
 %3 = spv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1800,23 +1489,19 @@ erf-op ::= ssa-id `=` `spv.CL.erf` ssa-use `:`
 %3 = spv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1845,23 +1530,19 @@ exp-op ::= ssa-id `=` `spv.CL.exp` ssa-use `:`
 %3 = spv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1890,25 +1571,19 @@ abs-op ::= ssa-id `=` `spv.CL.fabs` ssa-use `:`
 %3 = spv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1937,25 +1612,19 @@ floor-op ::= ssa-id `=` `spv.CL.floor` ssa-use `:`
 %3 = spv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1980,29 +1649,19 @@ fma-op ::= ssa-id `=` `spv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2031,23 +1690,19 @@ log-op ::= ssa-id `=` `spv.CL.log` ssa-use `:`
 %3 = spv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2077,25 +1732,19 @@ pow-op ::= ssa-id `=` `spv.CL.pow` ssa-use `:`
 %3 = spv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2123,25 +1772,19 @@ round-op ::= ssa-id `=` `spv.CL.round` ssa-use `:`
 %3 = spv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2170,25 +1813,19 @@ rsqrt-op ::= ssa-id `=` `spv.CL.rsqrt` ssa-use `:`
 %3 = spv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2217,25 +1854,19 @@ abs-op ::= ssa-id `=` `spv.CL.s_abs` ssa-use `:`
 %3 = spv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2264,23 +1895,19 @@ sin-op ::= ssa-id `=` `spv.CL.sin` ssa-use `:`
 %3 = spv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2309,25 +1936,19 @@ sqrt-op ::= ssa-id `=` `spv.CL.sqrt` ssa-use `:`
 %3 = spv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2356,25 +1977,19 @@ tanh-op ::= ssa-id `=` `spv.CL.tanh` ssa-use `:`
 %3 = spv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2412,24 +2027,18 @@ composite-construct-op ::= ssa-id `=` `spv.CompositeConstruct`
 %0 = spv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2462,24 +2071,18 @@ composite-extract-op ::= ssa-id `=` `spv.CompositeExtract` ssa-use
 %2 = spv.CompositeExtract %1[1 : i32] : !spv.array<4x!spv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2512,24 +2115,18 @@ composite-insert-op ::= ssa-id `=` `spv.CompositeInsert` ssa-use, ssa-use
 %0 = spv.CompositeInsert %object, %composite[1 : i32] : f32 into !spv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2569,21 +2166,17 @@ spv.Constant-op ::= ssa-id `=` `spv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2633,28 +2226,18 @@ spv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2683,21 +2266,17 @@ convert-f-to-s-op ::= ssa-id `=` `spv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2727,21 +2306,17 @@ convert-f-to-u-op ::= ssa-id `=` `spv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2770,21 +2345,17 @@ convert-s-to-f-op ::= ssa-id `=` `spv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2813,21 +2384,17 @@ convert-u-to-f-op ::= ssa-id `=` `spv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2852,25 +2419,19 @@ For example:
 %0 = spv.CooperativeMatrixLengthNV : !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixLengthNV(;
-    result=nothing::Union{Nothing,IR.Type}, type, location=Location()
-)
+function CooperativeMatrixLengthNV(; result=nothing::Union{Nothing, IR.Type}, type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type),]
+    attributes = NamedAttribute[namedattribute("type", type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixLengthNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixLengthNV", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2927,31 +2488,19 @@ For example:
      : !spv.ptr<i32, StorageBuffer> as !spv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function CooperativeMatrixLoadNV(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function CooperativeMatrixLoadNV(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixLoadNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixLoadNV", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3002,29 +2551,19 @@ For example:
   !spv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function CooperativeMatrixMulAddNV(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CooperativeMatrixMulAddNV(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixMulAddNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixMulAddNV", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3067,31 +2606,19 @@ For example:
     !spv.ptr<i32, StorageBuffer>, !spv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function CooperativeMatrixStoreNV(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function CooperativeMatrixStoreNV(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spv.CooperativeMatrixStoreNV",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spv.CooperativeMatrixStoreNV", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3124,37 +2651,22 @@ copy-memory-op ::= `spv.CopyMemory ` storage-class ssa-use
 spv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3204,21 +2716,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3256,21 +2760,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3298,28 +2794,19 @@ fadd-op ::= ssa-id `=` `spv.FAdd` ssa-use, ssa-use
 %5 = spv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3349,21 +2836,17 @@ f-convert-op ::= ssa-id `=` `spv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3393,28 +2876,19 @@ fdiv-op ::= ssa-id `=` `spv.FDiv` ssa-use, ssa-use
 %5 = spv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3445,28 +2919,19 @@ fmod-op ::= ssa-id `=` `spv.FMod` ssa-use, ssa-use
 %5 = spv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3496,28 +2961,19 @@ fmul-op ::= `spv.FMul` ssa-use, ssa-use
 %5 = spv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3545,25 +3001,19 @@ fmul-op ::= `spv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3594,21 +3044,17 @@ fordequal-op ::= ssa-id `=` `spv.FOrdEqual` ssa-use, ssa-use
 ```
 """
 function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3638,24 +3084,18 @@ fordgte-op ::= ssa-id `=` `spv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3685,24 +3125,18 @@ fordgt-op ::= ssa-id `=` `spv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3732,24 +3166,18 @@ fordlte-op ::= ssa-id `=` `spv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3779,24 +3207,18 @@ fordlt-op ::= ssa-id `=` `spv.FOrdLessThan` ssa-use, ssa-use
 %5 = spv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3826,24 +3248,18 @@ fordneq-op ::= ssa-id `=` `spv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3875,28 +3291,19 @@ frem-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3925,28 +3332,19 @@ fsub-op ::= ssa-id `=` `spv.FRemOp` ssa-use, ssa-use
 %5 = spv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3977,21 +3375,17 @@ funordequal-op ::= ssa-id `=` `spv.FUnordEqual` ssa-use, ssa-use
 ```
 """
 function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4021,24 +3415,18 @@ funordgte-op ::= ssa-id `=` `spv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4068,24 +3456,18 @@ funordgt-op ::= ssa-id `=` `spv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4115,24 +3497,18 @@ funordlte-op ::= ssa-id `=` `spv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4162,24 +3538,18 @@ funordlt-op ::= ssa-id `=` `spv.FUnordLessThan` ssa-use, ssa-use
 %5 = spv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4209,24 +3579,18 @@ funordneq-op ::= ssa-id `=` `spv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4259,28 +3623,18 @@ spv.func @foo() -> () \"None\" { ... }
 spv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type, sym_name, function_control, body::Region, location=Location()
-)
+function func(; function_type, sym_name, function_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
-
-    return IR.create_operation(
-        "spv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
+    
+    IR.create_operation(
+        "spv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4314,28 +3668,19 @@ spv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4368,25 +3713,19 @@ acos-op ::= ssa-id `=` `spv.GL.Acos` ssa-use `:`
 %3 = spv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4419,25 +3758,19 @@ asin-op ::= ssa-id `=` `spv.GL.Asin` ssa-use `:`
 %3 = spv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4470,25 +3803,19 @@ atan-op ::= ssa-id `=` `spv.GL.Atan` ssa-use `:`
 %3 = spv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4518,25 +3845,19 @@ ceil-op ::= ssa-id `=` `spv.GL.Ceil` ssa-use `:`
 %3 = spv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4567,23 +3888,19 @@ cos-op ::= ssa-id `=` `spv.GL.Cos` ssa-use `:`
 %3 = spv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4614,25 +3931,19 @@ cosh-op ::= ssa-id `=` `spv.GL.Cosh` ssa-use `:`
 %3 = spv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4663,23 +3974,19 @@ exp-op ::= ssa-id `=` `spv.GL.Exp` ssa-use `:`
 %3 = spv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4708,25 +4015,19 @@ abs-op ::= ssa-id `=` `spv.GL.FAbs` ssa-use `:`
 %3 = spv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4756,21 +4057,17 @@ fclamp-op ::= ssa-id `=` `spv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4800,25 +4097,19 @@ fmax-op ::= ssa-id `=` `spv.GL.FMax` ssa-use `:`
 %3 = spv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4848,25 +4139,19 @@ fmin-op ::= ssa-id `=` `spv.GL.FMin` ssa-use `:`
 %3 = spv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4888,29 +4173,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4939,25 +4214,19 @@ sign-op ::= ssa-id `=` `spv.GL.FSign` ssa-use `:`
 %3 = spv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4974,25 +4243,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5022,25 +4285,19 @@ floor-op ::= ssa-id `=` `spv.GL.Floor` ssa-use `:`
 %3 = spv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5080,21 +4337,17 @@ fma-op ::= ssa-id `=` `spv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5137,21 +4390,17 @@ frexpstruct-op ::= ssa-id `=` `spv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5180,25 +4429,19 @@ rsqrt-op ::= ssa-id `=` `spv.GL.InverseSqrt` ssa-use `:`
 %3 = spv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5236,25 +4479,19 @@ component.
 %y = spv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5286,23 +4523,19 @@ log-op ::= ssa-id `=` `spv.GL.Log` ssa-use `:`
 %3 = spv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5335,25 +4568,19 @@ pow-op ::= ssa-id `=` `spv.GL.Pow` ssa-use `:`
 %3 = spv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5382,25 +4609,19 @@ floor-op ::= ssa-id `=` `spv.GL.Round` ssa-use `:`
 %3 = spv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5428,25 +4649,19 @@ abs-op ::= ssa-id `=` `spv.GL.SAbs` ssa-use `:`
 %3 = spv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5475,21 +4690,17 @@ uclamp-op ::= ssa-id `=` `spv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5518,25 +4729,19 @@ smax-op ::= ssa-id `=` `spv.GL.SMax` ssa-use `:`
 %3 = spv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5565,25 +4770,19 @@ smin-op ::= ssa-id `=` `spv.GL.SMin` ssa-use `:`
 %3 = spv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5611,25 +4810,19 @@ sign-op ::= ssa-id `=` `spv.GL.SSign` ssa-use `:`
 %3 = spv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5660,23 +4853,19 @@ sin-op ::= ssa-id `=` `spv.GL.Sin` ssa-use `:`
 %3 = spv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5707,25 +4896,19 @@ sinh-op ::= ssa-id `=` `spv.GL.Sinh` ssa-use `:`
 %3 = spv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5754,25 +4937,19 @@ sqrt-op ::= ssa-id `=` `spv.GL.Sqrt` ssa-use `:`
 %3 = spv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5803,23 +4980,19 @@ tan-op ::= ssa-id `=` `spv.GL.Tan` ssa-use `:`
 %3 = spv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5850,25 +5023,19 @@ tanh-op ::= ssa-id `=` `spv.GL.Tanh` ssa-use `:`
 %3 = spv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5897,21 +5064,17 @@ uclamp-op ::= ssa-id `=` `spv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5940,25 +5103,19 @@ smax-op ::= ssa-id `=` `spv.GL.UMax` ssa-use `:`
 %3 = spv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5987,25 +5144,19 @@ smin-op ::= ssa-id `=` `spv.GL.UMin` ssa-use `:`
 %3 = spv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6049,39 +5200,23 @@ spv.GlobalVariable @var2 bind(1, 2) : !spv.ptr<f32, Uniform>
 spv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-
-    return IR.create_operation(
-        "spv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6130,29 +5265,19 @@ group-broadcast-op ::= ssa-id `=` `spv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6185,24 +5310,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spv.GroupNonUniformBallot` scope
 %0 = spv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6247,29 +5366,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6294,25 +5403,19 @@ non-uniform-elect-op ::= ssa-id `=` `spv.GroupNonUniformElect` scope
 %0 = spv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6358,33 +5461,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spv.GroupNonUniformFAdd` scope operation
 %1 = spv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6433,33 +5522,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spv.GroupNonUniformFMax` scope operation
 %1 = spv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6508,33 +5583,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spv.GroupNonUniformFMin` scope operation
 %1 = spv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6580,33 +5641,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spv.GroupNonUniformFMul` scope operation
 %1 = spv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6650,33 +5697,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spv.GroupNonUniformIAdd` scope operation
 %1 = spv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6720,33 +5753,19 @@ non-uniform-imul-op ::= ssa-id `=` `spv.GroupNonUniformIMul` scope operation
 %1 = spv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6790,33 +5809,19 @@ non-uniform-smax-op ::= ssa-id `=` `spv.GroupNonUniformSMax` scope operation
 %1 = spv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6860,33 +5865,19 @@ non-uniform-smin-op ::= ssa-id `=` `spv.GroupNonUniformSMin` scope operation
 %1 = spv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6931,33 +5922,19 @@ non-uniform-umax-op ::= ssa-id `=` `spv.GroupNonUniformUMax` scope operation
 %1 = spv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7002,33 +5979,19 @@ non-uniform-umin-op ::= ssa-id `=` `spv.GroupNonUniformUMin` scope operation
 %1 = spv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7063,28 +6026,19 @@ iadd-op ::= ssa-id `=` `spv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7115,21 +6069,17 @@ iequal-op ::= ssa-id `=` `spv.IEqual` ssa-use, ssa-use
 ```
 """
 function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7164,28 +6114,19 @@ imul-op ::= ssa-id `=` `spv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7216,21 +6157,17 @@ inot-equal-op ::= ssa-id `=` `spv.INotEqual` ssa-use, ssa-use
 ```
 """
 function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7266,21 +6203,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7315,28 +6248,19 @@ isub-op ::= `spv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7376,32 +6300,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spv.ImageDrefGather %1 : !spv.sampled_image<!spv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7422,21 +6333,17 @@ same as Result Type.
 ```
 """
 function Image(sampledimage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[sampledimage,]
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Image", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7475,21 +6382,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7515,28 +6418,18 @@ func @inbounds_ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i6
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7567,21 +6460,17 @@ isinf-op ::= ssa-id `=` `spv.IsInf` ssa-use
 ```
 """
 function IsInf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IsInf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7612,21 +6501,17 @@ isnan-op ::= ssa-id `=` `spv.IsNan` ssa-use
 ```
 """
 function IsNan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.IsNan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7663,31 +6548,20 @@ load-op ::= ssa-id ` = spv.Load ` storage-class ssa-use
 %3 = spv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7717,21 +6591,17 @@ logical-and ::= `spv.LogicalAnd` ssa-use `,` ssa-use
 ```
 """
 function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7760,24 +6630,18 @@ logical-equal ::= `spv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7806,24 +6670,18 @@ logical-not-equal ::= `spv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7850,21 +6708,17 @@ logical-not ::= `spv.LogicalNot` ssa-use `:` operand-type
 ```
 """
 function LogicalNot(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7894,21 +6748,17 @@ logical-or ::= `spv.LogicalOr` ssa-use `,` ssa-use
 ```
 """
 function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7942,19 +6792,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7987,24 +6833,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8036,24 +6876,18 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[matrix, scalar]
+function MatrixTimesScalar(matrix::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8096,20 +6930,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8128,16 +6955,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8184,34 +7007,20 @@ spv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8241,23 +7050,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8289,21 +7094,17 @@ ordered-op ::= ssa-id `=` `spv.Ordered` ssa-use, ssa-use
 ```
 """
 function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8352,28 +7153,18 @@ func @ptr_access_chain(%arg0: !spv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> () 
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8403,21 +7194,17 @@ spv-reference-of-op ::= ssa-id `=` `spv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8438,16 +7225,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8474,20 +7257,16 @@ spv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8517,21 +7296,17 @@ s-convert-op ::= ssa-id `=` `spv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8563,28 +7338,19 @@ sdiv-op ::= ssa-id `=` `spv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8614,24 +7380,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8661,24 +7421,18 @@ sgreater-than-op ::= ssa-id `=` `spv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8708,24 +7462,18 @@ sless-than-equal-op ::= ssa-id `=` `spv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8756,21 +7504,17 @@ sless-than-op ::= ssa-id `=` `spv.SLessThan` ssa-use, ssa-use
 ```
 """
 function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8803,28 +7547,19 @@ smod-op ::= ssa-id `=` `spv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8848,25 +7583,19 @@ must equal the component width in Result Type.
 %3 = spv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8899,28 +7628,19 @@ srem-op ::= ssa-id `=` `spv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8963,29 +7683,19 @@ select-op ::= ssa-id `=` `spv.Select` ssa-use, ssa-use, ssa-use
 %3 = spv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9013,19 +7723,15 @@ The merge block should only contain a `spv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9065,28 +7771,19 @@ shift-left-logical-op ::= ssa-id `=` `spv.ShiftLeftLogical`
 %5 = spv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9123,28 +7820,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spv.ShiftRightArithmetic`
 %5 = spv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9182,28 +7870,19 @@ shift-right-logical-op ::= ssa-id `=` `spv.ShiftRightLogical`
 %5 = spv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9248,21 +7927,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9302,19 +7973,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9388,21 +8053,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9435,27 +8096,20 @@ spv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9490,21 +8144,17 @@ subgroup-ballot-op ::= ssa-id `=` `spv.SubgroupBallotKHR`
 ```
 """
 function SubgroupBallotKHR(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBallotKHR",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBallotKHR", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9540,21 +8190,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spv.SubgroupBlockReadINTEL`
 ```
 """
 function SubgroupBlockReadINTEL(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBlockReadINTEL",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBlockReadINTEL", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9590,20 +8236,16 @@ spv.SubgroupBlockWriteINTEL \"StorageBuffer\" %ptr, %value : i32
 """
 function SubgroupBlockWriteINTEL(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.SubgroupBlockWriteINTEL",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.SubgroupBlockWriteINTEL", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9636,21 +8278,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9681,21 +8319,17 @@ u-convert-op ::= ssa-id `=` `spv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9726,28 +8360,19 @@ udiv-op ::= ssa-id `=` `spv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9777,24 +8402,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9824,24 +8443,18 @@ ugreater-than-op ::= ssa-id `=` `spv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9871,24 +8484,18 @@ uless-than-equal-op ::= ssa-id `=` `spv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9919,21 +8526,17 @@ uless-than-op ::= ssa-id `=` `spv.ULessThan` ssa-use, ssa-use
 ```
 """
 function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9964,28 +8567,19 @@ umod-op ::= ssa-id `=` `spv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10012,21 +8606,17 @@ undef-op ::= `spv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10058,21 +8648,17 @@ unordered-op ::= ssa-id `=` `spv.Unordered` ssa-use, ssa-use
 ```
 """
 function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Unordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10093,16 +8679,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10140,28 +8722,19 @@ where `init` specifies initializer.
 %2 = spv.Variable init(%0): !spv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10187,24 +8760,18 @@ or equal to the number of components in Vector.
 %2 = spv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10242,29 +8809,19 @@ vector-insert-dynamic-op ::= `spv.VectorInsertDynamic ` ssa-use `,`
 %2 = spv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10305,24 +8862,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10344,24 +8895,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10386,20 +8931,16 @@ spv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Shape.jl
+++ b/src/Dialects/15/Shape.jl
@@ -1,9 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -15,25 +14,19 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -54,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -124,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -260,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -289,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -324,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -361,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -396,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -437,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -467,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,25 +429,19 @@ negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,25 +452,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -566,25 +481,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -595,28 +504,19 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function func(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -642,19 +542,15 @@ shape.function_library {
 function function_library(; mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mapping", mapping),]
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mapping", mapping), ]
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -664,25 +560,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -695,25 +585,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -735,25 +619,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -765,25 +643,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -814,30 +686,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -849,25 +711,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -881,25 +737,19 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -912,25 +762,19 @@ extents. If the argument is of type `shape` then the result will be of type
 is and extent tensor `tensor<?xindex>` then the result will be of type
 `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -939,23 +783,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -992,28 +832,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) -> !shape.size {
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1023,22 +853,18 @@ end
 The `shape.return` operation represents a return operation within a function.
 The operation takes variable number of operands and produces no results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1051,25 +877,19 @@ as their equivalent non-error shapes. Error shapes can be tested for
 equality like any other shape value, meaning that the error value is equal
 to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1079,23 +899,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1107,25 +923,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1153,24 +963,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1184,21 +988,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1220,21 +1020,17 @@ representing sizes) then this propagages the error shape. E.g.,
 This operation is the compliment of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1273,28 +1069,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1302,22 +1089,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Shape.jl
+++ b/src/Dialects/15/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add`
@@ -14,19 +14,25 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -47,17 +53,21 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[inputs..., ]
+    results = IR.Type[result,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.any", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -81,19 +91,25 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function assuming_all(
+    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[inputs..., ]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.assuming_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -107,18 +123,24 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[witness, ]
-    owned_regions = Region[doRegion, ]
+function assuming(
+    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[witness,]
+    owned_regions = Region[doRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.assuming", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -130,18 +152,22 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands_::Vector{Value}; location=Location())
+function assuming_yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.assuming_yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming_yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -168,19 +194,25 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[shapes..., ]
+function broadcast(
+    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-    
-    IR.create_operation(
-        "shape.broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -196,17 +228,21 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.concat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.concat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -223,19 +259,23 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape), ]
+    attributes = NamedAttribute[namedattribute("shape", shape),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -248,19 +288,23 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -279,19 +323,25 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
+function const_witness(;
+    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing), ]
+    attributes = NamedAttribute[namedattribute("passing", passing),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_witness", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_witness",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -310,19 +360,25 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cstr_broadcastable(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_broadcastable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_broadcastable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -339,19 +395,25 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cstr_eq(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -374,19 +436,25 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
+function cstr_require(
+    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
+)
     results = IR.Type[]
-    operands = Value[pred, ]
+    operands = Value[pred,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    attributes = NamedAttribute[namedattribute("msg", msg),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_require", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_require",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -398,17 +466,21 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.debug_print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.debug_print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -429,19 +501,25 @@ negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function div(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -452,19 +530,25 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function from_extent_tensor(
+    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.from_extent_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.from_extent_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -481,19 +565,25 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
+function from_extents(
+    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[extents..., ]
+    operands = Value[extents...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-    
-    IR.create_operation(
-        "shape.from_extents", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.from_extents",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -504,19 +594,28 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
+function func(;
+    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "shape.func", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "shape.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -542,15 +641,19 @@ shape.function_library {
 function function_library(; mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mapping", mapping), ]
-    
-    IR.create_operation(
-        "shape.function_library", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mapping", mapping),]
+
+    return IR.create_operation(
+        "shape.function_library",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -560,19 +663,25 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
+function get_extent(
+    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shape, dim, ]
+    operands = Value[shape, dim]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-    
-    IR.create_operation(
-        "shape.get_extent", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.get_extent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -585,19 +694,25 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function index_to_size(
+    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.index_to_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.index_to_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -619,19 +734,25 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function is_broadcastable(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.is_broadcastable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.is_broadcastable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -643,19 +764,25 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -686,20 +813,30 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
+function meet(
+    arg0::Value,
+    arg1::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    error=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arg0, arg1, ]
+    operands = Value[arg0, arg1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-    
-    IR.create_operation(
-        "shape.meet", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.meet",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -711,19 +848,25 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -737,19 +880,25 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -762,19 +911,25 @@ extents. If the argument is of type `shape` then the result will be of type
 is and extent tensor `tensor<?xindex>` then the result will be of type
 `index`.
 """
-function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function num_elements(
+    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shape, ]
+    operands = Value[shape,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.num_elements", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.num_elements",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -783,19 +938,23 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, ]
+    operands = Value[shape,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "shape.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -832,18 +991,28 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) -> !shape.size {
 }
 ```
 """
-function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[shape, initVals..., ]
-    owned_regions = Region[region, ]
+function reduce(
+    shape::Value,
+    initVals::Vector{Value};
+    result::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[shape, initVals...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -853,18 +1022,22 @@ end
 The `shape.return` operation represents a return operation within a function.
 The operation takes variable number of operands and produces no results.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -877,19 +1050,25 @@ as their equivalent non-error shapes. Error shapes can be tested for
 equality like any other shape value, meaning that the error value is equal
 to itself.
 """
-function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shape_eq(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.shape_eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.shape_eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -899,19 +1078,23 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.shape_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.shape_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -923,19 +1106,25 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function size_to_index(
+    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.size_to_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.size_to_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -963,18 +1152,24 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
-    results = IR.Type[head, tail, ]
-    operands = Value[operand, index, ]
+function split_at(
+    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
+)
+    results = IR.Type[head, tail]
+    operands = Value[operand, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.split_at", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.split_at",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -988,17 +1183,21 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[input, ]
+    results = IR.Type[result,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.to_extent_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.to_extent_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1020,17 +1219,21 @@ representing sizes) then this propagages the error shape. E.g.,
 This operation is the compliment of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arg, ]
+    results = IR.Type[result,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.value_as_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.value_as_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1069,19 +1272,28 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function with_shape(
+    operand::Value,
+    shape::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, shape, ]
+    operands = Value[operand, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.with_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.with_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1089,18 +1301,22 @@ end
 `yield`
 
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Shape.jl
+++ b/src/Dialects/15/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -14,25 +14,19 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -53,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -91,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -123,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -228,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -259,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -288,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -360,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -395,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -436,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -466,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,25 +429,19 @@ negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -530,25 +452,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -565,25 +481,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -594,28 +504,19 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name, function_type, sym_visibility=nothing, body::Region, location=Location()
-)
+function func(; sym_name, function_type, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,19 +542,15 @@ shape.function_library {
 function function_library(; mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mapping", mapping),]
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mapping", mapping), ]
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,25 +560,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -694,25 +585,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -734,25 +619,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -764,25 +643,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -813,30 +686,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -848,25 +711,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -880,25 +737,19 @@ the result must be of type `size`. If error propagation is not possible
 because both operands are of type `index` then the result may be of type
 `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -911,25 +762,19 @@ extents. If the argument is of type `shape` then the result will be of type
 is and extent tensor `tensor<?xindex>` then the result will be of type
 `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -938,23 +783,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -991,28 +832,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) -> !shape.size {
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1022,22 +853,18 @@ end
 The `shape.return` operation represents a return operation within a function.
 The operation takes variable number of operands and produces no results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1050,25 +877,19 @@ as their equivalent non-error shapes. Error shapes can be tested for
 equality like any other shape value, meaning that the error value is equal
 to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1078,23 +899,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1106,25 +923,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1152,24 +963,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1183,21 +988,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1219,21 +1020,17 @@ representing sizes) then this propagages the error shape. E.g.,
 This operation is the compliment of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1272,28 +1069,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1301,22 +1089,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SparseTensor.jl
+++ b/src/Dialects/15/SparseTensor.jl
@@ -1,9 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `binary`
@@ -105,36 +104,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,30 +143,18 @@ sparse_tensor.compress %0, %1, %values, %filled, %added, %2
 	  memref<?xi1>, memref<?xindex>, index
 ```
 """
-function compress(
-    tensor::Value,
-    indices::Value,
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value;
-    location=Location(),
-)
+function compress(tensor::Value, indices::Value, values::Value, filled::Value, added::Value, count::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, values, filled, added, count]
+    operands = Value[tensor, indices, values, filled, added, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,21 +192,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -271,29 +238,18 @@ may be refined over time as our sparse abstractions evolve.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>, index
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -320,20 +276,16 @@ sparse_tensor.lex_insert %tensor, %indices, %val
 """
 function lex_insert(tensor::Value, indices::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, value]
+    operands = Value[tensor, indices, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.lex_insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.lex_insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -363,29 +315,20 @@ may be refined over time as our sparse abstractions evolve.
 %1 = sparse_tensor.load %0 : tensor<8xf64, #SV>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -408,21 +351,17 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,20 +383,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -500,30 +435,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVec>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -546,21 +470,17 @@ indices array.
 ```
 """
 function indices(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor, dim]
+    results = IR.Type[result, ]
+    operands = Value[tensor, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.indices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.indices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,21 +503,17 @@ pointers array.
 ```
 """
 function pointers(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor, dim]
+    results = IR.Type[result, ]
+    operands = Value[tensor, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.pointers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.pointers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,21 +535,17 @@ values array.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -701,28 +613,18 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -744,20 +646,16 @@ Yields a value from within a `binary` or `unary` block.
 """
 function yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SparseTensor.jl
+++ b/src/Dialects/15/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `binary`
@@ -104,36 +104,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,30 +143,18 @@ sparse_tensor.compress %0, %1, %values, %filled, %added, %2
 	  memref<?xi1>, memref<?xindex>, index
 ```
 """
-function compress(
-    tensor::Value,
-    indices::Value,
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value;
-    location=Location(),
-)
+function compress(tensor::Value, indices::Value, values::Value, filled::Value, added::Value, count::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, values, filled, added, count]
+    operands = Value[tensor, indices, values, filled, added, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,21 +192,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -270,29 +238,18 @@ may be refined over time as our sparse abstractions evolve.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>, index
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -319,20 +276,16 @@ sparse_tensor.lex_insert %tensor, %indices, %val
 """
 function lex_insert(tensor::Value, indices::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, value]
+    operands = Value[tensor, indices, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.lex_insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.lex_insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -362,29 +315,20 @@ may be refined over time as our sparse abstractions evolve.
 %1 = sparse_tensor.load %0 : tensor<8xf64, #SV>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,21 +351,17 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -443,20 +383,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -499,30 +435,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVec>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -545,21 +470,17 @@ indices array.
 ```
 """
 function indices(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor, dim]
+    results = IR.Type[result, ]
+    operands = Value[tensor, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.indices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.indices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +503,17 @@ pointers array.
 ```
 """
 function pointers(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor, dim]
+    results = IR.Type[result, ]
+    operands = Value[tensor, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.pointers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.pointers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,21 +535,17 @@ values array.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -700,28 +613,18 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -743,20 +646,16 @@ Yields a value from within a `binary` or `unary` block.
 """
 function yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/SparseTensor.jl
+++ b/src/Dialects/15/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `binary`
@@ -104,20 +104,36 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[x, y, ]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
+function binary(
+    x::Value,
+    y::Value;
+    output::IR.Type,
+    left_identity=nothing,
+    right_identity=nothing,
+    overlapRegion::Region,
+    leftRegion::Region,
+    rightRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[x, y]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
-    
-    IR.create_operation(
-        "sparse_tensor.binary", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(left_identity) &&
+        push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) &&
+        push!(attributes, namedattribute("right_identity", right_identity))
+
+    return IR.create_operation(
+        "sparse_tensor.binary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -143,18 +159,30 @@ sparse_tensor.compress %0, %1, %values, %filled, %added, %2
 	  memref<?xi1>, memref<?xindex>, index
 ```
 """
-function compress(tensor::Value, indices::Value, values::Value, filled::Value, added::Value, count::Value; location=Location())
+function compress(
+    tensor::Value,
+    indices::Value,
+    values::Value,
+    filled::Value,
+    added::Value,
+    count::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[tensor, indices, values, filled, added, count, ]
+    operands = Value[tensor, indices, values, filled, added, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.compress", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -192,17 +220,21 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.convert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.convert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -238,18 +270,29 @@ may be refined over time as our sparse abstractions evolve.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>, index
 ```
 """
-function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
-    results = IR.Type[values, filled, added, count, ]
-    operands = Value[tensor, ]
+function expand(
+    tensor::Value;
+    values::IR.Type,
+    filled::IR.Type,
+    added::IR.Type,
+    count::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[values, filled, added, count]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.expand", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.expand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -276,16 +319,20 @@ sparse_tensor.lex_insert %tensor, %indices, %val
 """
 function lex_insert(tensor::Value, indices::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, indices, value, ]
+    operands = Value[tensor, indices, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.lex_insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.lex_insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -315,20 +362,29 @@ may be refined over time as our sparse abstractions evolve.
 %1 = sparse_tensor.load %0 : tensor<8xf64, #SV>
 ```
 """
-function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
+function load(
+    tensor::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    hasInserts=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-    
-    IR.create_operation(
-        "sparse_tensor.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -351,17 +407,21 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.new", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.new",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -383,16 +443,20 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest, ]
+    operands = Value[tensor, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.out", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.out",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -435,19 +499,30 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVec>
 ```
 """
-function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
+function reduce(
+    x::Value,
+    y::Value,
+    identity::Value;
+    output=nothing::Union{Nothing,IR.Type},
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, identity, ]
-    owned_regions = Region[region, ]
+    operands = Value[x, y, identity]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "sparse_tensor.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -470,17 +545,21 @@ indices array.
 ```
 """
 function indices(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, dim, ]
+    results = IR.Type[result,]
+    operands = Value[tensor, dim]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.indices", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.indices",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -503,17 +582,21 @@ pointers array.
 ```
 """
 function pointers(tensor::Value, dim::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, dim, ]
+    results = IR.Type[result,]
+    operands = Value[tensor, dim]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.pointers", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.pointers",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -535,17 +618,21 @@ values array.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.values", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.values",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -613,18 +700,28 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[x, ]
-    owned_regions = Region[presentRegion, absentRegion, ]
+function unary(
+    x::Value;
+    output::IR.Type,
+    presentRegion::Region,
+    absentRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[x,]
+    owned_regions = Region[presentRegion, absentRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.unary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.unary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -646,16 +743,20 @@ Yields a value from within a `binary` or `unary` block.
 """
 function yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Tensor.jl
+++ b/src/Dialects/15/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `cast`
@@ -28,21 +28,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,21 +68,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,25 +107,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -163,21 +149,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,24 +181,18 @@ indices should all be of `index` type.
 %6 = tensor.extract %ut[%1, %2] : tensor<*xi32>
 ```
 """
-function extract(
-    tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -281,40 +257,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -337,21 +292,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,24 +328,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -419,24 +364,18 @@ indices should all be of `index` type.
 %6 = tensor.insert %ut into %dest[%1, %2] : tensor<*xi32>
 ```
 """
-function insert(
-    scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -495,41 +434,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,36 +522,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -699,40 +600,19 @@ Verification in the rank-reduced case:
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -748,23 +628,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -803,21 +679,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -847,21 +719,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -874,20 +742,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Tensor.jl
+++ b/src/Dialects/15/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `cast`
@@ -28,17 +28,21 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -68,17 +72,21 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "tensor.collapse_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "tensor.collapse_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -107,19 +115,25 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, index, ]
+    operands = Value[source, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "tensor.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -149,17 +163,21 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "tensor.expand_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "tensor.expand_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -181,18 +199,24 @@ indices should all be of `index` type.
 %6 = tensor.extract %ut[%1, %2] : tensor<*xi32>
 ```
 """
-function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, indices..., ]
+function extract(
+    tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[tensor, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.extract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -257,19 +281,40 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function extract_slice(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.extract_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.extract_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -292,17 +337,21 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[elements..., ]
+    results = IR.Type[result,]
+    operands = Value[elements...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.from_elements", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.from_elements",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -328,18 +377,24 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamicExtents..., ]
-    owned_regions = Region[body, ]
+function generate(
+    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[dynamicExtents...,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.generate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.generate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -364,18 +419,24 @@ indices should all be of `index` type.
 %6 = tensor.insert %ut into %dest[%1, %2] : tensor<*xi32>
 ```
 """
-function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[scalar, dest, indices..., ]
+function insert(
+    scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[scalar, dest, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -434,19 +495,41 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, offsets..., sizes..., strides..., ]
+function insert_slice(
+    source::Value,
+    dest::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, dest, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.insert_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.insert_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -522,20 +605,36 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, low..., high..., ]
-    owned_regions = Region[region, ]
+function pad(
+    source::Value,
+    low::Vector{Value},
+    high::Vector{Value};
+    result::IR.Type,
+    static_low,
+    static_high,
+    nofold=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, low..., high...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
+    attributes = NamedAttribute[
+        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
+    ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-    
-    IR.create_operation(
-        "tensor.pad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -600,19 +699,40 @@ Verification in the rank-reduced case:
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
+function parallel_insert_slice(
+    source::Value,
+    dest::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides..., ]
+    operands = Value[source, dest, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.parallel_insert_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.parallel_insert_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -628,19 +748,23 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "tensor.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -679,17 +803,21 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, shape, ]
+    results = IR.Type[result,]
+    operands = Value[source, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -719,17 +847,21 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate, ]
-    operands = Value[input, ]
+    results = IR.Type[aggregate,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.splat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.splat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -742,16 +874,20 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Tensor.jl
+++ b/src/Dialects/15/Tensor.jl
@@ -1,9 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `cast`
@@ -29,21 +28,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +68,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -116,25 +107,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -164,21 +149,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -200,24 +181,18 @@ indices should all be of `index` type.
 %6 = tensor.extract %ut[%1, %2] : tensor<*xi32>
 ```
 """
-function extract(
-    tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -282,40 +257,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -338,21 +292,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,24 +328,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -420,24 +364,18 @@ indices should all be of `index` type.
 %6 = tensor.insert %ut into %dest[%1, %2] : tensor<*xi32>
 ```
 """
-function insert(
-    scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -496,41 +434,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -606,36 +522,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -700,40 +600,19 @@ Verification in the rank-reduced case:
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -749,23 +628,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -804,21 +679,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -848,21 +719,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -875,20 +742,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Tosa.jl
+++ b/src/Dialects/15/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -10,17 +10,21 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -31,17 +35,21 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -55,18 +63,29 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[value, multiplier, shift, ]
+function apply_scale(
+    value::Value,
+    multiplier::Value,
+    shift::Value;
+    output::IR.Type,
+    double_round,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[value, multiplier, shift]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
-    
-    IR.create_operation(
-        "tosa.apply_scale", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round),]
+
+    return IR.create_operation(
+        "tosa.apply_scale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -77,17 +96,21 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.argmax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.argmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -97,18 +120,24 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function arithmetic_right_shift(
+    input1::Value, input2::Value; output::IR.Type, round, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round), ]
-    
-    IR.create_operation(
-        "tosa.arithmetic_right_shift", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("round", round),]
+
+    return IR.create_operation(
+        "tosa.arithmetic_right_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -119,19 +148,36 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function avg_pool2d(
+    input::Value;
+    output::IR.Type,
+    kernel,
+    stride,
+    pad,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.avg_pool2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("kernel", kernel),
+        namedattribute("stride", stride),
+        namedattribute("pad", pad),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.avg_pool2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -142,17 +188,21 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -162,17 +212,21 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -183,17 +237,21 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -204,17 +262,21 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -242,17 +304,21 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -262,17 +328,21 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -285,18 +355,29 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function clamp(
+    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
-    
-    IR.create_operation(
-        "tosa.clamp", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("min_int", min_int),
+        namedattribute("max_int", max_int),
+        namedattribute("min_fp", min_fp),
+        namedattribute("max_fp", max_fp),
+    ]
+
+    return IR.create_operation(
+        "tosa.clamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -306,17 +387,21 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.clz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.clz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,17 +412,21 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1..., ]
+    results = IR.Type[output,]
+    operands = Value[input1...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.concat", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.concat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -347,19 +436,23 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.const", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.const",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -369,19 +462,38 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function conv2d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -390,19 +502,38 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function conv3d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.conv3d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.conv3d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -414,18 +545,24 @@ that are not expressed in the existing TOSA operations. These operators are
 not expected to be portable across TOSA implementations. The input and
 output signatures must be expressed in the corresponding TOSA node.
 """
-function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
+function custom(
+    inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location()
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("identifier", identifier), ]
-    
-    IR.create_operation(
-        "tosa.custom", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier),]
+
+    return IR.create_operation(
+        "tosa.custom",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -435,19 +572,38 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function depthwise_conv2d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.depthwise_conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.depthwise_conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,17 +614,21 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -478,17 +638,21 @@ end
 Elementwise comparison operation
 """
 function equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -498,17 +662,21 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -518,17 +686,21 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -537,19 +709,31 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function fully_connected(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.fully_connected", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.fully_connected",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -560,17 +744,21 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[values, indices, ]
+    results = IR.Type[output,]
+    operands = Value[values, indices]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -580,17 +768,21 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.greater_equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.greater_equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -600,17 +792,21 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.greater", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.greater",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -621,17 +817,21 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.identity", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.identity",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -641,18 +841,29 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
-    results = IR.Type[output..., ]
-    operands = Value[cond, inputs..., ]
-    owned_regions = Region[then_branch, else_branch, ]
+function cond_if(
+    cond::Value,
+    inputs::Vector{Value};
+    output::Vector{IR.Type},
+    then_branch::Region,
+    else_branch::Region,
+    location=Location(),
+)
+    results = IR.Type[output...,]
+    operands = Value[cond, inputs...]
+    owned_regions = Region[then_branch, else_branch]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.cond_if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.cond_if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -662,17 +873,21 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -683,17 +898,21 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -703,18 +922,24 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function logical_left_shift(
+    input1::Value, input2::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_left_shift", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_left_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -724,17 +949,21 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -745,17 +974,21 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -765,18 +998,24 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function logical_right_shift(
+    input1::Value, input2::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_right_shift", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_right_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -787,17 +1026,21 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -808,19 +1051,26 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[c, ]
-    operands = Value[a, b, ]
+function matmul(
+    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
+)
+    results = IR.Type[c,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.matmul", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -833,17 +1083,25 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
-    
-    IR.create_operation(
-        "tosa.max_pool2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("kernel", kernel),
+        namedattribute("stride", stride),
+        namedattribute("pad", pad),
+    ]
+
+    return IR.create_operation(
+        "tosa.max_pool2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -854,17 +1112,21 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.maximum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.maximum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -875,17 +1137,21 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.minimum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.minimum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -896,17 +1162,21 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift), ]
-    
-    IR.create_operation(
-        "tosa.mul", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift),]
+
+    return IR.create_operation(
+        "tosa.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -915,19 +1185,26 @@ end
 
 Elementwise negation operation
 """
-function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+function negate(
+    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.negate", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.negate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -936,20 +1213,32 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, padding, ]
+function pad(
+    input1::Value,
+    padding::Value,
+    pad_const=nothing::Union{Nothing,Value};
+    output::IR.Type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input1, padding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.pad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -960,17 +1249,21 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -981,17 +1274,21 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.reciprocal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reciprocal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1001,17 +1298,21 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_all", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1021,17 +1322,21 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_any", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1041,17 +1346,21 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_max", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1061,17 +1370,21 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_min", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1081,17 +1394,21 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_prod", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_prod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1101,17 +1418,21 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_sum", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1121,17 +1442,23 @@ end
 ReLU with a scalar maximum value.
 """
 function reluN(input::Value; output::IR.Type, max_int, max_fp, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("max_int", max_int), namedattribute("max_fp", max_fp), ]
-    
-    IR.create_operation(
-        "tosa.reluN", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("max_int", max_int), namedattribute("max_fp", max_fp)
+    ]
+
+    return IR.create_operation(
+        "tosa.reluN",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1155,18 +1482,41 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function rescale(
+    input::Value;
+    output::IR.Type,
+    input_zp,
+    output_zp,
+    multiplier,
+    shift,
+    scale32,
+    double_round,
+    per_channel,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
-    
-    IR.create_operation(
-        "tosa.rescale", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("input_zp", input_zp),
+        namedattribute("output_zp", output_zp),
+        namedattribute("multiplier", multiplier),
+        namedattribute("shift", shift),
+        namedattribute("scale32", scale32),
+        namedattribute("double_round", double_round),
+        namedattribute("per_channel", per_channel),
+    ]
+
+    return IR.create_operation(
+        "tosa.rescale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1178,17 +1528,21 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
-    
-    IR.create_operation(
-        "tosa.reshape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
+
+    return IR.create_operation(
+        "tosa.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1200,18 +1554,41 @@ expected use, stride_y is approximately (IH<<shift)/OH and stride_x is
 approximately (IW<<shift)/OW.  OH and OW are also supplied as inputs since
 there may be off by one errors if calculating OH and OW from the strides.
 """
-function resize(input::Value; output::IR.Type, output_size, stride, offset, shift, stride_fp, offset_fp, mode, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function resize(
+    input::Value;
+    output::IR.Type,
+    output_size,
+    stride,
+    offset,
+    shift,
+    stride_fp,
+    offset_fp,
+    mode,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("output_size", output_size), namedattribute("stride", stride), namedattribute("offset", offset), namedattribute("shift", shift), namedattribute("stride_fp", stride_fp), namedattribute("offset_fp", offset_fp), namedattribute("mode", mode), ]
-    
-    IR.create_operation(
-        "tosa.resize", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("output_size", output_size),
+        namedattribute("stride", stride),
+        namedattribute("offset", offset),
+        namedattribute("shift", shift),
+        namedattribute("stride_fp", stride_fp),
+        namedattribute("offset_fp", offset_fp),
+        namedattribute("mode", mode),
+    ]
+
+    return IR.create_operation(
+        "tosa.resize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1223,17 +1600,21 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reverse", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reverse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1244,17 +1625,21 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1264,18 +1649,24 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
-    results = IR.Type[values_out, ]
-    operands = Value[values_in, indices, input, ]
+function scatter(
+    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
+)
+    results = IR.Type[values_out,]
+    operands = Value[values_in, indices, input]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1284,18 +1675,24 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[pred, on_true, on_false, ]
+function select(
+    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[pred, on_true, on_false]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1309,17 +1706,21 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.sigmoid", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.sigmoid",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1331,17 +1732,23 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
-    
-    IR.create_operation(
-        "tosa.slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("start", start), namedattribute("size", size)
+    ]
+
+    return IR.create_operation(
+        "tosa.slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1352,17 +1759,21 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1385,17 +1796,21 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, table, ]
+    results = IR.Type[output,]
+    operands = Value[input, table]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.table", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.table",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1408,17 +1823,21 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1428,17 +1847,21 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
-    
-    IR.create_operation(
-        "tosa.tile", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples),]
+
+    return IR.create_operation(
+        "tosa.tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1448,19 +1871,38 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, filter, bias, ]
+function transpose_conv2d(
+    input::Value,
+    filter::Value,
+    bias::Value;
+    output::IR.Type,
+    out_pad,
+    stride,
+    out_shape,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, filter, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.transpose_conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("out_pad", out_pad),
+        namedattribute("stride", stride),
+        namedattribute("out_shape", out_shape),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.transpose_conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1470,17 +1912,21 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, perms, ]
+    results = IR.Type[output,]
+    operands = Value[input1, perms]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1492,18 +1938,28 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
-    results = IR.Type[output..., ]
-    operands = Value[inputs..., ]
-    owned_regions = Region[cond, body, ]
+function while_loop(
+    inputs::Vector{Value};
+    output::Vector{IR.Type},
+    cond::Region,
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[output...,]
+    operands = Value[inputs...,]
+    owned_regions = Region[cond, body]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.while_loop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.while_loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1516,16 +1972,20 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., ]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Tosa.jl
+++ b/src/Dialects/15/Tosa.jl
@@ -1,9 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -11,21 +10,17 @@ import ...API
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -121,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,36 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -213,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -305,21 +242,17 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,21 +262,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -356,29 +285,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,21 +306,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,21 +327,17 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1...,]
+    results = IR.Type[output, ]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,23 +347,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -463,38 +369,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -503,38 +390,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -546,24 +414,18 @@ that are not expressed in the existing TOSA operations. These operators are
 not expected to be portable across TOSA implementations. The input and
 output signatures must be expressed in the corresponding TOSA node.
 """
-function custom(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("identifier", identifier),]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -573,38 +435,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -615,21 +458,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -639,21 +478,17 @@ end
 Elementwise comparison operation
 """
 function equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,21 +498,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -687,21 +518,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,31 +537,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -745,21 +560,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -769,21 +580,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -793,21 +600,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -818,21 +621,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -842,29 +641,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -874,21 +662,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -899,21 +683,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -923,24 +703,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -950,21 +724,17 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -975,21 +745,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -999,24 +765,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1027,21 +787,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1052,26 +808,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1084,25 +833,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1113,21 +854,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1138,21 +875,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1163,21 +896,17 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1186,26 +915,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1214,32 +936,20 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1250,21 +960,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1275,21 +981,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1299,21 +1001,17 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1323,21 +1021,17 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1347,21 +1041,17 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1371,21 +1061,17 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1395,21 +1081,17 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1419,21 +1101,17 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1443,23 +1121,17 @@ end
 ReLU with a scalar maximum value.
 """
 function reluN(input::Value; output::IR.Type, max_int, max_fp, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("max_int", max_int), namedattribute("max_fp", max_fp)
-    ]
-
-    return IR.create_operation(
-        "tosa.reluN",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("max_int", max_int), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.reluN", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1483,41 +1155,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1529,21 +1178,17 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1555,41 +1200,18 @@ expected use, stride_y is approximately (IH<<shift)/OH and stride_x is
 approximately (IW<<shift)/OW.  OH and OW are also supplied as inputs since
 there may be off by one errors if calculating OH and OW from the strides.
 """
-function resize(
-    input::Value;
-    output::IR.Type,
-    output_size,
-    stride,
-    offset,
-    shift,
-    stride_fp,
-    offset_fp,
-    mode,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, output_size, stride, offset, shift, stride_fp, offset_fp, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("output_size", output_size),
-        namedattribute("stride", stride),
-        namedattribute("offset", offset),
-        namedattribute("shift", shift),
-        namedattribute("stride_fp", stride_fp),
-        namedattribute("offset_fp", offset_fp),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("output_size", output_size), namedattribute("stride", stride), namedattribute("offset", offset), namedattribute("shift", shift), namedattribute("stride_fp", stride_fp), namedattribute("offset_fp", offset_fp), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1601,21 +1223,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1626,21 +1244,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1650,24 +1264,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1676,24 +1284,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1707,21 +1309,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1733,23 +1331,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1760,21 +1352,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1797,21 +1385,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1824,21 +1408,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1848,21 +1428,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1872,38 +1448,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1913,21 +1470,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1939,28 +1492,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1973,20 +1516,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Tosa.jl
+++ b/src/Dialects/15/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -10,21 +10,17 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -35,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -120,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,36 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -237,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -304,21 +242,17 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -328,21 +262,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,29 +285,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -387,21 +306,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -412,21 +327,17 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1...,]
+    results = IR.Type[output, ]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,23 +347,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -462,38 +369,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,38 +390,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -545,24 +414,18 @@ that are not expressed in the existing TOSA operations. These operators are
 not expected to be portable across TOSA implementations. The input and
 output signatures must be expressed in the corresponding TOSA node.
 """
-function custom(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("identifier", identifier),]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -572,38 +435,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -614,21 +458,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -638,21 +478,17 @@ end
 Elementwise comparison operation
 """
 function equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -662,21 +498,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -686,21 +518,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,31 +537,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -744,21 +560,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,21 +580,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -792,21 +600,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -817,21 +621,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -841,29 +641,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -873,21 +662,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -898,21 +683,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -922,24 +703,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -949,21 +724,17 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -974,21 +745,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -998,24 +765,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1026,21 +787,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1051,26 +808,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,25 +833,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1112,21 +854,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1137,21 +875,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1162,21 +896,17 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1185,26 +915,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1213,32 +936,20 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1249,21 +960,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1274,21 +981,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1298,21 +1001,17 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1322,21 +1021,17 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1346,21 +1041,17 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1370,21 +1061,17 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1394,21 +1081,17 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1418,21 +1101,17 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1442,23 +1121,17 @@ end
 ReLU with a scalar maximum value.
 """
 function reluN(input::Value; output::IR.Type, max_int, max_fp, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("max_int", max_int), namedattribute("max_fp", max_fp)
-    ]
-
-    return IR.create_operation(
-        "tosa.reluN",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("max_int", max_int), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.reluN", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1482,41 +1155,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1528,21 +1178,17 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1554,41 +1200,18 @@ expected use, stride_y is approximately (IH<<shift)/OH and stride_x is
 approximately (IW<<shift)/OW.  OH and OW are also supplied as inputs since
 there may be off by one errors if calculating OH and OW from the strides.
 """
-function resize(
-    input::Value;
-    output::IR.Type,
-    output_size,
-    stride,
-    offset,
-    shift,
-    stride_fp,
-    offset_fp,
-    mode,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, output_size, stride, offset, shift, stride_fp, offset_fp, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("output_size", output_size),
-        namedattribute("stride", stride),
-        namedattribute("offset", offset),
-        namedattribute("shift", shift),
-        namedattribute("stride_fp", stride_fp),
-        namedattribute("offset_fp", offset_fp),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("output_size", output_size), namedattribute("stride", stride), namedattribute("offset", offset), namedattribute("shift", shift), namedattribute("stride_fp", stride_fp), namedattribute("offset_fp", offset_fp), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1600,21 +1223,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1625,21 +1244,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1649,24 +1264,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1675,24 +1284,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1706,21 +1309,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1732,23 +1331,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1759,21 +1352,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1796,21 +1385,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1823,21 +1408,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1847,21 +1428,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1871,38 +1448,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1912,21 +1470,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1938,28 +1492,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1972,20 +1516,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Transform.jl
+++ b/src/Dialects/15/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `bufferization_one_shot_bufferize`
@@ -25,54 +25,31 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    target_is_module=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    location=Location(),
-)
+function bufferization_one_shot_bufferize(target::Value; allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) &&
-        push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `structured_decompose`
@@ -90,21 +67,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,24 +85,18 @@ end
 `structured_fuse_into_containing_op`
 Fuse a producer into a containing operation.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
-)
-    results = IR.Type[fused_op,]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -139,32 +106,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -184,21 +139,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -218,26 +169,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced 
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -270,32 +214,21 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    attribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, attribute=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(attribute) && push!(attributes, namedattribute("attribute", attribute))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -344,34 +277,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -391,41 +309,23 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced 
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    transformed::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pack_paddings=nothing,
-    hoist_paddings=nothing,
-    transpose_paddings=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) &&
-        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -448,41 +348,23 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that 
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -511,21 +393,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -550,34 +428,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -715,40 +578,22 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -791,33 +636,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -866,34 +698,21 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [10, 20, 0]
 ```
 """
-function structured_tile_to_foreach_thread_op(
-    target::Value;
-    foreach_thread_op::IR.Type,
-    tiled_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    thread_dim_mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, tiled_op]
-    operands = Value[target,]
+function structured_tile_to_foreach_thread_op(target::Value; foreach_thread_op::IR.Type, tiled_op::IR.Type, num_threads=nothing, tile_sizes=nothing, thread_dim_mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, tiled_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(thread_dim_mapping) &&
-        push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(thread_dim_mapping) && push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
+    
+    IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -922,32 +741,25 @@ reason.
 The operation always returns the handle to the target op that is expected 
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value; transformed::IR.Type, vectorize_padding=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `loop_get_parent_for`
@@ -959,25 +771,19 @@ parent operations in the same order as the list associated with the operand,
 except for operations that are parents to more than one input which are only
 present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -996,21 +802,17 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1038,31 +840,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1089,32 +879,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced 
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1136,26 +914,22 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alternatives`
@@ -1218,28 +992,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1263,20 +1028,16 @@ capabilities.
 """
 function foreach(target::Value; body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1299,21 +1060,17 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent,]
-    operands = Value[target,]
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_closest_isolated_parent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_closest_isolated_parent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1329,25 +1086,19 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value}; result::IR.Type, deduplicate=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[handles...,]
+function merge_handles(handles::Vector{Value}; result::IR.Type, deduplicate=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1370,21 +1121,17 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched,]
-    operands = Value[root,]
+    results = IR.Type[matched, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
-
-    return IR.create_operation(
-        "transform.pdl_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
+    
+    IR.create_operation(
+        "transform.pdl_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1413,24 +1160,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1450,28 +1191,19 @@ IR, typically the root operation of the pass interpreting the transform
 dialect. Operand omission is only allowed for sequences not contained in
 another sequence.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1511,25 +1243,19 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(
-    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
-)
+function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.with_pdl_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.with_pdl_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1540,22 +1266,18 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Transform.jl
+++ b/src/Dialects/15/Transform.jl
@@ -1,9 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `bufferization_one_shot_bufferize`
@@ -26,55 +25,31 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    target_is_module=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    location=Location(),
-)
+function bufferization_one_shot_bufferize(target::Value; allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) &&
-        push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `structured_decompose`
@@ -92,21 +67,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,24 +85,18 @@ end
 `structured_fuse_into_containing_op`
 Fuse a producer into a containing operation.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
-)
-    results = IR.Type[fused_op,]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,32 +106,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -186,21 +139,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,26 +169,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced 
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -272,32 +214,21 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    attribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, attribute=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(attribute) && push!(attributes, namedattribute("attribute", attribute))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,34 +277,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -393,41 +309,23 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced 
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    transformed::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pack_paddings=nothing,
-    hoist_paddings=nothing,
-    transpose_paddings=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) &&
-        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -450,41 +348,23 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that 
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -513,21 +393,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -552,34 +428,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -717,40 +578,22 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -793,33 +636,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -868,34 +698,21 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [10, 20, 0]
 ```
 """
-function structured_tile_to_foreach_thread_op(
-    target::Value;
-    foreach_thread_op::IR.Type,
-    tiled_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    thread_dim_mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, tiled_op]
-    operands = Value[target,]
+function structured_tile_to_foreach_thread_op(target::Value; foreach_thread_op::IR.Type, tiled_op::IR.Type, num_threads=nothing, tile_sizes=nothing, thread_dim_mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, tiled_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(thread_dim_mapping) &&
-        push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(thread_dim_mapping) && push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
+    
+    IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -924,33 +741,25 @@ reason.
 The operation always returns the handle to the target op that is expected 
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value; transformed::IR.Type, vectorize_padding=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `loop_get_parent_for`
@@ -962,25 +771,19 @@ parent operations in the same order as the list associated with the operand,
 except for operations that are parents to more than one input which are only
 present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -999,21 +802,17 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1041,31 +840,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1092,32 +879,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced 
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1139,27 +914,22 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `alternatives`
@@ -1222,28 +992,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1267,20 +1028,16 @@ capabilities.
 """
 function foreach(target::Value; body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1303,21 +1060,17 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent,]
-    operands = Value[target,]
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_closest_isolated_parent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_closest_isolated_parent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1333,25 +1086,19 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value}; result::IR.Type, deduplicate=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[handles...,]
+function merge_handles(handles::Vector{Value}; result::IR.Type, deduplicate=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1374,21 +1121,17 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched,]
-    operands = Value[root,]
+    results = IR.Type[matched, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
-
-    return IR.create_operation(
-        "transform.pdl_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
+    
+    IR.create_operation(
+        "transform.pdl_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1417,24 +1160,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1454,28 +1191,19 @@ IR, typically the root operation of the pass interpreting the transform
 dialect. Operand omission is only allowed for sequences not contained in
 another sequence.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1515,25 +1243,19 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(
-    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
-)
+function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.with_pdl_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.with_pdl_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1544,22 +1266,18 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Transform.jl
+++ b/src/Dialects/15/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `bufferization_one_shot_bufferize`
@@ -25,31 +25,54 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(target::Value; allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
+function bufferization_one_shot_bufferize(
+    target::Value;
+    allow_return_allocs=nothing,
+    allow_unknown_ops=nothing,
+    bufferize_function_boundaries=nothing,
+    create_deallocs=nothing,
+    target_is_module=nothing,
+    test_analysis_only=nothing,
+    print_conflicts=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
-    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
-    
-    IR.create_operation(
-        "transform.bufferization.one_shot_bufferize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(allow_return_allocs) &&
+        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) &&
+        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(
+        attributes,
+        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
+    )
+    !isnothing(create_deallocs) &&
+        push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) &&
+        push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) &&
+        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) &&
+        push!(attributes, namedattribute("print_conflicts", print_conflicts))
+
+    return IR.create_operation(
+        "transform.bufferization.one_shot_bufferize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `structured_decompose`
@@ -67,17 +90,21 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.decompose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.decompose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -85,18 +112,24 @@ end
 `structured_fuse_into_containing_op`
 Fuse a producer into a containing operation.
 """
-function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
-    results = IR.Type[fused_op, ]
-    operands = Value[producer_op, containing_op, ]
+function structured_fuse_into_containing_op(
+    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
+)
+    results = IR.Type[fused_op,]
+    operands = Value[producer_op, containing_op]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.fuse_into_containing_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.fuse_into_containing_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -106,20 +139,32 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
-    results = IR.Type[transformed, loops..., ]
-    operands = Value[target, ]
+function structured_fuse(
+    target::Value;
+    transformed::IR.Type,
+    loops::Vector{IR.Type},
+    tile_sizes=nothing,
+    tile_interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed, loops...]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
-    
-    IR.create_operation(
-        "transform.structured.fuse", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(tile_interchange) &&
+        push!(attributes, namedattribute("tile_interchange", tile_interchange))
+
+    return IR.create_operation(
+        "transform.structured.fuse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -139,17 +184,21 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.generalize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.generalize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -169,19 +218,26 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced 
 interchanged operations, which can be empty.
 """
-function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_interchange(
+    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-    
-    IR.create_operation(
-        "transform.structured.interchange", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(iterator_interchange) &&
+        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+
+    return IR.create_operation(
+        "transform.structured.interchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -214,21 +270,32 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, attribute=nothing, location=Location())
-    results = IR.Type[results_, ]
-    operands = Value[target, ]
+function structured_match(
+    target::Value;
+    results::IR.Type,
+    ops=nothing,
+    interface=nothing,
+    attribute=nothing,
+    location=Location(),
+)
+    results = IR.Type[results,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(attribute) && push!(attributes, namedattribute("attribute", attribute))
-    
-    IR.create_operation(
-        "transform.structured.match", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -277,19 +344,34 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
-    results = IR.Type[low_size, high_size, split_point, ]
-    operands = Value[target, ]
+function structured_multitile_sizes(
+    target::Value;
+    low_size::IR.Type,
+    high_size::IR.Type,
+    split_point::IR.Type,
+    dimension,
+    target_size,
+    divisor=nothing,
+    location=Location(),
+)
+    results = IR.Type[low_size, high_size, split_point]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
+    attributes = NamedAttribute[
+        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
+    ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-    
-    IR.create_operation(
-        "transform.structured.multitile_sizes", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.multitile_sizes",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,23 +391,41 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced 
 padded operations, which can be empty.
 """
-function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_pad(
+    target::Value;
+    transformed::IR.Type,
+    padding_values=nothing,
+    padding_dimensions=nothing,
+    pack_paddings=nothing,
+    hoist_paddings=nothing,
+    transpose_paddings=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-    
-    IR.create_operation(
-        "transform.structured.pad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(padding_values) &&
+        push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) &&
+        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) &&
+        push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) &&
+        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) &&
+        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+
+    return IR.create_operation(
+        "transform.structured.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -348,23 +448,41 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that 
 was modified inplace.
 """
-function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_promote(
+    target::Value;
+    transformed::IR.Type,
+    operands_to_promote=nothing,
+    use_full_tile_buffers=nothing,
+    use_full_tiles_by_default=nothing,
+    use_alloca=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
+    !isnothing(operands_to_promote) &&
+        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) &&
+        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(
+        attributes,
+        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
+    )
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "transform.structured.promote", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.promote",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -393,17 +511,21 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.scalarize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.scalarize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -428,19 +550,34 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
-    results = IR.Type[first, second, ]
-    operands = Value[target, ]
+function structured_split(
+    target::Value,
+    dynamic_split_point=nothing::Union{Nothing,Value};
+    first::IR.Type,
+    second::IR.Type,
+    dimension,
+    static_split_point,
+    location=Location(),
+)
+    results = IR.Type[first, second]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
+    attributes = NamedAttribute[
+        namedattribute("dimension", dimension),
+        namedattribute("static_split_point", static_split_point),
+    ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-    
-    IR.create_operation(
-        "transform.structured.split", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.split",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -578,22 +715,40 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_split_reduction(
+    target::Value;
+    init_or_alloc_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    split_factor=nothing,
+    insert_split_dimension=nothing,
+    use_scaling_algorithm=nothing,
+    use_alloc=nothing,
+    location=Location(),
+)
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) &&
+        push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) &&
+        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(use_scaling_algorithm) &&
+        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-    
-    IR.create_operation(
-        "transform.structured.split_reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.split_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -636,20 +791,33 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
-    results = IR.Type[tiled_linalg_op, loops..., ]
-    operands = Value[target, dynamic_sizes..., ]
+function structured_tile(
+    target::Value,
+    dynamic_sizes::Vector{Value};
+    tiled_linalg_op::IR.Type,
+    loops::Vector{IR.Type},
+    static_sizes=nothing,
+    interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[tiled_linalg_op, loops...]
+    operands = Value[target, dynamic_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) &&
+        push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    
-    IR.create_operation(
-        "transform.structured.tile", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -698,21 +866,34 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [10, 20, 0]
 ```
 """
-function structured_tile_to_foreach_thread_op(target::Value; foreach_thread_op::IR.Type, tiled_op::IR.Type, num_threads=nothing, tile_sizes=nothing, thread_dim_mapping=nothing, location=Location())
-    results = IR.Type[foreach_thread_op, tiled_op, ]
-    operands = Value[target, ]
+function structured_tile_to_foreach_thread_op(
+    target::Value;
+    foreach_thread_op::IR.Type,
+    tiled_op::IR.Type,
+    num_threads=nothing,
+    tile_sizes=nothing,
+    thread_dim_mapping=nothing,
+    location=Location(),
+)
+    results = IR.Type[foreach_thread_op, tiled_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(thread_dim_mapping) && push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
-    
-    IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(thread_dim_mapping) &&
+        push!(attributes, namedattribute("thread_dim_mapping", thread_dim_mapping))
+
+    return IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -741,25 +922,32 @@ reason.
 The operation always returns the handle to the target op that is expected 
 to be isolated from above.
 """
-function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_vectorize(
+    target::Value; transformed::IR.Type, vectorize_padding=nothing, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    
-    IR.create_operation(
-        "transform.structured.vectorize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(vectorize_padding) &&
+        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+
+    return IR.create_operation(
+        "transform.structured.vectorize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `loop_get_parent_for`
@@ -771,19 +959,25 @@ parent operations in the same order as the list associated with the operand,
 except for operations that are parents to more than one input which are only
 present once.
 """
-function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, location=Location())
-    results = IR.Type[parent, ]
-    operands = Value[target, ]
+function loop_get_parent_for(
+    target::Value; parent::IR.Type, num_loops=nothing, location=Location()
+)
+    results = IR.Type[parent,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
-    
-    IR.create_operation(
-        "transform.loop.get_parent_for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.loop.get_parent_for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -802,17 +996,21 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
-    
-    IR.create_operation(
-        "transform.loop.outline", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name),]
+
+    return IR.create_operation(
+        "transform.loop.outline",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -840,19 +1038,31 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function loop_peel(
+    target::Value;
+    transformed::IR.Type,
+    fail_if_already_divisible=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
-    
-    IR.create_operation(
-        "transform.loop.peel", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fail_if_already_divisible) && push!(
+        attributes,
+        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
+    )
+
+    return IR.create_operation(
+        "transform.loop.peel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -879,20 +1089,32 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced 
 pipelined loops, which can be empty.
 """
-function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function loop_pipeline(
+    target::Value;
+    transformed::IR.Type,
+    iteration_interval=nothing,
+    read_latency=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
-    
-    IR.create_operation(
-        "transform.loop.pipeline", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(iteration_interval) &&
+        push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) &&
+        push!(attributes, namedattribute("read_latency", read_latency))
+
+    return IR.create_operation(
+        "transform.loop.pipeline",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -914,22 +1136,26 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor), ]
-    
-    IR.create_operation(
-        "transform.loop.unroll", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor),]
+
+    return IR.create_operation(
+        "transform.loop.unroll",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `alternatives`
@@ -992,19 +1218,28 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
-    results = IR.Type[results_..., ]
+function alternatives(
+    scope=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    alternatives::Vector{Region},
+    location=Location(),
+)
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[alternatives..., ]
+    owned_regions = Region[alternatives...,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-    
-    IR.create_operation(
-        "transform.alternatives", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.alternatives",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1028,16 +1263,20 @@ capabilities.
 """
 function foreach(target::Value; body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
-    owned_regions = Region[body, ]
+    operands = Value[target,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1060,17 +1299,21 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent, ]
-    operands = Value[target, ]
+    results = IR.Type[parent,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.get_closest_isolated_parent", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.get_closest_isolated_parent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1086,19 +1329,25 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(handles::Vector{Value}; result::IR.Type, deduplicate=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[handles..., ]
+function merge_handles(
+    handles::Vector{Value}; result::IR.Type, deduplicate=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[handles...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-    
-    IR.create_operation(
-        "transform.merge_handles", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.merge_handles",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1121,17 +1370,21 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched, ]
-    operands = Value[root, ]
+    results = IR.Type[matched,]
+    operands = Value[root,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
-    
-    IR.create_operation(
-        "transform.pdl_match", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
+
+    return IR.create_operation(
+        "transform.pdl_match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1160,18 +1413,24 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
-    results = IR.Type[replicated..., ]
-    operands = Value[pattern, handles..., ]
+function replicate(
+    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
+)
+    results = IR.Type[replicated...,]
+    operands = Value[pattern, handles...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.replicate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.replicate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1191,19 +1450,28 @@ IR, typically the root operation of the pass interpreting the transform
 dialect. Operand omission is only allowed for sequences not contained in
 another sequence.
 """
-function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results_..., ]
+function sequence(
+    root=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    
-    IR.create_operation(
-        "transform.sequence", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.sequence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1243,19 +1511,25 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
+function with_pdl_patterns(
+    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    
-    IR.create_operation(
-        "transform.with_pdl_patterns", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.with_pdl_patterns",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1266,18 +1540,22 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Vector.jl
+++ b/src/Dialects/15/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `vscale`
@@ -18,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -113,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,28 +150,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -219,21 +197,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,36 +328,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value,
-    masks::Vector{Value};
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc, masks...]
+function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, masks..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,22 +374,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -467,29 +420,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -515,28 +457,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -584,24 +517,18 @@ For instance:
   to vector<4x4x2xf32>
 ```
 """
-function extract_map(
-    vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector, ids...]
+function extract_map(vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ids..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.extract_map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract_map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,25 +545,19 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -666,28 +587,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -708,29 +619,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,23 +661,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -811,30 +706,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -859,30 +742,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -932,29 +805,19 @@ For instance:
   into vector<64x4x32xf32>
 ```
 """
-function insert_map(
-    vector::Value,
-    dest::Value,
-    ids::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert_map(vector::Value, dest::Value, ids::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, dest, ids...]
+    operands = Value[vector, dest, ids..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insert_map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_map", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -972,29 +835,19 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1020,32 +873,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1106,21 +946,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1152,29 +988,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1206,28 +1031,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1258,34 +1073,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1306,32 +1105,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1385,30 +1171,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1438,20 +1213,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1477,29 +1248,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1587,30 +1348,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1631,37 +1381,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1698,29 +1431,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1760,21 +1482,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1809,25 +1527,19 @@ according to the given mask. The legality rules are:
            : vector<2xf32>, vector<2xf32>       ; yields vector<4xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1845,21 +1557,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1917,24 +1625,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2096,36 +1798,21 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2209,37 +1896,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2269,21 +1941,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2310,21 +1978,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2430,29 +2094,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2467,22 +2120,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/Vector.jl
+++ b/src/Dialects/15/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `vscale`
@@ -18,19 +18,23 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.vscale", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.vscale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -59,17 +63,21 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -105,17 +113,21 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[source, ]
+    results = IR.Type[vector,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -150,18 +162,28 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
+function compressstore(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore, ]
+    operands = Value[base, indices..., mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.compressstore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.compressstore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -197,17 +219,21 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
-    
-    IR.create_operation(
-        "vector.constant_mask", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
+
+    return IR.create_operation(
+        "vector.constant_mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -328,19 +354,36 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, acc, masks..., ]
+function contract(
+    lhs::Value,
+    rhs::Value,
+    acc::Value,
+    masks::Vector{Value};
+    result_0::IR.Type,
+    indexing_maps,
+    iterator_types,
+    kind=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs, acc, masks...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    attributes = NamedAttribute[
+        namedattribute("indexing_maps", indexing_maps),
+        namedattribute("iterator_types", iterator_types),
+    ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-    
-    IR.create_operation(
-        "vector.contract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.contract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -374,18 +417,22 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.create_mask", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.create_mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -420,18 +467,29 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., mask, pass_thru, ]
+function expandload(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.expandload", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.expandload",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -457,19 +515,28 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, ]
+function extractelement(
+    vector::Value,
+    position=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    
-    IR.create_operation(
-        "vector.extractelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.extractelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -517,18 +584,24 @@ For instance:
   to vector<4x4x2xf32>
 ```
 """
-function extract_map(vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[vector, ids..., ]
+function extract_map(
+    vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location()
+)
+    results = IR.Type[result_0,]
+    operands = Value[vector, ids...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.extract_map", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.extract_map",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -545,19 +618,25 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function extract(
+    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
+)
     results = IR.Type[]
-    operands = Value[vector, ]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "vector.extract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -587,18 +666,28 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[vector, ]
+function extract_strided_slice(
+    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
+)
+    results = IR.Type[result_0,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
-    
-    IR.create_operation(
-        "vector.extract_strided_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("offsets", offsets),
+        namedattribute("sizes", sizes),
+        namedattribute("strides", strides),
+    ]
+
+    return IR.create_operation(
+        "vector.extract_strided_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -619,19 +708,29 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function fma(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc, ]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -661,17 +760,23 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrix, ]
+    results = IR.Type[res,]
+    operands = Value[matrix,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
-    
-    IR.create_operation(
-        "vector.flat_transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("rows", rows), namedattribute("columns", columns)
+    ]
+
+    return IR.create_operation(
+        "vector.flat_transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -706,18 +811,30 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
+function gather(
+    base::Value,
+    indices::Vector{Value},
+    index_vec::Value,
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., index_vec, mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -742,20 +859,30 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function insertelement(
+    source::Value,
+    dest::Value,
+    position=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.insertelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insertelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -805,19 +932,29 @@ For instance:
   into vector<64x4x32xf32>
 ```
 """
-function insert_map(vector::Value, dest::Value, ids::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function insert_map(
+    vector::Value,
+    dest::Value,
+    ids::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, dest, ids..., ]
+    operands = Value[vector, dest, ids...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.insert_map", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert_map",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -835,19 +972,29 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function insert(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    position,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -873,19 +1020,32 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
+function insert_strided_slice(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    offsets,
+    strides,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
+    attributes = NamedAttribute[
+        namedattribute("offsets", offsets), namedattribute("strides", strides)
+    ]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.insert_strided_slice", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert_strided_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -946,17 +1106,21 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -988,18 +1152,29 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., mask, pass_thru, ]
+function maskedload(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.maskedload", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.maskedload",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1031,18 +1206,28 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
+function maskedstore(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore, ]
+    operands = Value[base, indices..., mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.maskedstore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.maskedstore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1073,18 +1258,34 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function matrix_multiply(
+    lhs::Value,
+    rhs::Value;
+    res::IR.Type,
+    lhs_rows,
+    lhs_columns,
+    rhs_columns,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
-    
-    IR.create_operation(
-        "vector.matrix_multiply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("lhs_rows", lhs_rows),
+        namedattribute("lhs_columns", lhs_columns),
+        namedattribute("rhs_columns", rhs_columns),
+    ]
+
+    return IR.create_operation(
+        "vector.matrix_multiply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1105,19 +1306,32 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
+function multi_reduction(
+    source::Value,
+    acc::Value;
+    dest=nothing::Union{Nothing,IR.Type},
+    kind,
+    reduction_dims,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, acc, ]
+    operands = Value[source, acc]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
+    attributes = NamedAttribute[
+        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
+    ]
     !isnothing(dest) && push!(results, dest)
-    
-    IR.create_operation(
-        "vector.multi_reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.multi_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1171,19 +1385,30 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, acc..., ]
+function outerproduct(
+    lhs::Value,
+    rhs::Value,
+    acc::Vector{Value};
+    result_0::IR.Type,
+    kind=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs, acc...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-    
-    IR.create_operation(
-        "vector.outerproduct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.outerproduct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1213,16 +1438,20 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1248,19 +1477,29 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[vector, ]
+function reduction(
+    vector::Value,
+    acc=nothing::Union{Nothing,Value};
+    dest::IR.Type,
+    kind,
+    location=Location(),
+)
+    results = IR.Type[dest,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    attributes = NamedAttribute[namedattribute("kind", kind),]
     !isnothing(acc) && push!(operands, acc)
-    
-    IR.create_operation(
-        "vector.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1348,19 +1587,30 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, input_shape..., output_shape..., ]
+function reshape(
+    vector::Value,
+    input_shape::Vector{Value},
+    output_shape::Vector{Value};
+    result::IR.Type,
+    fixed_vector_sizes,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector, input_shape..., output_shape...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
-    
-    IR.create_operation(
-        "vector.reshape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
+
+    return IR.create_operation(
+        "vector.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1381,20 +1631,37 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
+function scan(
+    source::Value,
+    initial_value::Value;
+    dest=nothing::Union{Nothing,IR.Type},
+    accumulated_value=nothing::Union{Nothing,IR.Type},
+    kind,
+    reduction_dim,
+    inclusive,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, initial_value, ]
+    operands = Value[source, initial_value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
+    attributes = NamedAttribute[
+        namedattribute("kind", kind),
+        namedattribute("reduction_dim", reduction_dim),
+        namedattribute("inclusive", inclusive),
+    ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-    
-    IR.create_operation(
-        "vector.scan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1431,18 +1698,29 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
+function scatter(
+    base::Value,
+    indices::Vector{Value},
+    index_vec::Value,
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
+    operands = Value[base, indices..., index_vec, mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1482,17 +1760,21 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.shape_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.shape_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1527,19 +1809,25 @@ according to the given mask. The legality rules are:
            : vector<2xf32>, vector<2xf32>       ; yields vector<4xf32>
 ```
 """
-function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
+function shuffle(
+    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
+)
     results = IR.Type[]
-    operands = Value[v1, v2, ]
+    operands = Value[v1, v2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    attributes = NamedAttribute[namedattribute("mask", mask),]
     !isnothing(vector) && push!(results, vector)
-    
-    IR.create_operation(
-        "vector.shuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.shuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1557,17 +1845,21 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate, ]
-    operands = Value[input, ]
+    results = IR.Type[aggregate,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.splat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.splat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1625,18 +1917,24 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
+function store(
+    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices..., ]
+    operands = Value[valueToStore, base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1798,21 +2096,36 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[source, indices..., padding, ]
+function transfer_read(
+    source::Value,
+    indices::Vector{Value},
+    padding::Value,
+    mask=nothing::Union{Nothing,Value};
+    vector::IR.Type,
+    permutation_map,
+    in_bounds=nothing,
+    location=Location(),
+)
+    results = IR.Type[vector,]
+    operands = Value[source, indices..., padding]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
     !isnothing(mask) && push!(operands, mask)
-    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
+    push!(
+        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
+    )
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-    
-    IR.create_operation(
-        "vector.transfer_read", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.transfer_read",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1896,22 +2209,37 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
+function transfer_write(
+    vector::Value,
+    source::Value,
+    indices::Vector{Value},
+    mask=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    permutation_map,
+    in_bounds=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, source, indices..., ]
+    operands = Value[vector, source, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
     !isnothing(mask) && push!(operands, mask)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
+    push!(
+        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
+    )
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-    
-    IR.create_operation(
-        "vector.transfer_write", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.transfer_write",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1941,17 +2269,21 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, ]
+    results = IR.Type[result,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp), ]
-    
-    IR.create_operation(
-        "vector.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp),]
+
+    return IR.create_operation(
+        "vector.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1978,17 +2310,21 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, ]
+    results = IR.Type[result,]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.type_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.type_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2094,18 +2430,29 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[laneid, args..., ]
-    owned_regions = Region[warpRegion, ]
+function warp_execute_on_lane_0(
+    laneid::Value,
+    args::Vector{Value};
+    results::Vector{IR.Type},
+    warp_size,
+    warpRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[laneid, args...]
+    owned_regions = Region[warpRegion,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
-    
-    IR.create_operation(
-        "vector.warp_execute_on_lane_0", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
+
+    return IR.create_operation(
+        "vector.warp_execute_on_lane_0",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2120,18 +2467,22 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/Vector.jl
+++ b/src/Dialects/15/Vector.jl
@@ -1,9 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `vscale`
@@ -19,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -163,28 +150,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,21 +197,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,36 +328,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value,
-    masks::Vector{Value};
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc, masks...]
+function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, masks..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -418,22 +374,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,29 +420,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -516,28 +457,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -585,24 +517,18 @@ For instance:
   to vector<4x4x2xf32>
 ```
 """
-function extract_map(
-    vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector, ids...]
+function extract_map(vector::Value, ids::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ids..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.extract_map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract_map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,25 +545,19 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -667,28 +587,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,29 +619,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -761,23 +661,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -812,30 +706,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -860,30 +742,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -933,29 +805,19 @@ For instance:
   into vector<64x4x32xf32>
 ```
 """
-function insert_map(
-    vector::Value,
-    dest::Value,
-    ids::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert_map(vector::Value, dest::Value, ids::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, dest, ids...]
+    operands = Value[vector, dest, ids..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insert_map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_map", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -973,29 +835,19 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1021,32 +873,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1107,21 +946,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1153,29 +988,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1207,28 +1031,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1259,34 +1073,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1307,32 +1105,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1386,30 +1171,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1439,20 +1213,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1478,29 +1248,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1588,30 +1348,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1632,37 +1381,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1699,29 +1431,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1761,21 +1482,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1810,25 +1527,19 @@ according to the given mask. The legality rules are:
            : vector<2xf32>, vector<2xf32>       ; yields vector<4xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1846,21 +1557,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1918,24 +1625,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2097,36 +1798,21 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2210,37 +1896,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2270,21 +1941,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2311,21 +1978,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2431,29 +2094,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2468,22 +2120,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/X86Vector.jl
+++ b/src/Dialects/15/X86Vector.jl
@@ -1,26 +1,32 @@
 module x86vector
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_dp_ps_256(
+    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -42,19 +48,25 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_dot(
+    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, b, ]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.dot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.dot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -62,19 +74,25 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_compress(
+    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, src, k, ]
+    operands = Value[a, src, k]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.compress", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -93,21 +111,33 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
+function avx512_mask_compress(
+    k::Value,
+    a::Value,
+    src=nothing::Union{Nothing,Value};
+    dst=nothing::Union{Nothing,IR.Type},
+    constant_src=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[k, a, ]
+    operands = Value[k, a]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.compress", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constant_src) &&
+        push!(attributes, namedattribute("constant_src", constant_src))
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -125,19 +155,31 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_mask_rndscale(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    dst=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.rndscale", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.rndscale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -145,19 +187,31 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_rndscale_pd_512(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -165,19 +219,31 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_rndscale_ps_512(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -195,19 +261,31 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_mask_scalef(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    dst=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.scalef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.scalef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -215,19 +293,31 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_scalef_pd_512(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -235,19 +325,31 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_scalef_ps_512(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -255,19 +357,25 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_rsqrt_ps_256(
+    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, ]
+    operands = Value[a,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -275,19 +383,23 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, ]
+    operands = Value[a,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-    
-    IR.create_operation(
-        "x86vector.avx.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -295,18 +407,24 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+function avx512_intr_vp2intersect_d_512(
+    a::Value, b::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -326,18 +444,24 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
-    results = IR.Type[k1, k2, ]
-    operands = Value[a, b, ]
+function avx512_vp2intersect(
+    a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location()
+)
+    results = IR.Type[k1, k2]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.vp2intersect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.vp2intersect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -345,18 +469,24 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+function avx512_intr_vp2intersect_q_512(
+    a::Value, b::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/15/X86Vector.jl
+++ b/src/Dialects/15/X86Vector.jl
@@ -1,32 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -74,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -111,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -155,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -219,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -261,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -293,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -325,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -357,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -383,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,24 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location()
-)
-    results = IR.Type[k1, k2]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -469,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/15/X86Vector.jl
+++ b/src/Dialects/15/X86Vector.jl
@@ -1,33 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -49,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -75,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -112,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -156,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -188,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -220,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -262,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -294,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -326,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -358,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -384,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -408,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -445,24 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location()
-)
-    results = IR.Type[k1, k2]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/AMDGPU.jl
+++ b/src/Dialects/16/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `lds_barrier`
@@ -25,12 +25,16 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amdgpu.lds_barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.lds_barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -63,25 +67,52 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
-    results = IR.Type[destD, ]
-    operands = Value[sourceA, sourceB, destC, ]
+function mfma(
+    sourceA::Value,
+    sourceB::Value,
+    destC::Value;
+    destD::IR.Type,
+    m,
+    n,
+    k,
+    blocks,
+    cbsz=nothing,
+    abid=nothing,
+    blgp=nothing,
+    reducePrecision=nothing,
+    negateA=nothing,
+    negateB=nothing,
+    negateC=nothing,
+    location=Location(),
+)
+    results = IR.Type[destD,]
+    operands = Value[sourceA, sourceB, destC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
+    attributes = NamedAttribute[
+        namedattribute("m", m),
+        namedattribute("n", n),
+        namedattribute("k", k),
+        namedattribute("blocks", blocks),
+    ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) &&
+        push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-    
-    IR.create_operation(
-        "amdgpu.mfma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.mfma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -105,22 +136,37 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_atomic_fadd(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -156,22 +202,37 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[memref, indices..., ]
+function raw_buffer_load(
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    value::IR.Type,
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -195,22 +256,37 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_store(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/AMDGPU.jl
+++ b/src/Dialects/16/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `lds_barrier`
@@ -25,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -67,52 +63,25 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    m,
-    n,
-    k,
-    blocks,
-    cbsz=nothing,
-    abid=nothing,
-    blgp=nothing,
-    reducePrecision=nothing,
-    negateA=nothing,
-    negateB=nothing,
-    negateC=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("blocks", blocks),
-    ]
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) &&
-        push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-
-    return IR.create_operation(
-        "amdgpu.mfma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.mfma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,37 +105,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -202,37 +156,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -256,37 +195,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/AMDGPU.jl
+++ b/src/Dialects/16/AMDGPU.jl
@@ -1,9 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `lds_barrier`
@@ -26,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -68,52 +63,25 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    m,
-    n,
-    k,
-    blocks,
-    cbsz=nothing,
-    abid=nothing,
-    blgp=nothing,
-    reducePrecision=nothing,
-    negateA=nothing,
-    negateB=nothing,
-    negateC=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("blocks", blocks),
-    ]
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) &&
-        push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-
-    return IR.create_operation(
-        "amdgpu.mfma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.mfma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,37 +105,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,37 +156,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -257,37 +195,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/AMX.jl
+++ b/src/Dialects/16/AMX.jl
@@ -1,38 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -40,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -104,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -296,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/AMX.jl
+++ b/src/Dialects/16/AMX.jl
@@ -1,25 +1,38 @@
 module amx
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbf16ps(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbf16ps", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbf16ps",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -27,18 +40,31 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbssd(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbssd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbssd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -46,18 +72,31 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbsud(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbsud", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbsud",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -65,18 +104,31 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbusd(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbusd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbusd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -84,18 +136,31 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbuud(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbuud", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbuud",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -103,18 +168,29 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+function tileloadd64(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tileloadd64", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tileloadd64",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -122,18 +198,29 @@ end
 `tilestored64`
 
 """
-function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function tilestored64(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tilestored64", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tilestored64",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -142,17 +229,21 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, ]
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tilezero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tilezero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -171,17 +262,21 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[base, indices..., ]
+    results = IR.Type[res,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -201,17 +296,21 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, acc, ]
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -233,20 +332,32 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, acc, ]
+function tile_muli(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    res::IR.Type,
+    isZextLhs=nothing,
+    isZextRhs=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-    
-    IR.create_operation(
-        "amx.tile_muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -266,16 +377,20 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val, ]
+    operands = Value[base, indices..., val]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -293,17 +408,21 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_zero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_zero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/AMX.jl
+++ b/src/Dialects/16/AMX.jl
@@ -1,39 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -41,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -105,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -230,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Affine.jl
+++ b/src/Dialects/16/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -27,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -68,27 +64,18 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(
-    linear_index::Value,
-    basis::Vector{Value};
-    multi_index::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[multi_index...,]
-    operands = Value[linear_index, basis...]
+function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
+    results = IR.Type[multi_index..., ]
+    operands = Value[linear_index, basis..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.delinearize_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.delinearize_index", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,24 +186,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -290,28 +271,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -338,21 +309,17 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -368,22 +335,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,22 +372,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -493,40 +452,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -548,33 +485,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -602,20 +524,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -658,24 +576,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -720,24 +632,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,22 +661,18 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Affine.jl
+++ b/src/Dialects/16/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply`
@@ -27,17 +27,21 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[mapOperands..., ]
+    results = IR.Type[result_0,]
+    operands = Value[mapOperands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.apply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.apply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -64,18 +68,27 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
-    results = IR.Type[multi_index..., ]
-    operands = Value[linear_index, basis..., ]
+function delinearize_index(
+    linear_index::Value,
+    basis::Vector{Value};
+    multi_index::Vector{IR.Type},
+    location=Location(),
+)
+    results = IR.Type[multi_index...,]
+    operands = Value[linear_index, basis...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.delinearize_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.delinearize_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -186,18 +199,24 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operand_0..., ]
-    owned_regions = Region[region, ]
+function for_(
+    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[operand_0...,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -271,18 +290,28 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operand_0..., ]
-    owned_regions = Region[thenRegion, elseRegion, ]
+function if_(
+    operand_0::Vector{Value};
+    results::Vector{IR.Type},
+    thenRegion::Region,
+    elseRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[operand_0...,]
+    owned_regions = Region[thenRegion, elseRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,17 +338,21 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -335,18 +368,22 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.max", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -372,18 +409,22 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.min", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -452,18 +493,40 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[mapOperands..., ]
-    owned_regions = Region[region, ]
+function parallel(
+    mapOperands::Vector{Value};
+    results::Vector{IR.Type},
+    reductions,
+    lowerBoundsMap,
+    lowerBoundsGroups,
+    upperBoundsMap,
+    upperBoundsGroups,
+    steps,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[mapOperands...,]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
-    
-    IR.create_operation(
-        "affine.parallel", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("reductions", reductions),
+        namedattribute("lowerBoundsMap", lowerBoundsMap),
+        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
+        namedattribute("upperBoundsMap", upperBoundsMap),
+        namedattribute("upperBoundsGroups", upperBoundsGroups),
+        namedattribute("steps", steps),
+    ]
+
+    return IR.create_operation(
+        "affine.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -485,18 +548,33 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
+function prefetch(
+    memref::Value,
+    indices::Vector{Value};
+    isWrite,
+    localityHint,
+    isDataCache,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memref, indices..., ]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
-    
-    IR.create_operation(
-        "affine.prefetch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("isWrite", isWrite),
+        namedattribute("localityHint", localityHint),
+        namedattribute("isDataCache", isDataCache),
+    ]
+
+    return IR.create_operation(
+        "affine.prefetch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -524,16 +602,20 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -576,18 +658,24 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+function vector_load(
+    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.vector_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.vector_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -632,18 +720,24 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
+function vector_store(
+    value::Value, memref::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.vector_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.vector_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -661,18 +755,22 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Affine.jl
+++ b/src/Dialects/16/Affine.jl
@@ -1,9 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -28,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -69,27 +64,18 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(
-    linear_index::Value,
-    basis::Vector{Value};
-    multi_index::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[multi_index...,]
-    operands = Value[linear_index, basis...]
+function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
+    results = IR.Type[multi_index..., ]
+    operands = Value[linear_index, basis..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.delinearize_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.delinearize_index", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -200,24 +186,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -291,28 +271,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -339,21 +309,17 @@ Example 2: Uses \'symbol\' keyword for symbols \'%n\' and \'%m\'.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -369,22 +335,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -410,22 +372,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -494,40 +452,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -549,33 +485,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -603,20 +524,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,24 +576,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-vectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -721,24 +632,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-vectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -756,22 +661,18 @@ Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 ```
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Arith.jl
+++ b/src/Dialects/16/Arith.jl
@@ -1,9 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `addf`
@@ -29,30 +28,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -77,25 +66,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -120,24 +103,18 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(
-    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
-)
-    results = IR.Type[sum, overflow]
-    operands = Value[lhs, rhs]
+function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
+    results = IR.Type[sum, overflow, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.addui_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addui_extended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,25 +139,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -203,21 +174,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -236,25 +203,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -275,25 +236,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -324,29 +279,18 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -415,29 +359,18 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -458,23 +391,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -482,30 +411,20 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,25 +450,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -576,25 +489,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -606,21 +513,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,21 +548,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -683,21 +582,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,21 +604,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -735,21 +626,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -769,25 +656,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -800,21 +681,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -827,21 +704,17 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_castui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_castui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -864,30 +737,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -895,25 +758,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -921,25 +778,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -962,30 +813,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -993,25 +834,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1019,25 +854,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1065,30 +894,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1096,25 +915,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1139,30 +952,20 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mulsi_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulsi_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1187,30 +990,20 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mului_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mului_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1235,29 +1028,20 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1282,25 +1066,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1308,30 +1086,20 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1357,25 +1125,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1401,25 +1163,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1432,21 +1188,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1464,25 +1216,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1504,25 +1250,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1541,25 +1281,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1587,30 +1321,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1618,25 +1342,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1649,21 +1367,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1686,21 +1400,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1713,21 +1423,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1752,25 +1458,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1804,29 +1504,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/Arith.jl
+++ b/src/Dialects/16/Arith.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `addf`
@@ -28,20 +28,30 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function addf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.addf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -66,19 +76,25 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function addi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.addi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -103,18 +119,24 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
-    results = IR.Type[sum, overflow, ]
-    operands = Value[lhs, rhs, ]
+function addui_extended(
+    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
+)
+    results = IR.Type[sum, overflow]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.addui_extended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addui_extended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -139,19 +161,25 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function andi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.andi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.andi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -174,17 +202,21 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -203,19 +235,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ceildivsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ceildivsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -236,19 +274,25 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ceildivui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ceildivui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -279,18 +323,29 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+function cmpf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    predicate,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "arith.cmpf", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "arith.cmpf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -359,18 +414,29 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+function cmpi(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    predicate,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "arith.cmpi", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "arith.cmpi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -391,19 +457,23 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -411,20 +481,30 @@ end
 `divf`
 
 """
-function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function divf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.divf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -450,19 +530,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -489,19 +575,25 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -513,17 +605,21 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -548,17 +644,21 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -582,17 +682,21 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -604,17 +708,21 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.fptosi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.fptosi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -626,17 +734,21 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.fptoui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.fptoui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -656,19 +768,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function floordivsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.floordivsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.floordivsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -681,17 +799,21 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.index_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.index_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -704,17 +826,21 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.index_castui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.index_castui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -737,20 +863,30 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function maxf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.maxf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -758,19 +894,25 @@ end
 `maxsi`
 
 """
-function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -778,19 +920,25 @@ end
 `maxui`
 
 """
-function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -813,20 +961,30 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function minf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.minf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -834,19 +992,25 @@ end
 `minsi`
 
 """
-function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -854,19 +1018,25 @@ end
 `minui`
 
 """
-function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -894,20 +1064,30 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function mulf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -915,19 +1095,25 @@ end
 `muli`
 
 """
-function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function muli(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -952,20 +1138,30 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
+function mulsi_extended(
+    lhs::Value,
+    rhs::Value;
+    low=nothing::Union{Nothing,IR.Type},
+    high=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-    
-    IR.create_operation(
-        "arith.mulsi_extended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mulsi_extended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -990,20 +1186,30 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
+function mului_extended(
+    lhs::Value,
+    rhs::Value;
+    low=nothing::Union{Nothing,IR.Type},
+    high=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-    
-    IR.create_operation(
-        "arith.mului_extended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mului_extended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1028,20 +1234,29 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function negf(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.negf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.negf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1066,19 +1281,25 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ori(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ori", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ori",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1086,20 +1307,30 @@ end
 `remf`
 
 """
-function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function remf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.remf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1125,19 +1356,25 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1163,19 +1400,25 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1188,17 +1431,21 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.sitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.sitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1216,19 +1463,25 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shli(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1250,19 +1503,25 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shrsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shrsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1281,19 +1540,25 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shrui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shrui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1321,20 +1586,30 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function subf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.subf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.subf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1342,19 +1617,25 @@ end
 `subi`
 
 """
-function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.subi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.subi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1367,17 +1648,21 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.truncf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.truncf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1400,17 +1685,21 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.trunci", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.trunci",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1423,17 +1712,21 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.uitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.uitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1458,19 +1751,25 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function xori(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.xori", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.xori",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1504,19 +1803,29 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function select(
+    condition::Value,
+    true_value::Value,
+    false_value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value, ]
+    operands = Value[condition, true_value, false_value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/16/Arith.jl
+++ b/src/Dialects/16/Arith.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `addf`
@@ -28,30 +28,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,25 +66,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -119,24 +103,18 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(
-    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
-)
-    results = IR.Type[sum, overflow]
-    operands = Value[lhs, rhs]
+function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
+    results = IR.Type[sum, overflow, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.addui_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addui_extended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,25 +139,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -202,21 +174,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,25 +203,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -274,25 +236,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,29 +279,18 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -414,29 +359,18 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -457,23 +391,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -481,30 +411,20 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -530,25 +450,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -575,25 +489,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -605,21 +513,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -644,21 +548,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -682,21 +582,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -708,21 +604,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -734,21 +626,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,25 +656,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -799,21 +681,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -826,21 +704,17 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_castui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_castui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -863,30 +737,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,25 +758,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -920,25 +778,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -961,30 +813,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -992,25 +834,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1018,25 +854,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1064,30 +894,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1095,25 +915,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1138,30 +952,20 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mulsi_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulsi_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1186,30 +990,20 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mului_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mului_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1234,29 +1028,20 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1281,25 +1066,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1307,30 +1086,20 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1356,25 +1125,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1400,25 +1163,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1431,21 +1188,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1463,25 +1216,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1503,25 +1250,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1540,25 +1281,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1586,30 +1321,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1617,25 +1342,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1648,21 +1367,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1685,21 +1400,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1712,21 +1423,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1751,25 +1458,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1803,29 +1504,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/ArmNeon.jl
+++ b/src/Dialects/16/ArmNeon.jl
@@ -1,9 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_smull`
@@ -17,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -48,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/ArmNeon.jl
+++ b/src/Dialects/16/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_smull`
@@ -16,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -47,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/ArmNeon.jl
+++ b/src/Dialects/16/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `intr_smull`
@@ -16,17 +16,21 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.intr.smull", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.intr.smull",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -43,17 +47,21 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, c, ]
+    results = IR.Type[res,]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.2d.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.2d.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -68,17 +76,21 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, c, ]
+    results = IR.Type[res,]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.intr.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.intr.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/ArmSVE.jl
+++ b/src/Dialects/16/ArmSVE.jl
@@ -1,25 +1,31 @@
 module arm_sve
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fadd(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fadd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -30,18 +36,24 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_addf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.addf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.addf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -49,18 +61,24 @@ end
 `intr_add`
 
 """
-function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_add(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -71,18 +89,24 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_addi(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.addi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.addi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -90,18 +114,24 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fdiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -112,18 +142,24 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -131,18 +167,24 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fmul(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fmul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -153,18 +195,24 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_mulf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -172,18 +220,24 @@ end
 `intr_mul`
 
 """
-function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_mul(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,18 +248,24 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_muli(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -213,18 +273,24 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sdiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -235,18 +301,24 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divi_signed(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divi_signed", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divi_signed",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -254,18 +326,24 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fsub(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fsub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fsub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -276,18 +354,24 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_subf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.subf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.subf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -295,18 +379,24 @@ end
 `intr_sub`
 
 """
-function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sub(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,18 +407,24 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_subi(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.subi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.subi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -336,18 +432,24 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_udiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.udiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.udiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -358,18 +460,24 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divi_unsigned(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divi_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divi_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -377,18 +485,24 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sdot(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -407,17 +521,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -425,18 +543,24 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_smmla(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.smmla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.smmla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,17 +582,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.smmla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.smmla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -476,18 +604,24 @@ end
 `intr_udot`
 
 """
-function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_udot(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.udot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.udot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -506,17 +640,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.udot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.udot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -524,18 +662,24 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_ummla(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.ummla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.ummla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -557,17 +701,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.ummla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.ummla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/ArmSVE.jl
+++ b/src/Dialects/16/ArmSVE.jl
@@ -1,32 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -37,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -90,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -143,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -196,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -249,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -274,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -302,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -327,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -380,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -433,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -461,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -486,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -544,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/ArmSVE.jl
+++ b/src/Dialects/16/ArmSVE.jl
@@ -1,31 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -89,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -142,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -379,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -460,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -485,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -543,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -662,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -701,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Async.jl
+++ b/src/Dialects/16/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add_to_group`
@@ -19,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,24 +116,18 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "async.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "async.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -157,23 +137,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -186,20 +162,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -211,20 +183,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -233,23 +201,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -258,25 +222,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -292,28 +250,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,25 +282,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -397,30 +339,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    bodyOperands::Vector{Value};
-    token::IR.Type,
-    bodyResults::Vector{IR.Type},
-    bodyRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[token, bodyResults...]
-    operands = Value[dependencies..., bodyOperands...]
-    owned_regions = Region[bodyRegion,]
+function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[token, bodyResults..., ]
+    operands = Value[dependencies..., bodyOperands..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -455,36 +386,21 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "async.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,22 +417,18 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -528,20 +440,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -551,25 +459,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -582,20 +484,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -607,20 +505,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -630,25 +524,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -659,21 +547,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -685,20 +569,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,25 +590,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -738,25 +612,18 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(
-    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[storage,]
+function runtime_load(storage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -766,25 +633,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -796,20 +657,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,20 +678,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -846,20 +699,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,20 +720,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,22 +739,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Async.jl
+++ b/src/Dialects/16/Async.jl
@@ -1,9 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add_to_group`
@@ -20,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -131,24 +116,18 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "async.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "async.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -158,23 +137,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,20 +162,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,20 +183,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -234,23 +201,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -259,25 +222,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -293,28 +250,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -335,25 +282,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -398,30 +339,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    bodyOperands::Vector{Value};
-    token::IR.Type,
-    bodyResults::Vector{IR.Type},
-    bodyRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[token, bodyResults...]
-    operands = Value[dependencies..., bodyOperands...]
-    owned_regions = Region[bodyRegion,]
+function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[token, bodyResults..., ]
+    operands = Value[dependencies..., bodyOperands..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -456,36 +386,21 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "async.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,22 +417,18 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -529,20 +440,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -552,25 +459,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -583,20 +484,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -608,20 +505,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -631,25 +524,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -660,21 +547,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -686,20 +569,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -711,25 +590,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -739,25 +612,18 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(
-    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[storage,]
+function runtime_load(storage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -767,25 +633,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -797,20 +657,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -822,20 +678,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -847,20 +699,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -872,20 +720,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -895,22 +739,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Async.jl
+++ b/src/Dialects/16/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add_to_group`
@@ -19,19 +19,25 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function add_to_group(
+    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, group, ]
+    operands = Value[operand, group]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "async.add_to_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.add_to_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -57,16 +63,20 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.await_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.await_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,19 +96,23 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.await", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.await",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -116,18 +130,24 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
-    
-    IR.create_operation(
-        "async.call", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee),]
+
+    return IR.create_operation(
+        "async.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -137,19 +157,23 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id, ]
+    operands = Value[id,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-    
-    IR.create_operation(
-        "async.coro.begin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.begin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -162,16 +186,20 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.end", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.end",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -183,16 +211,20 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle, ]
+    operands = Value[id, handle]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.free", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.free",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -201,19 +233,23 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-    
-    IR.create_operation(
-        "async.coro.id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -222,19 +258,25 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_save(
+    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-    
-    IR.create_operation(
-        "async.coro.save", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.save",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -250,18 +292,28 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
+function coro_suspend(
+    state::Value;
+    suspendDest::Block,
+    resumeDest::Block,
+    cleanupDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[state, ]
+    operands = Value[state,]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest, ]
+    successors = Block[suspendDest, resumeDest, cleanupDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.suspend", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.suspend",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -282,19 +334,25 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function create_group(
+    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[size, ]
+    operands = Value[size,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -339,19 +397,30 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[token, bodyResults..., ]
-    operands = Value[dependencies..., bodyOperands..., ]
-    owned_regions = Region[bodyRegion, ]
+function execute(
+    dependencies::Vector{Value},
+    bodyOperands::Vector{Value};
+    token::IR.Type,
+    bodyResults::Vector{IR.Type},
+    bodyRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[token, bodyResults...]
+    operands = Value[dependencies..., bodyOperands...]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
-    
-    IR.create_operation(
-        "async.execute", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
+
+    return IR.create_operation(
+        "async.execute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -386,21 +455,36 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    sym_visibility=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "async.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -417,18 +501,22 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -440,16 +528,20 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    
-    IR.create_operation(
-        "async.runtime.add_ref", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("count", count),]
+
+    return IR.create_operation(
+        "async.runtime.add_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -459,19 +551,25 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_add_to_group(
+    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, group, ]
+    operands = Value[operand, group]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "async.runtime.add_to_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.add_to_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -484,16 +582,20 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle, ]
+    operands = Value[operand, handle]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.await_and_resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.await_and_resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -505,16 +607,20 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.await", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.await",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -524,19 +630,25 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_create_group(
+    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[size, ]
+    operands = Value[size,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.runtime.create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -547,17 +659,21 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -569,16 +685,20 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    
-    IR.create_operation(
-        "async.runtime.drop_ref", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("count", count),]
+
+    return IR.create_operation(
+        "async.runtime.drop_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -590,19 +710,25 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_is_error(
+    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-    
-    IR.create_operation(
-        "async.runtime.is_error", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.is_error",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -612,18 +738,25 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(storage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[storage, ]
+function runtime_load(
+    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[storage,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.load", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "async.runtime.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -633,19 +766,25 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_num_worker_threads(;
+    result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.runtime.num_worker_threads", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.num_worker_threads",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -657,16 +796,20 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -678,16 +821,20 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.set_available", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.set_available",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -699,16 +846,20 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.set_error", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.set_error",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -720,16 +871,20 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage, ]
+    operands = Value[value, storage]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -739,18 +894,22 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Bufferization.jl
+++ b/src/Dialects/16/Bufferization.jl
@@ -1,9 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `alloc_tensor`
@@ -56,46 +55,22 @@ return %0 : tensor<?x?xf32, #SparseMatrix>
   : tensor<?x?xf32, #SparseMatrix>
 ```
 """
-function alloc_tensor(
-    dynamic_sizes::Vector{Value},
-    copy=nothing::Union{Nothing,Value};
-    size_hint=nothing::Union{Nothing,Value},
-    result::IR.Type,
-    memory_space=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[dynamic_sizes...,]
+function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; size_hint=nothing::Union{Nothing, Value}, result::IR.Type, memory_space=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
     !isnothing(size_hint) && push!(operands, size_hint)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(dynamic_sizes),
-            if (copy == nothing)
-                0
-            elseif 1(size_hint == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
-
-    return IR.create_operation(
-        "bufferization.alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1(size_hint==nothing) ? 0 : 1]))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    
+    IR.create_operation(
+        "bufferization.alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -116,21 +91,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,20 +133,16 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.dealloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -197,21 +164,17 @@ This operation is a specialized variant of the built-in
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -236,25 +199,18 @@ involving tensors and memrefs.
 If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
-function to_tensor(
-    memref::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[memref,]
+function to_tensor(memref::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Bufferization.jl
+++ b/src/Dialects/16/Bufferization.jl
@@ -1,8 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alloc_tensor`
@@ -55,45 +55,22 @@ return %0 : tensor<?x?xf32, #SparseMatrix>
   : tensor<?x?xf32, #SparseMatrix>
 ```
 """
-function alloc_tensor(
-    dynamic_sizes::Vector{Value},
-    copy=nothing::Union{Nothing,Value};
-    size_hint=nothing::Union{Nothing,Value},
-    result::IR.Type,
-    memory_space=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[dynamic_sizes...,]
+function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; size_hint=nothing::Union{Nothing, Value}, result::IR.Type, memory_space=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
     !isnothing(size_hint) && push!(operands, size_hint)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(dynamic_sizes), if (copy == nothing)
-                0
-            elseif 1(size_hint == nothing)
-                0
-            else
-                1
-            end
-        ]),
-    )
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
-
-    return IR.create_operation(
-        "bufferization.alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1(size_hint==nothing) ? 0 : 1]))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    
+    IR.create_operation(
+        "bufferization.alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,21 +91,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,20 +133,16 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.dealloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,21 +164,17 @@ This operation is a specialized variant of the built-in
 gradual bufferization.
 """
 function to_memref(tensor::Value; memref::IR.Type, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -234,25 +199,18 @@ involving tensors and memrefs.
 If tensor load is used in the bufferization steps, mutating the source
 buffer after loading leads to undefined behavior.
 """
-function to_tensor(
-    memref::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[memref,]
+function to_tensor(memref::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Builtin.jl
+++ b/src/Dialects/16/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `module_`
@@ -23,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -81,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Builtin.jl
+++ b/src/Dialects/16/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `module_`
@@ -23,20 +23,27 @@ module {
 }
 ```
 """
-function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
+function module_(;
+    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "builtin.module", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "builtin.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -74,18 +81,24 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
+function unrealized_conversion_cast(
+    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "builtin.unrealized_conversion_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "builtin.unrealized_conversion_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Builtin.jl
+++ b/src/Dialects/16/Builtin.jl
@@ -1,9 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `module_`
@@ -24,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -82,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Complex.jl
+++ b/src/Dialects/16/Complex.jl
@@ -1,9 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -16,23 +15,18 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function abs(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -47,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,23 +68,18 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function angle(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -112,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -146,23 +123,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -179,21 +152,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -209,23 +178,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -242,21 +207,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -270,25 +231,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -303,25 +258,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -338,23 +287,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -375,23 +320,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -406,23 +347,18 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function im(complex::Value; imaginary::IR.Type, location=Location())
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imaginary) && push!(results, imaginary)
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -440,23 +376,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -473,23 +405,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -502,25 +430,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -535,23 +457,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -567,25 +485,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -601,25 +513,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -634,23 +540,18 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function re(complex::Value; real::IR.Type, location=Location())
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(real) && push!(results, real)
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -665,23 +566,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -697,23 +594,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -729,23 +622,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,23 +649,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -791,25 +676,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -825,23 +704,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -857,23 +732,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/Complex.jl
+++ b/src/Dialects/16/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -15,23 +15,18 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function abs(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -46,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -79,23 +68,18 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function angle(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -111,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -145,23 +123,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -178,21 +152,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -208,23 +178,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,21 +207,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -269,25 +231,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -302,25 +258,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -337,23 +287,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -374,23 +320,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -405,23 +347,18 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function im(complex::Value; imaginary::IR.Type, location=Location())
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imaginary) && push!(results, imaginary)
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -439,23 +376,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -472,23 +405,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -501,25 +430,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -534,23 +457,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -566,25 +485,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -600,25 +513,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -633,23 +540,18 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function re(complex::Value; real::IR.Type, location=Location())
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(real) && push!(results, real)
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -664,23 +566,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -696,23 +594,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -728,23 +622,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -759,23 +649,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -790,25 +676,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -824,23 +704,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -856,23 +732,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/Complex.jl
+++ b/src/Dialects/16/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -15,18 +15,23 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[complex, ]
+function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.abs", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "complex.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -41,19 +46,25 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -68,18 +79,23 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[complex, ]
+function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.angle", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "complex.angle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -95,19 +111,25 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function atan2(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.atan2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.atan2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -123,19 +145,23 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.conj", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.conj",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -152,17 +178,21 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex, ]
+    results = IR.Type[complex,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "complex.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "complex.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -178,19 +208,23 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -207,17 +241,21 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex, ]
-    operands = Value[real, imaginary, ]
+    results = IR.Type[complex,]
+    operands = Value[real, imaginary]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -231,19 +269,25 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function div(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -258,19 +302,25 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function eq(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -287,19 +337,23 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -320,19 +374,23 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.expm1", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.expm1",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -347,18 +405,23 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary::IR.Type, location=Location())
-    results = IR.Type[imaginary, ]
-    operands = Value[complex, ]
+function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.im", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(imaginary) && push!(results, imaginary)
+
+    return IR.create_operation(
+        "complex.im",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -376,19 +439,23 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.log1p", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.log1p",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -405,19 +472,23 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -430,19 +501,25 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -457,19 +534,23 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.neg", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.neg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -485,19 +566,25 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function neq(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.neq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.neq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -513,19 +600,25 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -540,18 +633,23 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real::IR.Type, location=Location())
-    results = IR.Type[real, ]
-    operands = Value[complex, ]
+function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.re", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(real) && push!(results, real)
+
+    return IR.create_operation(
+        "complex.re",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -566,19 +664,23 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -594,19 +696,23 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -622,19 +728,23 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -649,19 +759,23 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -676,19 +790,25 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -704,19 +824,23 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -732,19 +856,23 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/16/ControlFlow.jl
+++ b/src/Dialects/16/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `assert`
@@ -20,16 +20,20 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg), ]
-    
-    IR.create_operation(
-        "cf.assert", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg),]
+
+    return IR.create_operation(
+        "cf.assert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -52,16 +56,20 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands..., ]
+    operands = Value[destOperands...,]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "cf.br", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "cf.br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -93,19 +101,33 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
+function cond_br(
+    condition::Value,
+    trueDestOperands::Vector{Value},
+    falseDestOperands::Vector{Value};
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
+    operands = Value[condition, trueDestOperands..., falseDestOperands...]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
-    
-    IR.create_operation(
-        "cf.cond_br", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
+    )
+
+    return IR.create_operation(
+        "cf.cond_br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -128,20 +150,37 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
+function switch(
+    flag::Value,
+    defaultOperands::Vector{Value},
+    caseOperands::Vector{Value};
+    case_values=nothing,
+    case_operand_segments,
+    defaultDestination::Block,
+    caseDestinations::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands..., ]
+    operands = Value[flag, defaultOperands..., caseOperands...]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations..., ]
-    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
-    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
+    successors = Block[defaultDestination, caseDestinations...]
+    attributes = NamedAttribute[namedattribute(
+        "case_operand_segments", case_operand_segments
+    ),]
+    push!(
+        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
+    )
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    
-    IR.create_operation(
-        "cf.switch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "cf.switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/ControlFlow.jl
+++ b/src/Dialects/16/ControlFlow.jl
@@ -1,9 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assert`
@@ -21,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -57,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -151,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/ControlFlow.jl
+++ b/src/Dialects/16/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assert`
@@ -20,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -56,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -101,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/EmitC.jl
+++ b/src/Dialects/16/EmitC.jl
@@ -1,9 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -24,21 +23,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,32 +56,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -109,21 +92,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,21 +129,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,19 +170,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -246,21 +216,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/EmitC.jl
+++ b/src/Dialects/16/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply`
@@ -23,17 +23,21 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
-    
-    IR.create_operation(
-        "emitc.apply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
+
+    return IR.create_operation(
+        "emitc.apply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -56,20 +60,32 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee,
+    args=nothing,
+    template_args=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    attributes = NamedAttribute[namedattribute("callee", callee),]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
-    
-    IR.create_operation(
-        "emitc.call", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(template_args) &&
+        push!(attributes, namedattribute("template_args", template_args))
+
+    return IR.create_operation(
+        "emitc.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -92,17 +108,21 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -129,17 +149,21 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "emitc.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "emitc.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -170,14 +194,19 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_), ]
-    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
-    
-    IR.create_operation(
-        "emitc.include", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("include", include_),]
+    !isnothing(is_standard_include) &&
+        push!(attributes, namedattribute("is_standard_include", is_standard_include))
+
+    return IR.create_operation(
+        "emitc.include",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -216,17 +245,21 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "emitc.variable", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "emitc.variable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/EmitC.jl
+++ b/src/Dialects/16/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -23,21 +23,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -60,32 +56,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -108,21 +92,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,21 +129,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,19 +170,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,21 +216,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Func.jl
+++ b/src/Dialects/16/Func.jl
@@ -1,9 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `call_indirect`
@@ -22,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -60,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -103,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,36 +140,21 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -210,22 +175,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Func.jl
+++ b/src/Dialects/16/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `call_indirect`
@@ -21,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -59,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,36 +140,21 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -209,22 +175,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Func.jl
+++ b/src/Dialects/16/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `call_indirect`
@@ -21,18 +21,27 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[callee, callee_operands..., ]
+function call_indirect(
+    callee::Value,
+    callee_operands::Vector{Value};
+    results::Vector{IR.Type},
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[callee, callee_operands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "func.call_indirect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.call_indirect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -50,18 +59,24 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
-    
-    IR.create_operation(
-        "func.call", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee),]
+
+    return IR.create_operation(
+        "func.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -87,17 +102,21 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "func.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "func.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -140,21 +159,36 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func_(;
+    sym_name,
+    function_type,
+    sym_visibility=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "func.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -175,18 +209,22 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "func.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/GPU.jl
+++ b/src/Dialects/16/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `all_reduce`
@@ -29,21 +29,32 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
+function all_reduce(
+    value::Value;
+    result_0=nothing::Union{Nothing,IR.Type},
+    op=nothing,
+    uniform=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, ]
-    owned_regions = Region[body, ]
+    operands = Value[value,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-    
-    IR.create_operation(
-        "gpu.all_reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.all_reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -69,21 +80,38 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
+function alloc(
+    asyncDependencies::Vector{Value},
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    hostShared=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-    
-    IR.create_operation(
-        "gpu.alloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.alloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -112,12 +140,16 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -133,19 +165,25 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function block_dim(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.block_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.block_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -161,19 +199,25 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function block_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.block_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.block_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -197,19 +241,28 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function dealloc(
+    asyncDependencies::Vector{Value},
+    memref::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref, ]
+    operands = Value[asyncDependencies..., memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -280,20 +333,26 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(; function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func(;
+    function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type),]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "gpu.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -326,15 +385,19 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.module", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -351,19 +414,25 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function global_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.global_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.global_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -379,19 +448,25 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function grid_dim(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.grid_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.grid_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -409,16 +484,20 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.host_register", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.host_register",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -432,19 +511,23 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.lane_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.lane_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -529,21 +612,59 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
+function launch_func(
+    asyncDependencies::Vector{Value},
+    gridSizeX::Value,
+    gridSizeY::Value,
+    gridSizeZ::Value,
+    blockSizeX::Value,
+    blockSizeY::Value,
+    blockSizeZ::Value,
+    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
+    kernelOperands::Vector{Value},
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    kernel,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
+    operands = Value[
+        asyncDependencies...,
+        gridSizeX,
+        gridSizeY,
+        gridSizeZ,
+        blockSizeX,
+        blockSizeY,
+        blockSizeZ,
+        kernelOperands...,
+    ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
+    attributes = NamedAttribute[namedattribute("kernel", kernel),]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(kernelOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies),
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.launch_func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.launch_func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -621,21 +742,57 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
+function launch(
+    asyncDependencies::Vector{Value},
+    gridSizeX::Value,
+    gridSizeY::Value,
+    gridSizeZ::Value,
+    blockSizeX::Value,
+    blockSizeY::Value,
+    blockSizeZ::Value,
+    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
-    owned_regions = Region[body, ]
+    operands = Value[
+        asyncDependencies...,
+        gridSizeX,
+        gridSizeY,
+        gridSizeZ,
+        blockSizeX,
+        blockSizeY,
+        blockSizeZ,
+    ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies),
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            (dynamicSharedMemorySize == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.launch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.launch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -657,19 +814,29 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function memcpy(
+    asyncDependencies::Vector{Value},
+    dst::Value,
+    src::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src, ]
+    operands = Value[asyncDependencies..., dst, src]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.memcpy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.memcpy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -691,19 +858,29 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function memset(
+    asyncDependencies::Vector{Value},
+    dst::Value,
+    value::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value, ]
+    operands = Value[asyncDependencies..., dst, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.memset", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.memset",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -718,12 +895,16 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.module_end", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.module_end",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -738,19 +919,23 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.num_subgroups", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.num_subgroups",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -765,16 +950,20 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format), ]
-    
-    IR.create_operation(
-        "gpu.printf", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("format", format),]
+
+    return IR.create_operation(
+        "gpu.printf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -785,18 +974,22 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -809,16 +1002,20 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex, ]
+    operands = Value[devIndex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.set_default_device", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.set_default_device",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -843,20 +1040,32 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
+function shuffle(
+    value::Value,
+    offset::Value,
+    width::Value;
+    shuffleResult=nothing::Union{Nothing,IR.Type},
+    valid=nothing::Union{Nothing,IR.Type},
+    mode,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, offset, width, ]
+    operands = Value[value, offset, width]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode), ]
+    attributes = NamedAttribute[namedattribute("mode", mode),]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-    
-    IR.create_operation(
-        "gpu.shuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.shuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -872,19 +1081,23 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.subgroup_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -915,21 +1128,33 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
+function subgroup_mma_compute(
+    opA::Value,
+    opB::Value,
+    opC::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    a_transpose=nothing,
+    b_transpose=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[opA, opB, opC, ]
+    operands = Value[opA, opB, opC]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_compute", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_compute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -957,17 +1182,21 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[value, ]
+    results = IR.Type[res,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -991,18 +1220,24 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[args..., ]
+function subgroup_mma_elementwise(
+    args::Vector{Value}; res::IR.Type, opType, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType), ]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_elementwise", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType),]
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_elementwise",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1030,19 +1265,30 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[srcMemref, indices..., ]
+function subgroup_mma_load_matrix(
+    srcMemref::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    leadDimension,
+    transpose=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[srcMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_load_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_load_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1069,19 +1315,30 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
+function subgroup_mma_store_matrix(
+    src::Value,
+    dstMemref::Value,
+    indices::Vector{Value};
+    leadDimension,
+    transpose=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices..., ]
+    operands = Value[src, dstMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_store_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_store_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1100,20 +1357,30 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
+function subgroup_reduce(
+    value::Value;
+    result_0=nothing::Union{Nothing,IR.Type},
+    op,
+    uniform=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op), ]
+    attributes = NamedAttribute[namedattribute("op", op),]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-    
-    IR.create_operation(
-        "gpu.subgroup_reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1128,19 +1395,23 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.subgroup_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1157,12 +1428,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1178,19 +1453,25 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function thread_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.thread_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.thread_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1227,19 +1508,27 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function wait(
+    asyncDependencies::Vector{Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., ]
+    operands = Value[asyncDependencies...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1257,16 +1546,20 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values..., ]
+    operands = Value[values...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/GPU.jl
+++ b/src/Dialects/16/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `all_reduce`
@@ -29,32 +29,21 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    uniform=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,38 +69,21 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    hostShared=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,16 +112,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -165,25 +133,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -199,25 +161,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,28 +197,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,26 +280,20 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(;
-    function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location()
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -385,19 +326,15 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -414,25 +351,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -448,25 +379,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -484,20 +409,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -511,23 +432,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -612,59 +529,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    kernelOperands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        kernelOperands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(kernelOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -742,57 +621,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -814,29 +657,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -858,29 +691,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -895,16 +718,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -919,23 +738,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -950,20 +765,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -974,22 +785,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1002,20 +809,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1040,32 +843,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    shuffleResult=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1081,23 +872,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1128,33 +915,21 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    a_transpose=nothing,
-    b_transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1182,21 +957,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1220,24 +991,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, opType, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1265,30 +1030,19 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1315,30 +1069,19 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value,
-    dstMemref::Value,
-    indices::Vector{Value};
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1357,30 +1100,20 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op,
-    uniform=nothing,
-    location=Location(),
-)
+function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op),]
+    attributes = NamedAttribute[namedattribute("op", op), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.subgroup_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1395,23 +1128,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1428,16 +1157,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1453,25 +1178,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1508,27 +1227,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1546,20 +1257,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/GPU.jl
+++ b/src/Dialects/16/GPU.jl
@@ -1,9 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `all_reduce`
@@ -30,32 +29,21 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    uniform=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -81,38 +69,21 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    hostShared=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,16 +112,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -166,25 +133,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -200,25 +161,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -242,28 +197,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,26 +280,20 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(;
-    function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location()
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -386,19 +326,15 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -415,25 +351,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -449,25 +379,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -485,20 +409,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -512,23 +432,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -613,59 +529,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    kernelOperands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        kernelOperands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(kernelOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -743,57 +621,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -815,29 +657,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -859,29 +691,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -896,16 +718,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -920,23 +738,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -951,20 +765,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -975,22 +785,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1003,20 +809,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1041,32 +843,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    shuffleResult=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1082,23 +872,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1129,33 +915,21 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    a_transpose=nothing,
-    b_transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1183,21 +957,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1221,24 +991,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, opType, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1266,30 +1030,19 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1316,30 +1069,19 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value,
-    dstMemref::Value,
-    indices::Vector{Value};
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1358,30 +1100,20 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op,
-    uniform=nothing,
-    location=Location(),
-)
+function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op),]
+    attributes = NamedAttribute[namedattribute("op", op), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.subgroup_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1396,23 +1128,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1429,16 +1157,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1454,25 +1178,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1509,27 +1227,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1547,20 +1257,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Index.jl
+++ b/src/Dialects/16/Index.jl
@@ -1,8 +1,8 @@
 module index
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -16,25 +16,19 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -51,25 +45,19 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -88,23 +76,19 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.bool.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.bool.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -127,21 +111,17 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.casts",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.casts", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,21 +144,17 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.castu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.castu", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,25 +174,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -236,25 +206,19 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -291,29 +255,19 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    pred,
-    location=Location(),
-)
+function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.cmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.cmp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -329,23 +283,19 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -365,25 +315,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -403,25 +347,19 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -441,25 +379,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.floordivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.floordivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -476,25 +408,19 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -512,25 +438,19 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -547,25 +467,19 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mins",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mins", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -583,25 +497,19 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.minu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.minu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -617,25 +525,19 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -652,25 +554,19 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -687,25 +583,19 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.rems",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.rems", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -723,25 +613,19 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.remu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.remu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,25 +644,19 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -797,25 +675,19 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shrs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shrs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -834,25 +706,19 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shru",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shru", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -869,23 +735,19 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sizeof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sizeof", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -902,25 +764,19 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -937,25 +793,19 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/Index.jl
+++ b/src/Dialects/16/Index.jl
@@ -1,8 +1,8 @@
 module index
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add`
@@ -16,19 +16,25 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -45,19 +51,25 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function and(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -76,19 +88,23 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.bool.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.bool.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -111,17 +127,21 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "index.casts", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.casts",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -144,17 +164,21 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "index.castu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.castu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -174,19 +198,25 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.ceildivs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.ceildivs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -206,19 +236,25 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.ceildivu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.ceildivu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -255,19 +291,29 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
+function cmp(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    pred,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred), ]
+    attributes = NamedAttribute[namedattribute("pred", pred),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.cmp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.cmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -283,19 +329,23 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -315,19 +365,25 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.divs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.divs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -347,19 +403,25 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.divu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.divu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -379,19 +441,25 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function floordivs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.floordivs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.floordivs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -408,19 +476,25 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.maxs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.maxs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -438,19 +512,25 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.maxu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.maxu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -467,19 +547,25 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mins(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.mins", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.mins",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -497,19 +583,25 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.minu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.minu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -525,19 +617,25 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -554,19 +652,25 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function or(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -583,19 +687,25 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function rems(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.rems", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.rems",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -613,19 +723,25 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.remu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.remu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -644,19 +760,25 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shl(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.shl", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.shl",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -675,19 +797,25 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.shrs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.shrs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -706,19 +834,25 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shru(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.shru", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.shru",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -735,19 +869,23 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.sizeof", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.sizeof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -764,19 +902,25 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -793,19 +937,25 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function xor(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/16/Index.jl
+++ b/src/Dialects/16/Index.jl
@@ -1,9 +1,8 @@
 module index
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -17,25 +16,19 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -52,25 +45,19 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -89,23 +76,19 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.bool.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.bool.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -128,21 +111,17 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.casts",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.casts", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -165,21 +144,17 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.castu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.castu", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,25 +174,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -237,25 +206,19 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -292,29 +255,19 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    pred,
-    location=Location(),
-)
+function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.cmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.cmp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -330,23 +283,19 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -366,25 +315,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -404,25 +347,19 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -442,25 +379,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.floordivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.floordivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -477,25 +408,19 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -513,25 +438,19 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -548,25 +467,19 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mins",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mins", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -584,25 +497,19 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.minu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.minu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -618,25 +525,19 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -653,25 +554,19 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -688,25 +583,19 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.rems",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.rems", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -724,25 +613,19 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.remu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.remu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -761,25 +644,19 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -798,25 +675,19 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shrs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shrs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -835,25 +706,19 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shru",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shru", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -870,23 +735,19 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sizeof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sizeof", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -903,25 +764,19 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -938,25 +793,19 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/LLVMIR.jl
+++ b/src/Dialects/16/LLVMIR.jl
@@ -1,33 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,17 +41,13 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.access_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.access_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -66,25 +55,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -93,21 +76,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,21 +120,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -172,18 +147,14 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope_domain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope_domain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -224,20 +195,14 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,30 +210,20 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -276,25 +231,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -302,33 +251,18 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res::IR.Type,
-    success_ordering,
-    failure_ordering,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -336,26 +270,18 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -364,21 +290,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,20 +310,16 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -433,35 +351,22 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    branch_weights=nothing,
-    location=Location(),
-)
+function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_0...,]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -469,36 +374,20 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -533,21 +422,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,25 +440,18 @@ end
 `extractelement`
 
 """
-function extractelement(
-    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, position]
+function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -582,21 +460,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,31 +478,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -636,32 +499,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -669,31 +519,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -701,31 +540,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -733,30 +561,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -765,21 +583,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -788,21 +602,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -811,21 +621,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -834,21 +640,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -856,31 +658,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -888,31 +679,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -925,19 +705,13 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
-    ]
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -945,23 +719,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -992,32 +762,20 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(
-    base::Value,
-    dynamicIndices::Vector{Value};
-    res::IR.Type,
-    rawConstantIndices,
-    elem_type=nothing,
-    inbounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, dynamicIndices...]
+function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, dynamicIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,19 +806,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1088,19 +840,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1201,50 +947,26 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1252,29 +974,18 @@ end
 `icmp`
 
 """
-function icmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1288,42 +999,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1331,29 +1023,19 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value,
-    value::Value,
-    position::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, value, position]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1361,29 +1043,19 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value,
-    value::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[container, value]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1392,21 +1064,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,41 +1082,21 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    branch_weights=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1481,51 +1129,28 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    function_entry_count=nothing,
-    memory=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) &&
-        push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1533,25 +1158,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1559,25 +1178,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1585,41 +1198,24 @@ end
 `load`
 
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1637,19 +1233,15 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1657,25 +1249,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1698,21 +1284,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1720,25 +1302,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1747,21 +1323,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1771,20 +1343,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1792,23 +1360,19 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing,Value}; location=Location())
+function return_(arg=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1816,25 +1380,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1843,21 +1401,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1866,21 +1420,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1888,25 +1438,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1914,29 +1458,19 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1944,25 +1478,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1971,21 +1499,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1993,41 +1517,24 @@ end
 `store`
 
 """
-function store(
-    value::Value,
-    addr::Value;
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2035,25 +1542,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2061,40 +1562,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2116,19 +1598,13 @@ function tbaa_root(; sym_name, identity, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("identity", identity)
-    ]
-
-    return IR.create_operation(
-        "llvm.tbaa_root",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("identity", identity), ]
+    
+    IR.create_operation(
+        "llvm.tbaa_root", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2180,30 +1656,19 @@ Defines a TBAA node describing a memory access.
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#tbaa-metadata
 """
-function tbaa_tag(;
-    sym_name, base_type, access_type, offset, constant=nothing, location=Location()
-)
+function tbaa_tag(; sym_name, base_type, access_type, offset, constant=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("base_type", base_type),
-        namedattribute("access_type", access_type),
-        namedattribute("offset", offset),
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("base_type", base_type), namedattribute("access_type", access_type), namedattribute("offset", offset), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
-
-    return IR.create_operation(
-        "llvm.tbaa_tag",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.tbaa_tag", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2250,22 +1715,14 @@ function tbaa_type_desc(; sym_name, identity=nothing, members, offsets, location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("members", members),
-        namedattribute("offsets", offsets),
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("members", members), namedattribute("offsets", offsets), ]
     !isnothing(identity) && push!(attributes, namedattribute("identity", identity))
-
-    return IR.create_operation(
-        "llvm.tbaa_type_desc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.tbaa_type_desc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2274,21 +1731,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2296,25 +1749,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2323,21 +1770,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2345,25 +1788,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2383,21 +1820,17 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2411,16 +1844,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2428,25 +1857,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2455,21 +1878,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/LLVMIR.jl
+++ b/src/Dialects/16/LLVMIR.jl
@@ -1,32 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -47,17 +41,13 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.access_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.access_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,25 +55,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -92,21 +76,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,21 +120,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -171,18 +147,14 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope_domain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope_domain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -223,20 +195,14 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-
-    return IR.create_operation(
-        "llvm.alias_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alias_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,30 +210,20 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -275,25 +231,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -301,33 +251,18 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res::IR.Type,
-    success_ordering,
-    failure_ordering,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -335,26 +270,18 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -363,21 +290,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -387,20 +310,16 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,35 +351,22 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    branch_weights=nothing,
-    location=Location(),
-)
+function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_0...,]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,36 +374,20 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -532,21 +422,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,25 +440,18 @@ end
 `extractelement`
 
 """
-function extractelement(
-    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, position]
+function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -581,21 +460,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -603,31 +478,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -635,32 +499,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -668,31 +519,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -700,31 +540,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -732,30 +561,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -764,21 +583,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -787,21 +602,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -810,21 +621,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -833,21 +640,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -855,31 +658,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -887,31 +679,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -924,19 +705,13 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
-    ]
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -944,23 +719,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -991,32 +762,20 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(
-    base::Value,
-    dynamicIndices::Vector{Value};
-    res::IR.Type,
-    rawConstantIndices,
-    elem_type=nothing,
-    inbounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, dynamicIndices...]
+function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, dynamicIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1047,19 +806,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1087,19 +840,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1200,50 +947,26 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1251,29 +974,18 @@ end
 `icmp`
 
 """
-function icmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1287,42 +999,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1330,29 +1023,19 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value,
-    value::Value,
-    position::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, value, position]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1360,29 +1043,19 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value,
-    value::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[container, value]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1391,21 +1064,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1413,41 +1082,21 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    branch_weights=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1480,51 +1129,28 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    function_entry_count=nothing,
-    memory=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) &&
-        push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1532,25 +1158,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1558,25 +1178,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1584,41 +1198,24 @@ end
 `load`
 
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1636,19 +1233,15 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1656,25 +1249,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1697,21 +1284,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1719,25 +1302,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1746,21 +1323,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1770,20 +1343,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1791,23 +1360,19 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing,Value}; location=Location())
+function return_(arg=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1815,25 +1380,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1842,21 +1401,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1865,21 +1420,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1887,25 +1438,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1913,29 +1458,19 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1943,25 +1478,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1970,21 +1499,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1992,41 +1517,24 @@ end
 `store`
 
 """
-function store(
-    value::Value,
-    addr::Value;
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2034,25 +1542,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2060,40 +1562,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2115,19 +1598,13 @@ function tbaa_root(; sym_name, identity, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("identity", identity)
-    ]
-
-    return IR.create_operation(
-        "llvm.tbaa_root",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("identity", identity), ]
+    
+    IR.create_operation(
+        "llvm.tbaa_root", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2179,30 +1656,19 @@ Defines a TBAA node describing a memory access.
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#tbaa-metadata
 """
-function tbaa_tag(;
-    sym_name, base_type, access_type, offset, constant=nothing, location=Location()
-)
+function tbaa_tag(; sym_name, base_type, access_type, offset, constant=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("base_type", base_type),
-        namedattribute("access_type", access_type),
-        namedattribute("offset", offset),
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("base_type", base_type), namedattribute("access_type", access_type), namedattribute("offset", offset), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
-
-    return IR.create_operation(
-        "llvm.tbaa_tag",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.tbaa_tag", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2249,22 +1715,14 @@ function tbaa_type_desc(; sym_name, identity=nothing, members, offsets, location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("members", members),
-        namedattribute("offsets", offsets),
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("members", members), namedattribute("offsets", offsets), ]
     !isnothing(identity) && push!(attributes, namedattribute("identity", identity))
-
-    return IR.create_operation(
-        "llvm.tbaa_type_desc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.tbaa_type_desc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2273,21 +1731,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2295,25 +1749,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2322,21 +1770,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2344,25 +1788,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2382,21 +1820,17 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2410,16 +1844,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2427,25 +1857,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2454,21 +1878,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/LLVMIR.jl
+++ b/src/Dialects/16/LLVMIR.jl
@@ -1,26 +1,32 @@
 module llvm
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `ashr`
 
 """
-function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function ashr(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.ashr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.ashr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -41,13 +47,17 @@ function access_group(; sym_name, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "llvm.access_group", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "llvm.access_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -55,19 +65,25 @@ end
 `add`
 
 """
-function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -76,17 +92,21 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.addrspacecast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.addrspacecast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -120,17 +140,21 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
-    
-    IR.create_operation(
-        "llvm.mlir.addressof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name),]
+
+    return IR.create_operation(
+        "llvm.mlir.addressof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -147,14 +171,18 @@ function alias_scope_domain(; sym_name, description=nothing, location=Location()
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-    
-    IR.create_operation(
-        "llvm.alias_scope_domain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alias_scope_domain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -195,14 +223,20 @@ function alias_scope(; sym_name, domain, description=nothing, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("domain", domain), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("domain", domain)
+    ]
     !isnothing(description) && push!(attributes, namedattribute("description", description))
-    
-    IR.create_operation(
-        "llvm.alias_scope", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alias_scope",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -210,20 +244,30 @@ end
 `alloca`
 
 """
-function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arraySize, ]
+function alloca(
+    arraySize::Value;
+    res::IR.Type,
+    alignment=nothing,
+    elem_type=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[arraySize,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
-    
-    IR.create_operation(
-        "llvm.alloca", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alloca",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -231,19 +275,25 @@ end
 `and`
 
 """
-function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function and(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -251,18 +301,33 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[ptr, cmp, val, ]
+function cmpxchg(
+    ptr::Value,
+    cmp::Value,
+    val::Value;
+    res::IR.Type,
+    success_ordering,
+    failure_ordering,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[ptr, cmp, val]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
-    
-    IR.create_operation(
-        "llvm.cmpxchg", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("success_ordering", success_ordering),
+        namedattribute("failure_ordering", failure_ordering),
+    ]
+
+    return IR.create_operation(
+        "llvm.cmpxchg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -270,18 +335,26 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[ptr, val, ]
+function atomicrmw(
+    ptr::Value, val::Value; res::IR.Type, bin_op, ordering, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[ptr, val]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
-    
-    IR.create_operation(
-        "llvm.atomicrmw", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
+    ]
+
+    return IR.create_operation(
+        "llvm.atomicrmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -290,17 +363,21 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -310,16 +387,20 @@ end
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands..., ]
+    operands = Value[destOperands...,]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.br", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -351,22 +432,35 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : (f32) -> ()
 ```
 """
-function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, location=Location())
+function call(
+    operand_0::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    callee=nothing,
+    fastmathFlags=nothing,
+    branch_weights=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0..., ]
+    operands = Value[operand_0...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.call", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -374,20 +468,36 @@ end
 `cond_br`
 
 """
-function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, trueDest::Block, falseDest::Block, location=Location())
+function cond_br(
+    condition::Value,
+    trueDestOperands::Vector{Value},
+    falseDestOperands::Vector{Value};
+    branch_weights=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
+    operands = Value[condition, trueDestOperands..., falseDestOperands...]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.cond_br", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
+    )
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.cond_br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -422,17 +532,21 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "llvm.mlir.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "llvm.mlir.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -440,18 +554,25 @@ end
 `extractelement`
 
 """
-function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[vector, position, ]
+function extractelement(
+    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[vector, position]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.extractelement", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(res) && push!(results, res)
+
+    return IR.create_operation(
+        "llvm.extractelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -460,17 +581,21 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[container, ]
+    results = IR.Type[res,]
+    operands = Value[container,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
-    
-    IR.create_operation(
-        "llvm.extractvalue", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("position", position),]
+
+    return IR.create_operation(
+        "llvm.extractvalue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -478,20 +603,31 @@ end
 `fadd`
 
 """
-function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fadd(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fadd", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -499,19 +635,32 @@ end
 `fcmp`
 
 """
-function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function fcmp(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    predicate,
+    fastmathFlags=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fcmp", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(res) && push!(results, res)
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fcmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -519,20 +668,31 @@ end
 `fdiv`
 
 """
-function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fdiv(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fdiv", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -540,20 +700,31 @@ end
 `fmul`
 
 """
-function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fmul(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fmul", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -561,20 +732,30 @@ end
 `fneg`
 
 """
-function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fneg(
+    operand::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fneg", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fneg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -583,17 +764,21 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fpext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fpext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -602,17 +787,21 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptosi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptosi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -621,17 +810,21 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptoui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptoui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -640,17 +833,21 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptrunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptrunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -658,20 +855,31 @@ end
 `frem`
 
 """
-function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function frem(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.frem", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.frem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -679,20 +887,31 @@ end
 `fsub`
 
 """
-function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fsub(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fsub", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fsub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -705,13 +924,19 @@ function fence(; ordering, syncscope, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ordering", ordering), namedattribute("syncscope", syncscope), ]
-    
-    IR.create_operation(
-        "llvm.fence", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("ordering", ordering), namedattribute("syncscope", syncscope)
+    ]
+
+    return IR.create_operation(
+        "llvm.fence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -719,19 +944,23 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val, ]
+    operands = Value[val,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.freeze", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.freeze",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -762,20 +991,32 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[base, dynamicIndices..., ]
+function getelementptr(
+    base::Value,
+    dynamicIndices::Vector{Value};
+    res::IR.Type,
+    rawConstantIndices,
+    elem_type=nothing,
+    inbounds=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[base, dynamicIndices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-    
-    IR.create_operation(
-        "llvm.getelementptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.getelementptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -806,13 +1047,19 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
-    
-    IR.create_operation(
-        "llvm.mlir.global_ctors", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
+    ]
+
+    return IR.create_operation(
+        "llvm.mlir.global_ctors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -840,13 +1087,19 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
-    
-    IR.create_operation(
-        "llvm.mlir.global_dtors", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
+    ]
+
+    return IR.create_operation(
+        "llvm.mlir.global_dtors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -947,26 +1200,50 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, initializer::Region, location=Location())
+function mlir_global(;
+    global_type,
+    constant=nothing,
+    sym_name,
+    linkage,
+    dso_local=nothing,
+    thread_local_=nothing,
+    value=nothing,
+    alignment=nothing,
+    addr_space=nothing,
+    unnamed_addr=nothing,
+    section=nothing,
+    initializer::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer, ]
+    owned_regions = Region[initializer,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
+    attributes = NamedAttribute[
+        namedattribute("global_type", global_type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("linkage", linkage),
+    ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) &&
+        push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) &&
+        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-    
-    IR.create_operation(
-        "llvm.mlir.global", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -974,18 +1251,29 @@ end
 `icmp`
 
 """
-function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function icmp(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    predicate,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "llvm.icmp", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(res) && push!(results, res)
+
+    return IR.create_operation(
+        "llvm.icmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -999,23 +1287,42 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
+function inline_asm(
+    operands::Vector{Value};
+    res=nothing::Union{Nothing,IR.Type},
+    asm_string,
+    constraints,
+    has_side_effects=nothing,
+    is_align_stack=nothing,
+    asm_dialect=nothing,
+    operand_attrs=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
+    attributes = NamedAttribute[
+        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
+    ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) &&
+        push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) &&
+        push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
-    
-    IR.create_operation(
-        "llvm.inline_asm", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(operand_attrs) &&
+        push!(attributes, namedattribute("operand_attrs", operand_attrs))
+
+    return IR.create_operation(
+        "llvm.inline_asm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1023,19 +1330,29 @@ end
 `insertelement`
 
 """
-function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function insertelement(
+    vector::Value,
+    value::Value,
+    position::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, value, position, ]
+    operands = Value[vector, value, position]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.insertelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.insertelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1043,19 +1360,29 @@ end
 `insertvalue`
 
 """
-function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function insertvalue(
+    container::Value,
+    value::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    position,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[container, value, ]
+    operands = Value[container, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.insertvalue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.insertvalue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1064,17 +1391,21 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.inttoptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.inttoptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1082,21 +1413,41 @@ end
 `invoke`
 
 """
-function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
+function invoke(
+    callee_operands::Vector{Value},
+    normalDestOperands::Vector{Value},
+    unwindDestOperands::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee=nothing,
+    branch_weights=nothing,
+    normalDest::Block,
+    unwindDest::Block,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest, ]
+    successors = Block[normalDest, unwindDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
+        ]),
+    )
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.invoke", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.invoke",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1129,28 +1480,51 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    linkage=nothing,
+    dso_local=nothing,
+    CConv=nothing,
+    personality=nothing,
+    garbageCollector=nothing,
+    passthrough=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    function_entry_count=nothing,
+    memory=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) &&
+        push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) &&
+        push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
-    
-    IR.create_operation(
-        "llvm.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1158,19 +1532,25 @@ end
 `lshr`
 
 """
-function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function lshr(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.lshr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.lshr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1178,19 +1558,25 @@ end
 `landingpad`
 
 """
-function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0..., ]
+function landingpad(
+    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-    
-    IR.create_operation(
-        "llvm.landingpad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.landingpad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1198,24 +1584,41 @@ end
 `load`
 
 """
-function load(addr::Value; res::IR.Type, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[addr, ]
+function load(
+    addr::Value;
+    res::IR.Type,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    alignment=nothing,
+    volatile_=nothing,
+    nontemporal=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[addr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-    
-    IR.create_operation(
-        "llvm.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1233,15 +1636,19 @@ llvm.metadata op defines one or more metadata nodes.
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "llvm.metadata", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "llvm.metadata",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1249,19 +1656,25 @@ end
 `mul`
 
 """
-function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1284,17 +1697,21 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.null", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.null",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1302,19 +1719,25 @@ end
 `or`
 
 """
-function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function or(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1323,17 +1746,21 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.ptrtoint", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.ptrtoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1343,16 +1770,20 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1360,19 +1791,23 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing, Value}; location=Location())
+function return_(arg=nothing::Union{Nothing,Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-    
-    IR.create_operation(
-        "llvm.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1380,19 +1815,25 @@ end
 `sdiv`
 
 """
-function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function sdiv(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.sdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1401,17 +1842,21 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.sext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1420,17 +1865,21 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.sitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1438,19 +1887,25 @@ end
 `srem`
 
 """
-function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function srem(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.srem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.srem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1458,19 +1913,29 @@ end
 `select`
 
 """
-function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function select(
+    condition::Value,
+    trueValue::Value,
+    falseValue::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue, ]
+    operands = Value[condition, trueValue, falseValue]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1478,19 +1943,25 @@ end
 `shl`
 
 """
-function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function shl(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.shl", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.shl",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1499,17 +1970,21 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[v1, v2, ]
+    results = IR.Type[res,]
+    operands = Value[v1, v2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask), ]
-    
-    IR.create_operation(
-        "llvm.shufflevector", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask),]
+
+    return IR.create_operation(
+        "llvm.shufflevector",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1517,24 +1992,41 @@ end
 `store`
 
 """
-function store(value::Value, addr::Value; access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, alignment=nothing, volatile_=nothing, nontemporal=nothing, location=Location())
+function store(
+    value::Value,
+    addr::Value;
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    alignment=nothing,
+    volatile_=nothing,
+    nontemporal=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, addr, ]
+    operands = Value[value, addr]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-    
-    IR.create_operation(
-        "llvm.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1542,19 +2034,25 @@ end
 `sub`
 
 """
-function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1562,21 +2060,40 @@ end
 `switch`
 
 """
-function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
+function switch(
+    value::Value,
+    defaultOperands::Vector{Value},
+    caseOperands::Vector{Value};
+    case_values=nothing,
+    case_operand_segments,
+    branch_weights=nothing,
+    defaultDestination::Block,
+    caseDestinations::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands..., ]
+    operands = Value[value, defaultOperands..., caseOperands...]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations..., ]
-    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
-    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
+    successors = Block[defaultDestination, caseDestinations...]
+    attributes = NamedAttribute[namedattribute(
+        "case_operand_segments", case_operand_segments
+    ),]
+    push!(
+        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
+    )
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.switch", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1598,13 +2115,19 @@ function tbaa_root(; sym_name, identity, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("identity", identity), ]
-    
-    IR.create_operation(
-        "llvm.tbaa_root", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("identity", identity)
+    ]
+
+    return IR.create_operation(
+        "llvm.tbaa_root",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1656,19 +2179,30 @@ Defines a TBAA node describing a memory access.
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#tbaa-metadata
 """
-function tbaa_tag(; sym_name, base_type, access_type, offset, constant=nothing, location=Location())
+function tbaa_tag(;
+    sym_name, base_type, access_type, offset, constant=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("base_type", base_type), namedattribute("access_type", access_type), namedattribute("offset", offset), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name),
+        namedattribute("base_type", base_type),
+        namedattribute("access_type", access_type),
+        namedattribute("offset", offset),
+    ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
-    
-    IR.create_operation(
-        "llvm.tbaa_tag", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.tbaa_tag",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1715,14 +2249,22 @@ function tbaa_type_desc(; sym_name, identity=nothing, members, offsets, location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("members", members), namedattribute("offsets", offsets), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name),
+        namedattribute("members", members),
+        namedattribute("offsets", offsets),
+    ]
     !isnothing(identity) && push!(attributes, namedattribute("identity", identity))
-    
-    IR.create_operation(
-        "llvm.tbaa_type_desc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.tbaa_type_desc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1731,17 +2273,21 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.trunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.trunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1749,19 +2295,25 @@ end
 `udiv`
 
 """
-function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function udiv(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.udiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.udiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1770,17 +2322,21 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.uitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.uitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1788,19 +2344,25 @@ end
 `urem`
 
 """
-function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function urem(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.urem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.urem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1820,17 +2382,21 @@ IR dialect type wrapping an LLVM IR structure type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.undef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.undef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1844,12 +2410,16 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.unreachable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.unreachable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1857,19 +2427,25 @@ end
 `xor`
 
 """
-function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function xor(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1878,17 +2454,21 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.zext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.zext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Linalg.jl
+++ b/src/Dialects/16/Linalg.jl
@@ -1,9 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `index`
@@ -42,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -77,27 +72,22 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `batch_matmul`
@@ -105,29 +95,19 @@ import ...API
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -139,29 +119,19 @@ dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -171,29 +141,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -205,29 +165,19 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_reduce_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_reduce_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,29 +194,18 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    dimensions,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -280,33 +219,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_ncw_fcw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_ncw_fcw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -316,33 +243,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,29 +267,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,33 +293,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -428,33 +321,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,33 +349,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -508,33 +377,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -549,33 +406,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -585,29 +430,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -617,33 +452,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -654,33 +477,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -690,29 +501,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -722,31 +523,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -757,33 +547,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -793,33 +571,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -830,33 +596,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -867,33 +621,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -903,33 +645,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -939,33 +669,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -975,33 +693,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1012,33 +718,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,33 +742,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1084,29 +766,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1116,33 +788,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1152,33 +812,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1189,29 +837,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1226,29 +864,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1351,39 +979,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,28 +1024,18 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(
-    inputs::Vector{Value},
-    init::Value;
-    result::Vector{IR.Type},
-    mapper::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[inputs..., init]
-    owned_regions = Region[mapper,]
+function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[inputs..., init, ]
+    owned_regions = Region[mapper, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1445,31 +1045,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1479,31 +1068,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1513,29 +1091,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1545,29 +1113,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1582,29 +1140,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1614,33 +1162,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1654,33 +1190,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1690,33 +1214,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1730,33 +1242,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1766,33 +1266,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1802,33 +1290,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1838,33 +1314,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1874,33 +1338,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1910,33 +1362,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1946,33 +1386,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1982,33 +1410,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2022,33 +1438,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2058,33 +1462,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2094,33 +1486,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2130,33 +1510,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2166,33 +1534,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2206,33 +1562,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2244,29 +1588,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2278,29 +1612,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2335,29 +1659,18 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(
-    inputs::Vector{Value},
-    inits::Vector{Value};
-    result_0::Vector{IR.Type},
-    dimensions,
-    combiner::Region,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[inputs..., inits...]
-    owned_regions = Region[combiner,]
+function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[inputs..., inits..., ]
+    owned_regions = Region[combiner, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2378,29 +1691,18 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    permutation,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "linalg.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "linalg.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2410,29 +1712,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Linalg.jl
+++ b/src/Dialects/16/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `index`
@@ -41,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,26 +72,22 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `batch_matmul`
@@ -103,29 +95,19 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,29 +119,19 @@ dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +141,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,29 +165,19 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_reduce_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_reduce_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -242,29 +194,18 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    dimensions,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -278,33 +219,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_ncw_fcw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_ncw_fcw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -314,33 +243,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -350,29 +267,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -386,33 +293,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,33 +321,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -466,33 +349,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -506,33 +377,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -547,33 +406,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,29 +430,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -615,33 +452,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -652,33 +477,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -688,29 +501,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -720,31 +523,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,33 +547,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -791,33 +571,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -828,33 +596,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -865,33 +621,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -901,33 +645,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -937,33 +669,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -973,33 +693,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1010,33 +718,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1046,33 +742,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1082,29 +766,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1114,33 +788,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1150,33 +812,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1187,29 +837,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1224,29 +864,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,39 +979,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1412,28 +1024,18 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(
-    inputs::Vector{Value},
-    init::Value;
-    result::Vector{IR.Type},
-    mapper::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[inputs..., init]
-    owned_regions = Region[mapper,]
+function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[inputs..., init, ]
+    owned_regions = Region[mapper, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1443,31 +1045,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1477,31 +1068,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1511,29 +1091,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1543,29 +1113,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1580,29 +1140,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1612,33 +1162,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1652,33 +1190,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1688,33 +1214,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1728,33 +1242,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1764,33 +1266,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1800,33 +1290,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1836,33 +1314,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1872,33 +1338,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1908,33 +1362,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1944,33 +1386,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1980,33 +1410,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2020,33 +1438,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2056,33 +1462,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2092,33 +1486,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2128,33 +1510,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2164,33 +1534,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2204,33 +1562,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2242,29 +1588,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2276,29 +1612,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2333,29 +1659,18 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(
-    inputs::Vector{Value},
-    inits::Vector{Value};
-    result_0::Vector{IR.Type},
-    dimensions,
-    combiner::Region,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[inputs..., inits...]
-    owned_regions = Region[combiner,]
+function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[inputs..., inits..., ]
+    owned_regions = Region[combiner, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2376,29 +1691,18 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    permutation,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "linalg.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "linalg.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2408,29 +1712,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Linalg.jl
+++ b/src/Dialects/16/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `index`
@@ -41,19 +41,23 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim), ]
+    attributes = NamedAttribute[namedattribute("dim", dim),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "linalg.index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -72,22 +76,26 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values..., ]
+    operands = Value[values...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "linalg.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `batch_matmul`
@@ -95,19 +103,29 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -119,19 +137,29 @@ dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matmul_transpose_b(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matmul_transpose_b", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matmul_transpose_b",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -141,19 +169,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matvec(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matvec", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matvec",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -165,19 +203,29 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_reduce_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_reduce_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_reduce_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,18 +242,29 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[input, init, ]
-    owned_regions = Region[region, ]
+function broadcast(
+    input::Value,
+    init::Value;
+    result::Vector{IR.Type},
+    dimensions,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[input, init]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
-    
-    IR.create_operation(
-        "linalg.broadcast", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
+
+    return IR.create_operation(
+        "linalg.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -219,21 +278,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d_ncw_fcw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_1d_ncw_fcw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_1d_ncw_fcw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -243,21 +314,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d_nwc_wcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_1d_nwc_wcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_1d_nwc_wcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -267,19 +350,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_1d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_1d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -293,21 +386,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nchw_fchw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nchw_fchw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nchw_fchw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -321,21 +426,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_ngchw_fgchw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -349,21 +466,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_fhwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -377,21 +506,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_hwcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -406,21 +547,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_hwcf_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -430,19 +583,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_2d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -452,21 +615,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d_ndhwc_dhwcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -477,21 +652,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d_ndhwc_dhwcf_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -501,19 +688,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_3d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_3d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -523,20 +720,31 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function copy(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -547,21 +755,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_nwc_wc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -571,21 +791,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_nwc_wcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -596,21 +828,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nchw_chw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -621,21 +865,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -645,21 +901,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwc_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -669,21 +937,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -693,21 +973,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwcm_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -718,21 +1010,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ndhwc_dhwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -742,21 +1046,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ndhwc_dhwcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -766,19 +1082,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function dot(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.dot", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.dot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -788,21 +1114,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function elemwise_binary(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    fun=nothing,
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.elemwise_binary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.elemwise_binary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -812,21 +1150,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function elemwise_unary(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    fun=nothing,
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.elemwise_unary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.elemwise_unary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -837,19 +1187,29 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function fill(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.fill", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.fill",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -864,19 +1224,29 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function fill_rng_2d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.fill_rng_2d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.fill_rng_2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -979,21 +1349,39 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function generic(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    indexing_maps,
+    iterator_types,
+    doc=nothing,
+    library_call=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    attributes = NamedAttribute[
+        namedattribute("indexing_maps", indexing_maps),
+        namedattribute("iterator_types", iterator_types),
+    ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
-    
-    IR.create_operation(
-        "linalg.generic", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(library_call) &&
+        push!(attributes, namedattribute("library_call", library_call))
+
+    return IR.create_operation(
+        "linalg.generic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1024,18 +1412,28 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[inputs..., init, ]
-    owned_regions = Region[mapper, ]
+function map(
+    inputs::Vector{Value},
+    init::Value;
+    result::Vector{IR.Type},
+    mapper::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[inputs..., init]
+    owned_regions = Region[mapper,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "linalg.map", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.map",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1045,20 +1443,31 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.matmul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1068,20 +1477,31 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul_transpose_b(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.matmul_transpose_b", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.matmul_transpose_b",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1091,19 +1511,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.matmul_unsigned", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.matmul_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1113,19 +1543,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matvec(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.matvec", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.matvec",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1140,19 +1580,29 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function mmt4d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.mmt4d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.mmt4d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1162,21 +1612,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nchw_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nchw_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nchw_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1190,21 +1652,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nchw_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nchw_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nchw_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1214,21 +1688,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ncw_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ncw_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ncw_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1242,21 +1728,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ncw_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ncw_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ncw_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1266,21 +1764,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1290,21 +1800,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1314,21 +1836,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1338,21 +1872,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1362,21 +1908,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_max_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1386,21 +1944,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1410,21 +1980,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_min_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1438,21 +2020,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1462,21 +2056,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1486,21 +2092,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_max_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1510,21 +2128,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1534,21 +2164,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_min_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1562,21 +2204,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1588,19 +2242,29 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function quantized_batch_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.quantized_batch_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.quantized_batch_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1612,19 +2276,29 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function quantized_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.quantized_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.quantized_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1659,18 +2333,29 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[inputs..., inits..., ]
-    owned_regions = Region[combiner, ]
+function reduce(
+    inputs::Vector{Value},
+    inits::Vector{Value};
+    result_0::Vector{IR.Type},
+    dimensions,
+    combiner::Region,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[inputs..., inits...]
+    owned_regions = Region[combiner,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
-    
-    IR.create_operation(
-        "linalg.reduce", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
+
+    return IR.create_operation(
+        "linalg.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1691,18 +2376,29 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[input, init, ]
-    owned_regions = Region[region, ]
+function transpose(
+    input::Value,
+    init::Value;
+    result::Vector{IR.Type},
+    permutation,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[input, init]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
-    
-    IR.create_operation(
-        "linalg.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation),]
+
+    return IR.create_operation(
+        "linalg.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1712,19 +2408,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function vecmat(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.vecmat", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.vecmat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/MLProgram.jl
+++ b/src/Dialects/16/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `func`
@@ -24,36 +24,21 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,21 +57,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -110,28 +91,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -156,21 +127,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -204,35 +171,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -256,28 +209,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -303,20 +246,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,22 +268,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -357,22 +292,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -396,36 +327,21 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,21 +352,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/MLProgram.jl
+++ b/src/Dialects/16/MLProgram.jl
@@ -1,9 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `func`
@@ -25,36 +24,21 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +57,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,28 +91,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -157,21 +127,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -205,35 +171,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -257,28 +209,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -304,20 +246,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -330,22 +268,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -358,22 +292,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -397,36 +327,21 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,21 +352,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/MLProgram.jl
+++ b/src/Dialects/16/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `func`
@@ -24,21 +24,36 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_visibility=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.func", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,17 +72,21 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load_const", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load_const",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -91,18 +110,28 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
-    results = IR.Type[result, produceToken, ]
-    operands = Value[consumeTokens..., ]
+function global_load_graph(
+    consumeTokens::Vector{Value};
+    result::IR.Type,
+    produceToken::IR.Type,
+    global_,
+    location=Location(),
+)
+    results = IR.Type[result, produceToken]
+    operands = Value[consumeTokens...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load_graph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load_graph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -127,17 +156,21 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -171,21 +204,35 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
+function global_(;
+    sym_name,
+    type,
+    is_mutable=nothing,
+    value=nothing,
+    sym_visibility=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.global", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -209,18 +256,28 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
-    results = IR.Type[produceToken, ]
-    operands = Value[value, consumeTokens..., ]
+function global_store_graph(
+    value::Value,
+    consumeTokens::Vector{Value};
+    produceToken::IR.Type,
+    global_,
+    location=Location(),
+)
+    results = IR.Type[produceToken,]
+    operands = Value[value, consumeTokens...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_store_graph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_store_graph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -246,16 +303,20 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_store", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -268,18 +329,22 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands_::Vector{Value}; location=Location())
+function output(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.output", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.output",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -292,18 +357,22 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,21 +396,36 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
+function subgraph(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_visibility=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.subgraph", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.subgraph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -352,17 +436,21 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token, ]
+    results = IR.Type[token,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.token", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.token",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Math.jl
+++ b/src/Dialects/16/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `absf`
@@ -18,20 +18,29 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function absf(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.absf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.absf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -49,19 +58,23 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.absi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.absi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -92,20 +105,30 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function atan2(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.atan2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.atan2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -129,20 +152,29 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function atan(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.atan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.atan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -162,20 +194,29 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function cbrt(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.cbrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cbrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -199,20 +240,29 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function ceil(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -237,20 +287,30 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function copysign(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.copysign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.copysign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -274,20 +334,29 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function cos(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -304,19 +373,23 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ctlz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ctlz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -333,19 +406,23 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.cttz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cttz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -362,19 +439,23 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ctpop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ctpop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -398,20 +479,29 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function erf(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -435,20 +525,29 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function exp2(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.exp2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.exp2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -474,20 +573,29 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function expm1(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.expm1", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.expm1",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -511,20 +619,29 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function exp(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -560,20 +677,30 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function fpowi(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.fpowi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.fpowi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -597,20 +724,29 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function floor(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -639,20 +775,31 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function fma(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -676,19 +823,25 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ipowi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ipowi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ipowi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -706,20 +859,29 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log10(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log10", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log10",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -739,20 +901,29 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log1p(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log1p", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log1p",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -770,20 +941,29 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log2(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -801,20 +981,29 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -838,20 +1027,30 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function powf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.powf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.powf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -878,20 +1077,29 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function roundeven(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.roundeven", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.roundeven",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -918,20 +1126,29 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function round(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -949,20 +1166,29 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function rsqrt(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -986,20 +1212,29 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function sin(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1017,20 +1252,29 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function sqrt(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1048,20 +1292,29 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function tan(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1079,20 +1332,29 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function tanh(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1118,20 +1380,29 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function trunc(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.trunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.trunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/16/Math.jl
+++ b/src/Dialects/16/Math.jl
@@ -1,9 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `absf`
@@ -19,29 +18,20 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.absf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -59,23 +49,19 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.absi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -106,30 +92,20 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -153,29 +129,20 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -195,29 +162,20 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cbrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cbrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,29 +199,20 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -288,30 +237,20 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -335,29 +274,20 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -374,23 +304,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,23 +333,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -440,23 +362,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -480,29 +398,20 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -526,29 +435,20 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -574,29 +474,20 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -620,29 +511,20 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -678,30 +560,20 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fpowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fpowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -725,29 +597,20 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -776,31 +639,20 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -824,25 +676,19 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ipowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ipowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -860,29 +706,20 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -902,29 +739,20 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -942,29 +770,20 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -982,29 +801,20 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1028,30 +838,20 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1078,29 +878,20 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.roundeven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.roundeven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1127,29 +918,20 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1167,29 +949,20 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1213,29 +986,20 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1253,29 +1017,20 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1293,29 +1048,20 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1333,29 +1079,20 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1381,29 +1118,20 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/Math.jl
+++ b/src/Dialects/16/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `absf`
@@ -18,29 +18,20 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.absf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -58,23 +49,19 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.absi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -105,30 +92,20 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -152,29 +129,20 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -194,29 +162,20 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cbrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cbrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -240,29 +199,20 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -287,30 +237,20 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -334,29 +274,20 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -373,23 +304,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -406,23 +333,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -439,23 +362,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -479,29 +398,20 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -525,29 +435,20 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -573,29 +474,20 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -619,29 +511,20 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -677,30 +560,20 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fpowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fpowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -724,29 +597,20 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -775,31 +639,20 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -823,25 +676,19 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ipowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ipowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -859,29 +706,20 @@ the same type.
 %y = math.log10 %x : f64
 ```
 """
-function log10(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -901,29 +739,20 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -941,29 +770,20 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -981,29 +801,20 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1027,30 +838,20 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1077,29 +878,20 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.roundeven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.roundeven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1126,29 +918,20 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1166,29 +949,20 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1212,29 +986,20 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1252,29 +1017,20 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1292,29 +1048,20 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1332,29 +1079,20 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1380,29 +1118,20 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/16/MemRef.jl
+++ b/src/Dialects/16/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assume_alignment`
@@ -16,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -50,30 +46,19 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    kind,
-    location=Location(),
-)
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -85,20 +70,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,20 +99,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,28 +136,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,28 +189,18 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[memref, indices...]
+function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -288,30 +245,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,30 +299,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,22 +350,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,22 +377,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -520,21 +449,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +507,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -617,20 +538,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,25 +576,19 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -728,22 +639,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -767,24 +674,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -831,21 +732,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,25 +768,19 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(
-    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-
-    return IR.create_operation(
-        "memref.extract_aligned_pointer_as_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_aligned_pointer_as_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -937,16 +828,9 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(
-    source::Value;
-    base_buffer=nothing::Union{Nothing,IR.Type},
-    offset=nothing::Union{Nothing,IR.Type},
-    sizes=nothing::Union{Nothing,Vector{IR.Type}},
-    strides=nothing::Union{Nothing,Vector{IR.Type}},
-    location=Location(),
-)
+function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -954,16 +838,12 @@ function extract_strided_metadata(
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-
-    return IR.create_operation(
-        "memref.extract_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -982,21 +862,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1038,38 +914,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1091,33 +951,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1133,23 +978,19 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1211,30 +1052,20 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(
-    source::Value,
-    dynamicResultSize=nothing::Union{Nothing,Value};
-    result_0::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source,]
+function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.realloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.realloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1276,40 +1107,19 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,21 +1159,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1399,20 +1205,16 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1430,21 +1232,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1486,28 +1284,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1645,40 +1433,19 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1699,20 +1466,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/MemRef.jl
+++ b/src/Dialects/16/MemRef.jl
@@ -1,9 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assume_alignment`
@@ -17,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -51,30 +46,19 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    kind,
-    location=Location(),
-)
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -86,20 +70,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -119,20 +99,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,28 +136,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -223,28 +189,18 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[memref, indices...]
+function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -289,30 +245,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -353,30 +299,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -414,22 +350,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -445,22 +377,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,21 +449,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,21 +507,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,20 +538,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,25 +576,19 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -729,22 +639,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,24 +674,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -832,21 +732,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -872,25 +768,19 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(
-    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-
-    return IR.create_operation(
-        "memref.extract_aligned_pointer_as_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_aligned_pointer_as_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -938,16 +828,9 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(
-    source::Value;
-    base_buffer=nothing::Union{Nothing,IR.Type},
-    offset=nothing::Union{Nothing,IR.Type},
-    sizes=nothing::Union{Nothing,Vector{IR.Type}},
-    strides=nothing::Union{Nothing,Vector{IR.Type}},
-    location=Location(),
-)
+function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -955,16 +838,12 @@ function extract_strided_metadata(
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-
-    return IR.create_operation(
-        "memref.extract_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -983,21 +862,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1039,38 +914,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1092,33 +951,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1134,23 +978,19 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1212,30 +1052,20 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(
-    source::Value,
-    dynamicResultSize=nothing::Union{Nothing,Value};
-    result_0::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source,]
+function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.realloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.realloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1277,40 +1107,19 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1350,21 +1159,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1400,20 +1205,16 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1431,21 +1232,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1487,28 +1284,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1646,40 +1433,19 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1700,20 +1466,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/MemRef.jl
+++ b/src/Dialects/16/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `assume_alignment`
@@ -16,16 +16,20 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
-    
-    IR.create_operation(
-        "memref.assume_alignment", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment),]
+
+    return IR.create_operation(
+        "memref.assume_alignment",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -46,19 +50,30 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
+function atomic_rmw(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    kind,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    attributes = NamedAttribute[namedattribute("kind", kind),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "memref.atomic_rmw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.atomic_rmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -70,16 +85,20 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.atomic_yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.atomic_yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -99,16 +118,20 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target, ]
+    operands = Value[source, target]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -136,18 +159,28 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
-    owned_regions = Region[atomic_body, ]
+function generic_atomic_rmw(
+    memref::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    atomic_body::Region,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
+    owned_regions = Region[atomic_body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.generic_atomic_rmw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.generic_atomic_rmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -189,18 +222,28 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+function load(
+    memref::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.load", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "memref.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -245,20 +288,30 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[dynamicSizes..., symbolOperands..., ]
+function alloc(
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.alloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -299,20 +352,30 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[dynamicSizes..., symbolOperands..., ]
+function alloca(
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.alloca", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -350,18 +413,22 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
+function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.alloca_scope", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca_scope",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -377,18 +444,22 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results_::Vector{Value}; location=Location())
+function alloca_scope_return(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.alloca_scope.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca_scope.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -449,17 +520,21 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -507,17 +582,21 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "memref.collapse_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "memref.collapse_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -538,16 +617,20 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -576,19 +659,25 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, index, ]
+    operands = Value[source, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "memref.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -639,18 +728,22 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands_::Vector{Value}; location=Location())
+function dma_start(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dma_start", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dma_start",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -674,18 +767,24 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
+function dma_wait(
+    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
+)
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements, ]
+    operands = Value[tagMemRef, tagIndices..., numElements]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dma_wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dma_wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -732,17 +831,21 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "memref.expand_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "memref.expand_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -768,19 +871,25 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
+function extract_aligned_pointer_as_index(
+    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-    
-    IR.create_operation(
-        "memref.extract_aligned_pointer_as_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.extract_aligned_pointer_as_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -828,9 +937,16 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
+function extract_strided_metadata(
+    source::Value;
+    base_buffer=nothing::Union{Nothing,IR.Type},
+    offset=nothing::Union{Nothing,IR.Type},
+    sizes=nothing::Union{Nothing,Vector{IR.Type}},
+    strides=nothing::Union{Nothing,Vector{IR.Type}},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -838,12 +954,16 @@ function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Noth
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-    
-    IR.create_operation(
-        "memref.extract_strided_metadata", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.extract_strided_metadata",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -862,17 +982,21 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "memref.get_global", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "memref.get_global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -914,22 +1038,38 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
+function global_(;
+    sym_name,
+    sym_visibility=nothing,
+    type,
+    initial_value=nothing,
+    constant=nothing,
+    alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) &&
+        push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.global", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -951,18 +1091,33 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
+function prefetch(
+    memref::Value,
+    indices::Vector{Value};
+    isWrite,
+    localityHint,
+    isDataCache,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memref, indices..., ]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
-    
-    IR.create_operation(
-        "memref.prefetch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("isWrite", isWrite),
+        namedattribute("localityHint", localityHint),
+        namedattribute("isDataCache", isDataCache),
+    ]
+
+    return IR.create_operation(
+        "memref.prefetch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -978,19 +1133,23 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "memref.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1052,20 +1211,30 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[source, ]
+function realloc(
+    source::Value,
+    dynamicResultSize=nothing::Union{Nothing,Value};
+    result_0::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.realloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.realloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1107,19 +1276,40 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function reinterpret_cast(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "memref.reinterpret_cast", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "memref.reinterpret_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1159,17 +1349,21 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, shape, ]
+    results = IR.Type[result,]
+    operands = Value[source, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1205,16 +1399,20 @@ in these contexts.
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1232,17 +1430,21 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[in, ]
+    results = IR.Type[result_0,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
-    
-    IR.create_operation(
-        "memref.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation),]
+
+    return IR.create_operation(
+        "memref.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1284,18 +1486,28 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[source, byte_shift, sizes..., ]
+function view(
+    source::Value,
+    byte_shift::Value,
+    sizes::Vector{Value};
+    result_0::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[source, byte_shift, sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.view", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.view",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1433,19 +1645,40 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function subview(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "memref.subview", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "memref.subview",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1466,16 +1699,20 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref, ]
+    operands = Value[tensor, memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.tensor_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.tensor_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/NVGPU.jl
+++ b/src/Dialects/16/NVGPU.jl
@@ -1,8 +1,8 @@
 module nvgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `device_async_copy`
@@ -54,40 +54,21 @@ nvgpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(
-    dst::Value,
-    dstIndices::Vector{Value},
-    src::Value,
-    srcIndices::Vector{Value},
-    srcElements=nothing::Union{Nothing,Value};
-    asyncToken::IR.Type,
-    dstElements,
-    bypassL1=nothing,
-    location=Location(),
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[dst, dstIndices..., src, srcIndices...]
+function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}, srcElements=nothing::Union{Nothing, Value}; asyncToken::IR.Type, dstElements, bypassL1=nothing, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[dst, dstIndices..., src, srcIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dstElements", dstElements),]
+    attributes = NamedAttribute[namedattribute("dstElements", dstElements), ]
     !isnothing(srcElements) && push!(operands, srcElements)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1, length(dstIndices), 1, length(srcIndices), (srcElements == nothing) ? 0 : 1
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), (srcElements==nothing) ? 0 : 1]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-
-    return IR.create_operation(
-        "nvgpu.device_async_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,24 +92,18 @@ Groups are executed in the order they are created.
 %0 = nvgpu.device_async_create_group
   ```
 """
-function device_async_create_group(
-    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[inputTokens...,]
+function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[inputTokens..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.device_async_create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_create_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,21 +124,17 @@ nvgpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies,]
+    operands = Value[asyncDependencies, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-
-    return IR.create_operation(
-        "nvgpu.device_async_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -185,31 +156,18 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    transpose,
-    numTiles,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
-    ]
-
-    return IR.create_operation(
-        "nvgpu.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
+    
+    IR.create_operation(
+        "nvgpu.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -237,35 +195,20 @@ nvgpu.mma.sp.sync (%a, %b, %c) metadata (%meta) {mmaShape = [16, 8, 32]} :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sp_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value,
-    sparseMetadata::Value;
-    res::IR.Type,
-    mmaShape,
-    sparsitySelector=nothing,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC, sparseMetadata]
+function mma_sp_sync(matrixA::Value, matrixB::Value, matrixC::Value, sparseMetadata::Value; res::IR.Type, mmaShape, sparsitySelector=nothing, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, sparseMetadata, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
-    !isnothing(sparsitySelector) &&
-        push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    !isnothing(sparsitySelector) && push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sp.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sp.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -291,31 +234,19 @@ This operation is meant to follow the semantic of described here:
     (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf32>) -> vector<2x2xf32>
 ```
 """
-function mma_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value;
-    res::IR.Type,
-    mmaShape,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC]
+function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/NVGPU.jl
+++ b/src/Dialects/16/NVGPU.jl
@@ -1,9 +1,8 @@
 module nvgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `device_async_copy`
@@ -55,40 +54,21 @@ nvgpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(
-    dst::Value,
-    dstIndices::Vector{Value},
-    src::Value,
-    srcIndices::Vector{Value},
-    srcElements=nothing::Union{Nothing,Value};
-    asyncToken::IR.Type,
-    dstElements,
-    bypassL1=nothing,
-    location=Location(),
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[dst, dstIndices..., src, srcIndices...]
+function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}, srcElements=nothing::Union{Nothing, Value}; asyncToken::IR.Type, dstElements, bypassL1=nothing, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[dst, dstIndices..., src, srcIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dstElements", dstElements),]
+    attributes = NamedAttribute[namedattribute("dstElements", dstElements), ]
     !isnothing(srcElements) && push!(operands, srcElements)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1, length(dstIndices), 1, length(srcIndices), (srcElements == nothing) ? 0 : 1
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), (srcElements==nothing) ? 0 : 1]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-
-    return IR.create_operation(
-        "nvgpu.device_async_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,24 +92,18 @@ Groups are executed in the order they are created.
 %0 = nvgpu.device_async_create_group
   ```
 """
-function device_async_create_group(
-    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[inputTokens...,]
+function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[inputTokens..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.device_async_create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_create_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,21 +124,17 @@ nvgpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies,]
+    operands = Value[asyncDependencies, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-
-    return IR.create_operation(
-        "nvgpu.device_async_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -186,31 +156,18 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    transpose,
-    numTiles,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
-    ]
-
-    return IR.create_operation(
-        "nvgpu.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
+    
+    IR.create_operation(
+        "nvgpu.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,35 +195,20 @@ nvgpu.mma.sp.sync (%a, %b, %c) metadata (%meta) {mmaShape = [16, 8, 32]} :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sp_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value,
-    sparseMetadata::Value;
-    res::IR.Type,
-    mmaShape,
-    sparsitySelector=nothing,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC, sparseMetadata]
+function mma_sp_sync(matrixA::Value, matrixB::Value, matrixC::Value, sparseMetadata::Value; res::IR.Type, mmaShape, sparsitySelector=nothing, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, sparseMetadata, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
-    !isnothing(sparsitySelector) &&
-        push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    !isnothing(sparsitySelector) && push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sp.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sp.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -292,31 +234,19 @@ This operation is meant to follow the semantic of described here:
     (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf32>) -> vector<2x2xf32>
 ```
 """
-function mma_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value;
-    res::IR.Type,
-    mmaShape,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC]
+function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/NVGPU.jl
+++ b/src/Dialects/16/NVGPU.jl
@@ -1,8 +1,8 @@
 module nvgpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `device_async_copy`
@@ -54,21 +54,40 @@ nvgpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}, srcElements=nothing::Union{Nothing, Value}; asyncToken::IR.Type, dstElements, bypassL1=nothing, location=Location())
-    results = IR.Type[asyncToken, ]
-    operands = Value[dst, dstIndices..., src, srcIndices..., ]
+function device_async_copy(
+    dst::Value,
+    dstIndices::Vector{Value},
+    src::Value,
+    srcIndices::Vector{Value},
+    srcElements=nothing::Union{Nothing,Value};
+    asyncToken::IR.Type,
+    dstElements,
+    bypassL1=nothing,
+    location=Location(),
+)
+    results = IR.Type[asyncToken,]
+    operands = Value[dst, dstIndices..., src, srcIndices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dstElements", dstElements), ]
+    attributes = NamedAttribute[namedattribute("dstElements", dstElements),]
     !isnothing(srcElements) && push!(operands, srcElements)
-    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), (srcElements==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            1, length(dstIndices), 1, length(srcIndices), (srcElements == nothing) ? 0 : 1
+        ]),
+    )
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-    
-    IR.create_operation(
-        "nvgpu.device_async_copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -92,18 +111,24 @@ Groups are executed in the order they are created.
 %0 = nvgpu.device_async_create_group
   ```
 """
-function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
-    results = IR.Type[asyncToken, ]
-    operands = Value[inputTokens..., ]
+function device_async_create_group(
+    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
+)
+    results = IR.Type[asyncToken,]
+    operands = Value[inputTokens...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.device_async_create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -124,17 +149,21 @@ nvgpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies, ]
+    operands = Value[asyncDependencies,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-    
-    IR.create_operation(
-        "nvgpu.device_async_wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -156,18 +185,31 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[srcMemref, indices..., ]
+function ldmatrix(
+    srcMemref::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    transpose,
+    numTiles,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[srcMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
-    
-    IR.create_operation(
-        "nvgpu.ldmatrix", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
+    ]
+
+    return IR.create_operation(
+        "nvgpu.ldmatrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -195,20 +237,35 @@ nvgpu.mma.sp.sync (%a, %b, %c) metadata (%meta) {mmaShape = [16, 8, 32]} :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sp_sync(matrixA::Value, matrixB::Value, matrixC::Value, sparseMetadata::Value; res::IR.Type, mmaShape, sparsitySelector=nothing, tf32Enabled=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrixA, matrixB, matrixC, sparseMetadata, ]
+function mma_sp_sync(
+    matrixA::Value,
+    matrixB::Value,
+    matrixC::Value,
+    sparseMetadata::Value;
+    res::IR.Type,
+    mmaShape,
+    sparsitySelector=nothing,
+    tf32Enabled=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[matrixA, matrixB, matrixC, sparseMetadata]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
-    !isnothing(sparsitySelector) && push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+    !isnothing(sparsitySelector) &&
+        push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-    
-    IR.create_operation(
-        "nvgpu.mma.sp.sync", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mma.sp.sync",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -234,19 +291,31 @@ This operation is meant to follow the semantic of described here:
     (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf32>) -> vector<2x2xf32>
 ```
 """
-function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, tf32Enabled=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrixA, matrixB, matrixC, ]
+function mma_sync(
+    matrixA::Value,
+    matrixB::Value,
+    matrixC::Value;
+    res::IR.Type,
+    mmaShape,
+    tf32Enabled=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[matrixA, matrixB, matrixC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-    
-    IR.create_operation(
-        "nvgpu.mma.sync", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mma.sync",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/OpenACC.jl
+++ b/src/Dialects/16/OpenACC.jl
@@ -1,8 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `data`
@@ -22,68 +22,21 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    deviceptrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        deviceptrOperands...,
-        attachOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (ifCond == nothing) ? 0 : 1length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(deviceptrOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,63 +51,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        copyinOperands...,
-        createOperands...,
-        createZeroOperands...,
-        attachOperands...,
-    ]
+    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyinOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,59 +83,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    deleteOperands::Vector{Value},
-    detachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
-    ]
+    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyoutOperands),
-            length(deleteOperands),
-            length(detachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,42 +118,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,68 +156,29 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    reductionOp=nothing,
-    exec_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) &&
-        push!(attributes, namedattribute("exec_mapping", exec_mapping))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,55 +197,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs=nothing::Union{Nothing,Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    devicePtrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionOp=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        devicePtrOperands...,
-        attachOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -434,53 +209,18 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (numGangs == nothing)
-                0
-            elseif 1(numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(devicePtrOperands),
-            length(attachOperands),
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -497,42 +237,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -550,16 +269,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -577,59 +292,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    hostOperands::Vector{Value},
-    deviceOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
-    ]
+    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(hostOperands),
-            length(deviceOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,48 +327,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -698,22 +354,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/OpenACC.jl
+++ b/src/Dialects/16/OpenACC.jl
@@ -1,8 +1,8 @@
 module acc
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `data`
@@ -22,21 +22,68 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
+function data(
+    ifCond=nothing::Union{Nothing,Value};
+    copyOperands::Vector{Value},
+    copyinOperands::Vector{Value},
+    copyinReadonlyOperands::Vector{Value},
+    copyoutOperands::Vector{Value},
+    copyoutZeroOperands::Vector{Value},
+    createOperands::Vector{Value},
+    createZeroOperands::Vector{Value},
+    noCreateOperands::Vector{Value},
+    presentOperands::Vector{Value},
+    deviceptrOperands::Vector{Value},
+    attachOperands::Vector{Value},
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        copyOperands...,
+        copyinOperands...,
+        copyinReadonlyOperands...,
+        copyoutOperands...,
+        copyoutZeroOperands...,
+        createOperands...,
+        createZeroOperands...,
+        noCreateOperands...,
+        presentOperands...,
+        deviceptrOperands...,
+        attachOperands...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (ifCond == nothing) ? 0 : 1length(copyOperands),
+            length(copyinOperands),
+            length(copyinReadonlyOperands),
+            length(copyoutOperands),
+            length(copyoutZeroOperands),
+            length(createOperands),
+            length(createZeroOperands),
+            length(noCreateOperands),
+            length(presentOperands),
+            length(deviceptrOperands),
+            length(attachOperands),
+        ]),
+    )
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -51,24 +98,63 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
+function enter_data(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    copyinOperands::Vector{Value},
+    createOperands::Vector{Value},
+    createZeroOperands::Vector{Value},
+    attachOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
+    operands = Value[
+        waitOperands...,
+        copyinOperands...,
+        createOperands...,
+        createZeroOperands...,
+        attachOperands...,
+    ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(copyinOperands),
+            length(createOperands),
+            length(createZeroOperands),
+            length(attachOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-    
-    IR.create_operation(
-        "acc.enter_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.enter_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -83,25 +169,59 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
+function exit_data(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    copyoutOperands::Vector{Value},
+    deleteOperands::Vector{Value},
+    detachOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    finalize=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
+    operands = Value[
+        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
+    ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(copyoutOperands),
+            length(deleteOperands),
+            length(detachOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-    
-    IR.create_operation(
-        "acc.exit_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.exit_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -118,21 +238,42 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
+function init(
+    deviceTypeOperands::Vector{Value},
+    deviceNumOperand=nothing::Union{Nothing,Value};
+    ifCond=nothing::Union{Nothing,Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[deviceTypeOperands..., ]
+    operands = Value[deviceTypeOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
-    
-    IR.create_operation(
-        "acc.init", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(deviceTypeOperands),
+            if (deviceNumOperand == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+
+    return IR.create_operation(
+        "acc.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -156,29 +297,68 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
-    owned_regions = Region[region, ]
+function loop(
+    gangNum=nothing::Union{Nothing,Value};
+    gangStatic=nothing::Union{Nothing,Value},
+    workerNum=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    tileOperands::Vector{Value},
+    privateOperands::Vector{Value},
+    reductionOperands::Vector{Value},
+    results::Vector{IR.Type},
+    collapse=nothing,
+    seq=nothing,
+    independent=nothing,
+    auto_=nothing,
+    reductionOp=nothing,
+    exec_mapping=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (gangNum == nothing)
+                0
+            elseif 1(gangStatic == nothing)
+                0
+            elseif 1(workerNum == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            else
+                1length(tileOperands)
+            end,
+            length(privateOperands),
+            length(reductionOperands),
+        ]),
+    )
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
-    
-    IR.create_operation(
-        "acc.loop", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(exec_mapping) &&
+        push!(attributes, namedattribute("exec_mapping", exec_mapping))
+
+    return IR.create_operation(
+        "acc.loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -197,10 +377,55 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
+function parallel(
+    async=nothing::Union{Nothing,Value};
+    waitOperands::Vector{Value},
+    numGangs=nothing::Union{Nothing,Value},
+    numWorkers=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    selfCond=nothing::Union{Nothing,Value},
+    reductionOperands::Vector{Value},
+    copyOperands::Vector{Value},
+    copyinOperands::Vector{Value},
+    copyinReadonlyOperands::Vector{Value},
+    copyoutOperands::Vector{Value},
+    copyoutZeroOperands::Vector{Value},
+    createOperands::Vector{Value},
+    createZeroOperands::Vector{Value},
+    noCreateOperands::Vector{Value},
+    presentOperands::Vector{Value},
+    devicePtrOperands::Vector{Value},
+    attachOperands::Vector{Value},
+    gangPrivateOperands::Vector{Value},
+    gangFirstPrivateOperands::Vector{Value},
+    asyncAttr=nothing,
+    waitAttr=nothing,
+    selfAttr=nothing,
+    reductionOp=nothing,
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        waitOperands...,
+        reductionOperands...,
+        copyOperands...,
+        copyinOperands...,
+        copyinReadonlyOperands...,
+        copyoutOperands...,
+        copyoutZeroOperands...,
+        createOperands...,
+        createZeroOperands...,
+        noCreateOperands...,
+        presentOperands...,
+        devicePtrOperands...,
+        attachOperands...,
+        gangPrivateOperands...,
+        gangFirstPrivateOperands...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -209,18 +434,53 @@ function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Val
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (async == nothing) ? 0 : 1length(waitOperands),
+            if (numGangs == nothing)
+                0
+            elseif 1(numWorkers == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            elseif 1(selfCond == nothing)
+                0
+            else
+                1length(reductionOperands)
+            end,
+            length(copyOperands),
+            length(copyinOperands),
+            length(copyinReadonlyOperands),
+            length(copyoutOperands),
+            length(copyoutZeroOperands),
+            length(createOperands),
+            length(createZeroOperands),
+            length(noCreateOperands),
+            length(presentOperands),
+            length(devicePtrOperands),
+            length(attachOperands),
+            length(gangPrivateOperands),
+            length(gangFirstPrivateOperands),
+        ]),
+    )
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.parallel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -237,21 +497,42 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
+function shutdown(
+    deviceTypeOperands::Vector{Value},
+    deviceNumOperand=nothing::Union{Nothing,Value};
+    ifCond=nothing::Union{Nothing,Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[deviceTypeOperands..., ]
+    operands = Value[deviceTypeOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
-    
-    IR.create_operation(
-        "acc.shutdown", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(deviceTypeOperands),
+            if (deviceNumOperand == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+
+    return IR.create_operation(
+        "acc.shutdown",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -269,12 +550,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -292,25 +577,59 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
+function update(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    deviceTypeOperands::Vector{Value},
+    hostOperands::Vector{Value},
+    deviceOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    ifPresent=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
+    operands = Value[
+        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
+    ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(deviceTypeOperands),
+            length(hostOperands),
+            length(deviceOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-    
-    IR.create_operation(
-        "acc.update", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.update",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,23 +646,48 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
+function wait(
+    waitOperands::Vector{Value},
+    asyncOperand=nothing::Union{Nothing,Value};
+    waitDevnum=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    async=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., ]
+    operands = Value[waitOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(waitOperands),
+            if (asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-    
-    IR.create_operation(
-        "acc.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -354,18 +698,22 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/OpenACC.jl
+++ b/src/Dialects/16/OpenACC.jl
@@ -1,9 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `data`
@@ -23,68 +22,21 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    deviceptrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, deviceptrOperands::Vector{Value}, attachOperands::Vector{Value}, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        deviceptrOperands...,
-        attachOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., deviceptrOperands..., attachOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (ifCond == nothing) ? 0 : 1length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(deviceptrOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(deviceptrOperands), length(attachOperands), ]))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -99,63 +51,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyinOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, attachOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        copyinOperands...,
-        createOperands...,
-        createZeroOperands...,
-        attachOperands...,
-    ]
+    operands = Value[waitOperands..., copyinOperands..., createOperands..., createZeroOperands..., attachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyinOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(attachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyinOperands), length(createOperands), length(createZeroOperands), length(attachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -170,59 +83,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    deleteOperands::Vector{Value},
-    detachOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, copyoutOperands::Vector{Value}, deleteOperands::Vector{Value}, detachOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., copyoutOperands..., deleteOperands..., detachOperands...
-    ]
+    operands = Value[waitOperands..., copyoutOperands..., deleteOperands..., detachOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(copyoutOperands),
-            length(deleteOperands),
-            length(detachOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(copyoutOperands), length(deleteOperands), length(detachOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -239,42 +118,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -298,68 +156,29 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    reductionOp=nothing,
-    exec_mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, reductionOp=nothing, exec_mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
     !isnothing(auto_) && push!(attributes, namedattribute("auto_", auto_))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
-    !isnothing(exec_mapping) &&
-        push!(attributes, namedattribute("exec_mapping", exec_mapping))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(exec_mapping) && push!(attributes, namedattribute("exec_mapping", exec_mapping))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,55 +197,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs=nothing::Union{Nothing,Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    copyOperands::Vector{Value},
-    copyinOperands::Vector{Value},
-    copyinReadonlyOperands::Vector{Value},
-    copyoutOperands::Vector{Value},
-    copyoutZeroOperands::Vector{Value},
-    createOperands::Vector{Value},
-    createZeroOperands::Vector{Value},
-    noCreateOperands::Vector{Value},
-    presentOperands::Vector{Value},
-    devicePtrOperands::Vector{Value},
-    attachOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionOp=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs=nothing::Union{Nothing, Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, copyOperands::Vector{Value}, copyinOperands::Vector{Value}, copyinReadonlyOperands::Vector{Value}, copyoutOperands::Vector{Value}, copyoutZeroOperands::Vector{Value}, createOperands::Vector{Value}, createZeroOperands::Vector{Value}, noCreateOperands::Vector{Value}, presentOperands::Vector{Value}, devicePtrOperands::Vector{Value}, attachOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionOp=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        copyOperands...,
-        copyinOperands...,
-        copyinReadonlyOperands...,
-        copyoutOperands...,
-        copyoutZeroOperands...,
-        createOperands...,
-        createZeroOperands...,
-        noCreateOperands...,
-        presentOperands...,
-        devicePtrOperands...,
-        attachOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., copyOperands..., copyinOperands..., copyinReadonlyOperands..., copyoutOperands..., copyoutZeroOperands..., createOperands..., createZeroOperands..., noCreateOperands..., presentOperands..., devicePtrOperands..., attachOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -435,53 +209,18 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (numGangs == nothing)
-                0
-            elseif 1(numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(copyOperands),
-            length(copyinOperands),
-            length(copyinReadonlyOperands),
-            length(copyoutOperands),
-            length(copyoutZeroOperands),
-            length(createOperands),
-            length(createZeroOperands),
-            length(noCreateOperands),
-            length(presentOperands),
-            length(devicePtrOperands),
-            length(attachOperands),
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (numGangs==nothing) ? 0 : 1(numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(copyOperands), length(copyinOperands), length(copyinReadonlyOperands), length(copyoutOperands), length(copyoutZeroOperands), length(createOperands), length(createZeroOperands), length(noCreateOperands), length(presentOperands), length(devicePtrOperands), length(attachOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(reductionOp) && push!(attributes, namedattribute("reductionOp", reductionOp))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -498,42 +237,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -551,16 +269,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,59 +292,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    hostOperands::Vector{Value},
-    deviceOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, hostOperands::Vector{Value}, deviceOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands...
-    ]
+    operands = Value[waitOperands..., deviceTypeOperands..., hostOperands..., deviceOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(hostOperands),
-            length(deviceOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(hostOperands), length(deviceOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -647,48 +327,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -699,22 +354,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/OpenMP.jl
+++ b/src/Dialects/16/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `atomic_capture`
@@ -37,20 +37,27 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
+function atomic_capture(;
+    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.capture", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.capture",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,20 +76,27 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
+function atomic_read(
+    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, v, ]
+    operands = Value[x, v]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.read", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.read",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -116,20 +130,31 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
+function atomic_update(
+    x::Value;
+    hint_val=nothing,
+    memory_order_val=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
-    owned_regions = Region[region, ]
+    operands = Value[x,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.update", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.update",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -150,20 +175,31 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
+function atomic_write(
+    address::Value,
+    value::Value;
+    hint_val=nothing,
+    memory_order_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[address, value, ]
+    operands = Value[address, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.write", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.write",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -179,12 +215,16 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,19 +234,29 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
+function cancel(
+    if_expr=nothing::Union{Nothing,Value};
+    cancellation_construct_type_val,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    attributes = NamedAttribute[namedattribute(
+        "cancellation_construct_type_val", cancellation_construct_type_val
+    ),]
     !isnothing(if_expr) && push!(operands, if_expr)
-    
-    IR.create_operation(
-        "omp.cancel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.cancel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -222,13 +272,19 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
-    
-    IR.create_operation(
-        "omp.cancellationpoint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute(
+        "cancellation_construct_type_val", cancellation_construct_type_val
+    ),]
+
+    return IR.create_operation(
+        "omp.cancellationpoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -244,14 +300,18 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    
-    IR.create_operation(
-        "omp.critical.declare", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.critical.declare",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -264,16 +324,20 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "omp.critical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.critical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -287,16 +351,20 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList..., ]
+    operands = Value[varList...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.flush", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.flush",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,15 +377,19 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.master", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.master",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -339,20 +411,31 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
+function ordered(
+    depend_vec_vars::Vector{Value};
+    depend_type_val=nothing,
+    num_loops_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[depend_vec_vars..., ]
+    operands = Value[depend_vec_vars...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
-    
-    IR.create_operation(
-        "omp.ordered", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(depend_type_val) &&
+        push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) &&
+        push!(attributes, namedattribute("num_loops_val", num_loops_val))
+
+    return IR.create_operation(
+        "omp.ordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -370,16 +453,20 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-    
-    IR.create_operation(
-        "omp.ordered_region", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.ordered_region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -415,23 +502,51 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
+function parallel(
+    if_expr_var=nothing::Union{Nothing,Value};
+    num_threads_var=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    reductions=nothing,
+    proc_bind_val=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr_var == nothing)
+                0
+            elseif 1(num_threads_var == nothing)
+                0
+            else
+                1length(allocate_vars)
+            end,
+            length(allocators_vars),
+            length(reduction_vars),
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-    
-    IR.create_operation(
-        "omp.parallel", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(proc_bind_val) &&
+        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+
+    return IR.create_operation(
+        "omp.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -460,18 +575,31 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
+function reduction_declare(;
+    sym_name,
+    type,
+    initializerRegion::Region,
+    reductionRegion::Region,
+    atomicReductionRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "omp.reduction.declare", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+
+    return IR.create_operation(
+        "omp.reduction.declare",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -485,16 +613,20 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator, ]
+    operands = Value[operand, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -508,15 +640,19 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.section", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.section",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -547,21 +683,38 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
+function sections(
+    reduction_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    reductions=nothing,
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(reduction_vars), length(allocate_vars), length(allocators_vars)
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.sections", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.sections",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -610,25 +763,55 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
+function simdloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    aligned_vars::Vector{Value},
+    if_expr=nothing::Union{Nothing,Value};
+    nontemporal_vars::Vector{Value},
+    alignment_values=nothing,
+    order_val=nothing,
+    simdlen=nothing,
+    safelen=nothing,
+    inclusive=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), (if_expr==nothing) ? 0 : 1length(nontemporal_vars), ]))
-    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            length(aligned_vars),
+            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
+        ]),
+    )
+    !isnothing(alignment_values) &&
+        push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-    
-    IR.create_operation(
-        "omp.simdloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.simdloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -641,20 +824,30 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
+function single(
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.single", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.single",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -678,23 +871,47 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
+function target(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    thread_limit=nothing::Union{Nothing,Value},
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            elseif 1(thread_limit == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.target", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -729,21 +946,47 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
+function target_data(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    use_device_ptr::Vector{Value},
+    use_device_addr::Vector{Value},
+    map_operands::Vector{Value},
+    map_types,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
+    attributes = NamedAttribute[namedattribute("map_types", map_types),]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
-    
-    IR.create_operation(
-        "omp.target_data", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            else
+                1length(use_device_ptr)
+            end,
+            length(use_device_addr),
+            length(map_operands),
+        ]),
+    )
+
+    return IR.create_operation(
+        "omp.target_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -771,22 +1014,44 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
+function target_enter_data(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    map_operands::Vector{Value},
+    nowait=nothing,
+    map_types,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[map_operands..., ]
+    operands = Value[map_operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
+    attributes = NamedAttribute[namedattribute("map_types", map_types),]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            else
+                1length(map_operands)
+            end
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.target_enter_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target_enter_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -814,22 +1079,44 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
+function target_exit_data(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    map_operands::Vector{Value},
+    nowait=nothing,
+    map_types,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[map_operands..., ]
+    operands = Value[map_operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
+    attributes = NamedAttribute[namedattribute("map_types", map_types),]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            else
+                1length(map_operands)
+            end
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.target_exit_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target_exit_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -857,20 +1144,37 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
+function taskgroup(
+    task_reduction_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    task_reductions=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
-    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
-    
-    IR.create_operation(
-        "omp.taskgroup", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
+        ]),
+    )
+    !isnothing(task_reductions) &&
+        push!(attributes, namedattribute("task_reductions", task_reductions))
+
+    return IR.create_operation(
+        "omp.taskgroup",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -972,10 +1276,39 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
+function taskloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    if_expr=nothing::Union{Nothing,Value};
+    final_expr=nothing::Union{Nothing,Value},
+    in_reduction_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    priority=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    grain_size=nothing::Union{Nothing,Value},
+    num_tasks=nothing::Union{Nothing,Value},
+    inclusive=nothing,
+    untied=nothing,
+    mergeable=nothing,
+    in_reductions=nothing,
+    reductions=nothing,
+    nogroup=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound...,
+        upperBound...,
+        step...,
+        in_reduction_vars...,
+        reduction_vars...,
+        allocate_vars...,
+        allocators_vars...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -983,19 +1316,48 @@ function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Ve
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            if (if_expr == nothing)
+                0
+            elseif 1(final_expr == nothing)
+                0
+            else
+                1length(in_reduction_vars)
+            end,
+            length(reduction_vars),
+            (priority == nothing) ? 0 : 1length(allocate_vars),
+            length(allocators_vars),
+            if (grain_size == nothing)
+                0
+            elseif 1(num_tasks == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) &&
+        push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-    
-    IR.create_operation(
-        "omp.taskloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1041,25 +1403,55 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
+function task(
+    if_expr=nothing::Union{Nothing,Value};
+    final_expr=nothing::Union{Nothing,Value},
+    in_reduction_vars::Vector{Value},
+    priority=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    untied=nothing,
+    mergeable=nothing,
+    in_reductions=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(final_expr == nothing)
+                0
+            else
+                1length(in_reduction_vars)
+            end,
+            (priority == nothing) ? 0 : 1length(allocate_vars),
+            length(allocators_vars),
+        ]),
+    )
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
-    
-    IR.create_operation(
-        "omp.task", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(in_reductions) &&
+        push!(attributes, namedattribute("in_reductions", in_reductions))
+
+    return IR.create_operation(
+        "omp.task",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1075,12 +1467,16 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.taskwait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskwait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1096,12 +1492,16 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.taskyield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskyield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1119,12 +1519,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1147,17 +1551,21 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr, ]
-    operands = Value[sym_addr, ]
+    results = IR.Type[tls_addr,]
+    operands = Value[sym_addr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.threadprivate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.threadprivate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1222,28 +1630,71 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
+function wsloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    linear_vars::Vector{Value},
+    linear_step_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    schedule_chunk_var=nothing::Union{Nothing,Value};
+    reductions=nothing,
+    schedule_val=nothing,
+    schedule_modifier=nothing,
+    simd_modifier=nothing,
+    nowait=nothing,
+    ordered_val=nothing,
+    order_val=nothing,
+    inclusive=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound...,
+        upperBound...,
+        step...,
+        linear_vars...,
+        linear_step_vars...,
+        reduction_vars...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            length(linear_vars),
+            length(linear_step_vars),
+            length(reduction_vars),
+            (schedule_chunk_var == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) &&
+        push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) &&
+        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) &&
+        push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-    
-    IR.create_operation(
-        "omp.wsloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.wsloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1254,18 +1705,22 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results_::Vector{Value}; location=Location())
+function yield(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/OpenMP.jl
+++ b/src/Dialects/16/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `atomic_capture`
@@ -37,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,27 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
-)
+function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -175,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -215,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -234,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -272,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -300,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -324,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -351,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -411,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -453,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -575,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -613,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -683,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -763,55 +610,25 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    aligned_vars::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    nontemporal_vars::Vector{Value},
-    alignment_values=nothing,
-    order_val=nothing,
-    simdlen=nothing,
-    safelen=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(aligned_vars),
-            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
-        ]),
-    )
-    !isnothing(alignment_values) &&
-        push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), (if_expr==nothing) ? 0 : 1length(nontemporal_vars), ]))
+    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -824,30 +641,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,47 +678,23 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            elseif 1(thread_limit == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -946,47 +729,21 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    use_device_ptr::Vector{Value},
-    use_device_addr::Vector{Value},
-    map_operands::Vector{Value},
-    map_types,
-    region::Region,
-    location=Location(),
-)
+function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
-    owned_regions = Region[region,]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(use_device_ptr)
-            end,
-            length(use_device_addr),
-            length(map_operands),
-        ]),
-    )
-
-    return IR.create_operation(
-        "omp.target_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
+    
+    IR.create_operation(
+        "omp.target_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1014,44 +771,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(map_operands)
-            end
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1079,44 +814,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(map_operands)
-            end
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1144,37 +857,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1276,39 +972,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1316,48 +983,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1403,55 +1041,25 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1467,16 +1075,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1492,16 +1096,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1519,16 +1119,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1551,21 +1147,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1630,71 +1222,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1705,22 +1254,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/OpenMP.jl
+++ b/src/Dialects/16/OpenMP.jl
@@ -1,9 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `atomic_capture`
@@ -38,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,27 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location()
-)
+function atomic_read(x::Value, v::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -131,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -176,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -216,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -412,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -454,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -503,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -576,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -614,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -684,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -764,55 +610,25 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    aligned_vars::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    nontemporal_vars::Vector{Value},
-    alignment_values=nothing,
-    order_val=nothing,
-    simdlen=nothing,
-    safelen=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(aligned_vars),
-            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
-        ]),
-    )
-    !isnothing(alignment_values) &&
-        push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), (if_expr==nothing) ? 0 : 1length(nontemporal_vars), ]))
+    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -825,30 +641,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -872,44 +678,23 @@ even if the target task is not yet completed.
 
 TODO:  map, is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        elseif 1(thread_limit == nothing)
-            0
-        else
-            1
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -944,47 +729,21 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    use_device_ptr::Vector{Value},
-    use_device_addr::Vector{Value},
-    map_operands::Vector{Value},
-    map_types,
-    region::Region,
-    location=Location(),
-)
+function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
-    owned_regions = Region[region,]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(use_device_ptr)
-            end,
-            length(use_device_addr),
-            length(map_operands),
-        ]),
-    )
-
-    return IR.create_operation(
-        "omp.target_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
+    
+    IR.create_operation(
+        "omp.target_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1012,41 +771,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1074,41 +814,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1136,37 +857,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1268,39 +972,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1308,48 +983,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1395,55 +1041,25 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1459,16 +1075,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1484,16 +1096,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1511,16 +1119,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1543,21 +1147,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1622,71 +1222,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1697,22 +1254,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/PDL.jl
+++ b/src/Dialects/16/PDL.jl
@@ -1,9 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_native_constraint`
@@ -21,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -66,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,29 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    valueType=nothing::Union{Nothing,Value};
-    attr::IR.Type,
-    value=nothing,
-    location=Location(),
-)
-    results = IR.Type[attr,]
+function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,20 +133,16 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue,]
+    operands = Value[opValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -191,30 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -234,25 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -353,37 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operandValues::Vector{Value},
-    attributeValues::Vector{Value},
-    typeValues::Vector{Value};
-    op::IR.Type,
-    opName=nothing,
-    attributeValueNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operandValues..., attributeValues..., typeValues...]
+function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operandValues..., attributeValues..., typeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(operandValues), length(attributeValues), length(typeValues)
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -414,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -459,21 +402,17 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,32 +441,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    opValue::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[opValue, replValues...]
+    operands = Value[opValue, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,26 +481,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -601,23 +524,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,31 +579,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    bodyRegion::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[bodyRegion,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -707,23 +616,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) &&
-        push!(attributes, namedattribute("constantType", constantType))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -746,23 +650,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) &&
-        push!(attributes, namedattribute("constantTypes", constantTypes))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/PDL.jl
+++ b/src/Dialects/16/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_native_constraint`
@@ -20,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,29 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    valueType=nothing::Union{Nothing,Value};
-    attr::IR.Type,
-    value=nothing,
-    location=Location(),
-)
-    results = IR.Type[attr,]
+function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,20 +133,16 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue,]
+    operands = Value[opValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -190,30 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -233,25 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,37 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operandValues::Vector{Value},
-    attributeValues::Vector{Value},
-    typeValues::Vector{Value};
-    op::IR.Type,
-    opName=nothing,
-    attributeValueNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operandValues..., attributeValues..., typeValues...]
+function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operandValues..., attributeValues..., typeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(operandValues), length(attributeValues), length(typeValues)
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -458,21 +402,17 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,32 +441,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    opValue::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[opValue, replValues...]
+    operands = Value[opValue, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -553,26 +481,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -600,23 +524,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,31 +579,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    bodyRegion::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[bodyRegion,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -706,23 +616,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) &&
-        push!(attributes, namedattribute("constantType", constantType))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -745,23 +650,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) &&
-        push!(attributes, namedattribute("constantTypes", constantTypes))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/PDL.jl
+++ b/src/Dialects/16/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_native_constraint`
@@ -20,16 +20,20 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl.apply_native_constraint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl.apply_native_constraint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -61,18 +65,24 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[args..., ]
+function apply_native_rewrite(
+    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl.apply_native_rewrite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl.apply_native_rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -101,20 +111,29 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
-    results = IR.Type[attr, ]
+function attribute(
+    valueType=nothing::Union{Nothing,Value};
+    attr::IR.Type,
+    value=nothing,
+    location=Location(),
+)
+    results = IR.Type[attr,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    
-    IR.create_operation(
-        "pdl.attribute", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -133,16 +152,20 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue, ]
+    operands = Value[opValue,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl.erase", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.erase",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -167,24 +190,30 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
+function operand(
+    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
+)
+    results = IR.Type[value,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-    
-    IR.create_operation(
-        "pdl.operand", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`operands_`
+`operands`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -204,19 +233,25 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
+function operands(
+    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
+)
+    results = IR.Type[value,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-    
-    IR.create_operation(
-        "pdl.operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,20 +352,37 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
-    results = IR.Type[op, ]
-    operands = Value[operandValues..., attributeValues..., typeValues..., ]
+function operation(
+    operandValues::Vector{Value},
+    attributeValues::Vector{Value},
+    typeValues::Vector{Value};
+    op::IR.Type,
+    opName=nothing,
+    attributeValueNames,
+    location=Location(),
+)
+    results = IR.Type[op,]
+    operands = Value[operandValues..., attributeValues..., typeValues...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
-    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(operandValues), length(attributeValues), length(typeValues)
+        ]),
+    )
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-    
-    IR.create_operation(
-        "pdl.operation", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -361,16 +413,20 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
+    attributes = NamedAttribute[namedattribute("benefit", benefit),]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    
-    IR.create_operation(
-        "pdl.pattern", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.pattern",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -402,17 +458,21 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arguments..., ]
+    results = IR.Type[result,]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl.range", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.range",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -441,20 +501,32 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
+function replace(
+    opValue::Value,
+    replOperation=nothing::Union{Nothing,Value};
+    replValues::Vector{Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[opValue, replValues..., ]
+    operands = Value[opValue, replValues...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
-    
-    IR.create_operation(
-        "pdl.replace", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
+    )
+
+    return IR.create_operation(
+        "pdl.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -481,22 +553,26 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val, ]
-    operands = Value[parent, ]
+    results = IR.Type[val,]
+    operands = Value[parent,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl.result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl.result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`results_`
+`results`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -524,19 +600,23 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val, ]
-    operands = Value[parent, ]
+function results(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val,]
+    operands = Value[parent,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl.results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -579,21 +659,31 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
+function rewrite(
+    root=nothing::Union{Nothing,Value};
+    externalArgs::Vector{Value},
+    name=nothing,
+    bodyRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[externalArgs..., ]
-    owned_regions = Region[bodyRegion, ]
+    operands = Value[externalArgs...,]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
+    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "pdl.rewrite", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -616,18 +706,23 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
-    
-    IR.create_operation(
-        "pdl.type", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constantType) &&
+        push!(attributes, namedattribute("constantType", constantType))
+
+    return IR.create_operation(
+        "pdl.type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -650,18 +745,23 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
-    
-    IR.create_operation(
-        "pdl.types", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constantTypes) &&
+        push!(attributes, namedattribute("constantTypes", constantTypes))
+
+    return IR.create_operation(
+        "pdl.types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/PDLInterp.jl
+++ b/src/Dialects/16/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_constraint`
@@ -20,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -135,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -163,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -284,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -359,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -399,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -425,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -523,21 +423,17 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.create_range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.create_range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,21 +450,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -585,21 +477,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,20 +506,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -649,21 +533,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -685,16 +565,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -719,20 +595,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -754,33 +626,20 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -798,21 +657,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -829,21 +684,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -862,21 +713,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,21 +741,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -936,22 +779,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -969,21 +808,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1011,22 +846,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,21 +879,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,21 +910,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1117,20 +940,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1149,37 +968,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1200,20 +1003,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1231,28 +1030,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1270,28 +1059,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1309,28 +1088,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1117,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1387,24 +1146,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1422,24 +1175,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/PDLInterp.jl
+++ b/src/Dialects/16/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_constraint`
@@ -20,18 +20,24 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
+function apply_constraint(
+    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.apply_constraint", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.apply_constraint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,18 +63,24 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[args..., ]
+function apply_rewrite(
+    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.apply_rewrite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.apply_rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -85,18 +97,24 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
+function are_equal(
+    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.are_equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.are_equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -117,14 +135,18 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.branch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -141,18 +163,24 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
+function check_attribute(
+    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[attribute, ]
+    operands = Value[attribute,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_attribute", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
+
+    return IR.create_operation(
+        "pdl_interp.check_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -175,19 +203,31 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
+function check_operand_count(
+    inputOp::Value;
+    count,
+    compareAtLeast=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-    
-    IR.create_operation(
-        "pdl_interp.check_operand_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("count", count),]
+    !isnothing(compareAtLeast) &&
+        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+
+    return IR.create_operation(
+        "pdl_interp.check_operand_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -204,18 +244,24 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
+function check_operation_name(
+    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_operation_name", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.check_operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -238,19 +284,31 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
+function check_result_count(
+    inputOp::Value;
+    count,
+    compareAtLeast=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-    
-    IR.create_operation(
-        "pdl_interp.check_result_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("count", count),]
+    !isnothing(compareAtLeast) &&
+        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+
+    return IR.create_operation(
+        "pdl_interp.check_result_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -267,18 +325,24 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
+function check_type(
+    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_type", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("type", type),]
+
+    return IR.create_operation(
+        "pdl_interp.check_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -295,18 +359,24 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
+function check_types(
+    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("types", types), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_types", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("types", types),]
+
+    return IR.create_operation(
+        "pdl_interp.check_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -329,12 +399,16 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.continue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.continue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -351,17 +425,21 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute, ]
+    results = IR.Type[attribute,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -384,20 +462,42 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
-    results = IR.Type[resultOp, ]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
+function create_operation(
+    inputOperands::Vector{Value},
+    inputAttributes::Vector{Value},
+    inputResultTypes::Vector{Value};
+    resultOp::IR.Type,
+    name,
+    inputAttributeNames,
+    inferredResultTypes=nothing,
+    location=Location(),
+)
+    results = IR.Type[resultOp,]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
-    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
-    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-    
-    IR.create_operation(
-        "pdl_interp.create_operation", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("name", name),
+        namedattribute("inputAttributeNames", inputAttributeNames),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(inputOperands), length(inputAttributes), length(inputResultTypes)
+        ]),
+    )
+    !isnothing(inferredResultTypes) &&
+        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+
+    return IR.create_operation(
+        "pdl_interp.create_operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -423,17 +523,21 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arguments..., ]
+    results = IR.Type[result,]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.create_range", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.create_range",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -450,17 +554,21 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_type", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -477,17 +585,21 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_types", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -506,16 +618,20 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.erase", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.erase",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -533,17 +649,21 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[range, ]
+    results = IR.Type[result,]
+    operands = Value[range,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.extract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -565,12 +685,16 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.finalize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.finalize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -595,16 +719,20 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values, ]
-    owned_regions = Region[region, ]
-    successors = Block[successor, ]
+    operands = Value[values,]
+    owned_regions = Region[region,]
+    successors = Block[successor,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -626,20 +754,33 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "pdl_interp.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -657,17 +798,21 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[attribute,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.get_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -684,17 +829,21 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_attribute_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_attribute_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -713,17 +862,21 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp, ]
-    operands = Value[value, ]
+    results = IR.Type[inputOp,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_defining_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_defining_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -741,17 +894,21 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_operand", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.get_operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -779,18 +936,22 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl_interp.get_operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -808,17 +969,21 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.get_result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -846,18 +1011,22 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl_interp.get_results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -879,17 +1048,21 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations, ]
-    operands = Value[value, ]
+    results = IR.Type[operations,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_users", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_users",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -910,17 +1083,21 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_value_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_value_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -940,16 +1117,20 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.is_not_null", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.is_not_null",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -968,21 +1149,37 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
+function record_match(
+    inputs::Vector{Value},
+    matchedOps::Vector{Value};
+    rewriter,
+    rootKind=nothing,
+    generatedOps=nothing,
+    benefit,
+    dest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps..., ]
+    operands = Value[inputs..., matchedOps...]
     owned_regions = Region[]
-    successors = Block[dest, ]
-    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
+    successors = Block[dest,]
+    attributes = NamedAttribute[
+        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
+    ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
-    
-    IR.create_operation(
-        "pdl_interp.record_match", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(generatedOps) &&
+        push!(attributes, namedattribute("generatedOps", generatedOps))
+
+    return IR.create_operation(
+        "pdl_interp.record_match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1003,16 +1200,20 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues..., ]
+    operands = Value[inputOp, replValues...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.replace", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1030,18 +1231,28 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_attribute(
+    attribute::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[attribute, ]
+    operands = Value[attribute,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_attribute", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1059,18 +1270,28 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_operand_count(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_operand_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_operand_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1088,18 +1309,28 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_operation_name(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_operation_name", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1117,18 +1348,28 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_result_count(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_result_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_result_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1146,18 +1387,24 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_type(
+    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_type", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1175,18 +1422,24 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_types(
+    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_types", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/PDLInterp.jl
+++ b/src/Dialects/16/PDLInterp.jl
@@ -1,9 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_constraint`
@@ -21,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -204,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -285,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -360,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -400,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -524,21 +423,17 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.create_range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.create_range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,21 +450,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -586,21 +477,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,20 +506,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -650,21 +533,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -686,16 +565,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -720,20 +595,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,33 +626,20 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -799,21 +657,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -830,21 +684,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -863,21 +713,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -895,21 +741,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -937,22 +779,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -970,21 +808,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1012,22 +846,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1049,21 +879,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1084,21 +910,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1118,20 +940,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1150,37 +968,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1201,20 +1003,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1232,28 +1030,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1271,28 +1059,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1310,28 +1088,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,28 +1117,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1388,24 +1146,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1423,24 +1175,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Quant.jl
+++ b/src/Dialects/16/Quant.jl
@@ -1,25 +1,29 @@
 module quant
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `dcast`
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[arg, ]
+    results = IR.Type[result_0,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.dcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.dcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -28,17 +32,21 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[arg, ]
+    results = IR.Type[result_0,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.qcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.qcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -47,17 +55,21 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[arg, ]
+    results = IR.Type[result_0,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.scast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.scast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Quant.jl
+++ b/src/Dialects/16/Quant.jl
@@ -1,30 +1,25 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `dcast`
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -33,21 +28,17 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -56,21 +47,17 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Quant.jl
+++ b/src/Dialects/16/Quant.jl
@@ -1,29 +1,25 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `dcast`
 
 """
 function dcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -32,21 +28,17 @@ end
 
 """
 function qcast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -55,21 +47,17 @@ end
 
 """
 function scast(arg::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[arg,]
+    results = IR.Type[result_0, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SCF.jl
+++ b/src/Dialects/16/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `condition`
@@ -14,16 +14,20 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args..., ]
+    operands = Value[condition, args...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.condition", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.condition",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,17 +73,21 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0..., ]
+    results = IR.Type[result_0...,]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.execute_region", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.execute_region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -172,18 +180,30 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[lowerBound, upperBound, step, initArgs..., ]
-    owned_regions = Region[region, ]
+function for_(
+    lowerBound::Value,
+    upperBound::Value,
+    step::Value,
+    initArgs::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[lowerBound, upperBound, step, initArgs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -312,20 +332,31 @@ Example with privatized tensors:
 }
 ```
 """
-function foreach_thread(num_threads::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, mapping=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[num_threads..., outputs..., ]
-    owned_regions = Region[region, ]
+function foreach_thread(
+    num_threads::Vector{Value},
+    outputs::Vector{Value};
+    results::Vector{IR.Type},
+    mapping=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[num_threads..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs)]))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-    
-    IR.create_operation(
-        "scf.foreach_thread", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.foreach_thread",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -375,18 +406,28 @@ scf.if %b  {
 }
 ```
 """
-function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[condition, ]
-    owned_regions = Region[thenRegion, elseRegion, ]
+function if_(
+    condition::Value;
+    results::Vector{IR.Type},
+    thenRegion::Region,
+    elseRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[condition,]
+    owned_regions = Region[thenRegion, elseRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -421,18 +462,29 @@ default {
 }
 ```
 """
-function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[arg, ]
-    owned_regions = Region[defaultRegion, caseRegions..., ]
+function index_switch(
+    arg::Value;
+    results::Vector{IR.Type},
+    cases,
+    defaultRegion::Region,
+    caseRegions::Vector{Region},
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[arg,]
+    owned_regions = Region[defaultRegion, caseRegions...]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases), ]
-    
-    IR.create_operation(
-        "scf.index_switch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases),]
+
+    return IR.create_operation(
+        "scf.index_switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -482,19 +534,36 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
-    owned_regions = Region[region, ]
+function parallel(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    initVals::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[lowerBound..., upperBound..., step..., initVals...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
-    
-    IR.create_operation(
-        "scf.parallel", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound), length(upperBound), length(step), length(initVals)
+        ]),
+    )
+
+    return IR.create_operation(
+        "scf.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -512,15 +581,19 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.foreach_thread.perform_concurrently", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.foreach_thread.perform_concurrently",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -562,16 +635,20 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
-    owned_regions = Region[reductionOperator, ]
+    operands = Value[operand,]
+    owned_regions = Region[reductionOperator,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -588,16 +665,20 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.reduce.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.reduce.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -715,18 +796,28 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[inits..., ]
-    owned_regions = Region[before, after, ]
+function while_(
+    inits::Vector{Value};
+    results::Vector{IR.Type},
+    before::Region,
+    after::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[inits...,]
+    owned_regions = Region[before, after]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.while", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.while",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -743,18 +834,22 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results_::Vector{Value}; location=Location())
+function yield(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/SCF.jl
+++ b/src/Dialects/16/SCF.jl
@@ -1,9 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `condition`
@@ -15,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -74,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -181,30 +172,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,31 +312,20 @@ Example with privatized tensors:
 }
 ```
 """
-function foreach_thread(
-    num_threads::Vector{Value},
-    outputs::Vector{Value};
-    results::Vector{IR.Type},
-    mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[num_threads..., outputs...]
-    owned_regions = Region[region,]
+function foreach_thread(num_threads::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[num_threads..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs), ]))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "scf.foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,28 +375,18 @@ scf.if %b  {
 }
 ```
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,29 +421,18 @@ default {
 }
 ```
 """
-function index_switch(
-    arg::Value;
-    results::Vector{IR.Type},
-    cases,
-    defaultRegion::Region,
-    caseRegions::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[arg,]
-    owned_regions = Region[defaultRegion, caseRegions...]
+function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[arg, ]
+    owned_regions = Region[defaultRegion, caseRegions..., ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases),]
-
-    return IR.create_operation(
-        "scf.index_switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases), ]
+    
+    IR.create_operation(
+        "scf.index_switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -535,36 +482,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,19 +512,15 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.foreach_thread.perform_concurrently",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread.perform_concurrently", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -636,20 +562,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -666,20 +588,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -797,28 +715,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -835,22 +743,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SCF.jl
+++ b/src/Dialects/16/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `condition`
@@ -14,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -180,30 +172,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,31 +312,20 @@ Example with privatized tensors:
 }
 ```
 """
-function foreach_thread(
-    num_threads::Vector{Value},
-    outputs::Vector{Value};
-    results::Vector{IR.Type},
-    mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[num_threads..., outputs...]
-    owned_regions = Region[region,]
+function foreach_thread(num_threads::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[num_threads..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(num_threads), length(outputs), ]))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "scf.foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -406,28 +375,18 @@ scf.if %b  {
 }
 ```
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,29 +421,18 @@ default {
 }
 ```
 """
-function index_switch(
-    arg::Value;
-    results::Vector{IR.Type},
-    cases,
-    defaultRegion::Region,
-    caseRegions::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[arg,]
-    owned_regions = Region[defaultRegion, caseRegions...]
+function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[arg, ]
+    owned_regions = Region[defaultRegion, caseRegions..., ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases),]
-
-    return IR.create_operation(
-        "scf.index_switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases), ]
+    
+    IR.create_operation(
+        "scf.index_switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -534,36 +482,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -581,19 +512,15 @@ The result number corresponds to the position of the op in the terminator.
 function foreach_thread_perform_concurrently(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.foreach_thread.perform_concurrently",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.foreach_thread.perform_concurrently", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,20 +562,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -665,20 +588,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -796,28 +715,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -834,22 +743,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SPIRV.jl
+++ b/src/Dialects/16/SPIRV.jl
@@ -1,9 +1,8 @@
 module spirv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `AccessChain`
@@ -47,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -93,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spirv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spirv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,31 +137,18 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,35 +198,18 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -278,35 +237,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -343,31 +285,18 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -404,31 +333,18 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -464,26 +380,18 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -518,26 +426,18 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -575,31 +475,18 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -636,31 +523,18 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -698,31 +572,18 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -760,31 +621,18 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -822,31 +670,18 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -884,31 +719,18 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -946,31 +768,18 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1006,25 +815,19 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1070,30 +873,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1139,29 +931,19 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1189,29 +971,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1243,25 +1015,19 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1305,21 +1071,17 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,28 +1111,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1400,28 +1153,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1451,28 +1195,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1510,36 +1245,20 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spirv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spirv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1565,20 +1284,16 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1607,25 +1322,19 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1654,23 +1363,19 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1699,23 +1404,19 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1744,23 +1445,19 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1789,25 +1486,19 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1837,25 +1528,19 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1884,25 +1569,19 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1931,25 +1610,19 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1976,29 +1649,19 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2027,23 +1690,19 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2073,25 +1732,19 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2120,25 +1773,19 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rint", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2166,25 +1813,19 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2213,25 +1854,19 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2260,25 +1895,19 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2304,25 +1933,19 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2348,25 +1971,19 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2395,23 +2012,19 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2440,25 +2053,19 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2487,25 +2094,19 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2531,25 +2132,19 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2575,25 +2170,19 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2631,24 +2220,18 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2681,24 +2264,18 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2731,24 +2308,18 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2788,21 +2359,17 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spirv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spirv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2852,28 +2419,18 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2902,21 +2459,17 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2946,21 +2499,17 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2989,21 +2538,17 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3032,21 +2577,17 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3079,37 +2620,22 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spirv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spirv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3151,31 +2677,18 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.EXT.AtomicFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.EXT.AtomicFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3225,21 +2738,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spirv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spirv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3277,21 +2782,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spirv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spirv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3319,28 +2816,19 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3370,21 +2858,17 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3414,28 +2898,19 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3466,28 +2941,19 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3517,28 +2983,19 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3566,25 +3023,19 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3614,28 +3065,18 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3665,28 +3106,18 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3716,28 +3147,18 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3767,28 +3188,18 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3818,28 +3229,18 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3869,28 +3270,18 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3922,28 +3313,19 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3972,28 +3354,19 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4023,28 +3396,18 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4074,28 +3437,18 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4125,28 +3478,18 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4176,28 +3519,18 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4227,28 +3560,18 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4278,28 +3601,18 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4332,36 +3645,20 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_name,
-    function_control,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "spirv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4395,28 +3692,19 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    return_value=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(return_value) && push!(results, return_value)
-
-    return IR.create_operation(
-        "spirv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4449,25 +3737,19 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4500,25 +3782,19 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4551,25 +3827,19 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4599,25 +3869,19 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4648,23 +3912,19 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4695,25 +3955,19 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4744,23 +3998,19 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4789,25 +4039,19 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4837,21 +4081,17 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4881,25 +4121,19 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4929,25 +4163,19 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4969,29 +4197,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5020,25 +4238,19 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5055,25 +4267,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5103,25 +4309,19 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5161,21 +4361,17 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5218,21 +4414,17 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5261,25 +4453,19 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5317,25 +4503,19 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spirv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5367,23 +4547,19 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5416,25 +4592,19 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5465,25 +4635,19 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.RoundEven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.RoundEven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5515,25 +4679,19 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5561,25 +4719,19 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5608,21 +4760,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5651,25 +4799,19 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5698,25 +4840,19 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5744,25 +4880,19 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5793,23 +4923,19 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5840,25 +4966,19 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5887,25 +5007,19 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5936,23 +5050,19 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5983,25 +5093,19 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6030,21 +5134,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6073,25 +5173,19 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6120,25 +5214,19 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6165,21 +5253,17 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtrExplicit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtrExplicit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6203,21 +5287,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6261,39 +5341,23 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-
-    return IR.create_operation(
-        "spirv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6342,29 +5406,19 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6400,32 +5454,19 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6461,32 +5502,19 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6522,32 +5550,19 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6584,32 +5599,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupFMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6645,32 +5647,19 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6707,32 +5696,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupIMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6765,24 +5741,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6827,29 +5797,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6874,25 +5834,19 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6938,33 +5892,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7013,33 +5953,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7088,33 +6014,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7160,33 +6072,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7230,33 +6128,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7300,33 +6184,19 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7370,33 +6240,19 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7440,33 +6296,19 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7495,29 +6337,19 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7544,29 +6376,19 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7594,29 +6416,19 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7644,29 +6456,19 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(
-    value::Value,
-    mask::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, mask]
+    operands = Value[value, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7711,33 +6513,19 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7782,33 +6570,19 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7845,32 +6619,19 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7907,32 +6668,19 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7968,32 +6716,19 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8030,32 +6765,19 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8089,21 +6811,17 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.IAddCarry",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAddCarry", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8138,28 +6856,19 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8189,28 +6898,18 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8245,28 +6944,19 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8300,36 +6990,20 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8367,30 +7041,19 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    scope,
-    location=Location(),
-)
+function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope),]
+    attributes = NamedAttribute[namedattribute("scope", scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixMad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixMad", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8428,36 +7091,20 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8482,25 +7129,19 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(;
-    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
-)
+function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8536,21 +7177,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8586,20 +7223,16 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8629,28 +7262,18 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8686,21 +7309,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8735,28 +7354,19 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8796,32 +7406,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spirv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spirv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8841,25 +7438,18 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(
-    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[sampledimage,]
+function Image(sampledimage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Image", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8898,21 +7488,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8938,28 +7524,18 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8989,23 +7565,18 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsInf(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsInf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9035,23 +7606,18 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsNan(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsNan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9074,20 +7640,16 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.AssumeTrue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.AssumeTrue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9122,21 +7684,17 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.SubgroupBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.SubgroupBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9173,31 +7731,20 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9226,28 +7773,18 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9276,28 +7813,18 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9326,28 +7853,18 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9373,25 +7890,18 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[operand,]
+function LogicalNot(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9420,28 +7930,18 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9475,19 +7975,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9520,24 +8016,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9568,28 +8058,19 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value,
-    scalar::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, scalar]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9632,20 +8113,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9664,16 +8138,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9720,34 +8190,20 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spirv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9772,27 +8228,19 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9849,31 +8297,19 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function NV_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9924,29 +8360,19 @@ For example:
   !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixMulAdd(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9989,31 +8415,19 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function NV_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10043,23 +8457,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10090,28 +8500,18 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Ordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10160,28 +8560,18 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10205,21 +8595,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrCastToGeneric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrCastToGeneric", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10249,21 +8635,17 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spirv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spirv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10284,16 +8666,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10320,20 +8698,16 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10363,21 +8737,17 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10409,28 +8779,19 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10473,30 +8834,19 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10534,25 +8884,19 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10582,28 +8926,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10633,28 +8967,18 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10684,28 +9008,18 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10735,28 +9049,18 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10789,28 +9093,19 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10839,24 +9134,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10880,25 +9169,19 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10931,28 +9214,19 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10997,30 +9271,19 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11060,25 +9323,19 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11121,29 +9378,19 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11171,19 +9418,15 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11223,28 +9466,19 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11281,28 +9515,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11340,28 +9565,19 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11406,21 +9622,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11460,19 +9668,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11546,21 +9748,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11593,27 +9791,20 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11646,21 +9837,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11691,21 +9878,17 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11736,28 +9919,19 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11802,30 +9976,19 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11865,25 +10028,19 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11913,28 +10070,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11964,28 +10111,18 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12015,28 +10152,18 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12066,28 +10193,18 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12118,28 +10235,19 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12169,24 +10277,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12213,21 +10315,17 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12258,28 +10356,18 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Unordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12300,16 +10388,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12347,28 +10431,19 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spirv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12394,25 +10469,18 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12450,29 +10518,19 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12513,24 +10571,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spirv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spirv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12552,24 +10604,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12594,20 +10640,16 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SPIRV.jl
+++ b/src/Dialects/16/SPIRV.jl
@@ -1,8 +1,8 @@
 module spirv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `AccessChain`
@@ -46,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spirv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spirv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -147,31 +137,18 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,35 +198,18 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -277,35 +237,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -342,31 +285,18 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -403,31 +333,18 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,26 +380,18 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -517,26 +426,18 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -574,31 +475,18 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,31 +523,18 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -697,31 +572,18 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -759,31 +621,18 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,31 +670,18 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -883,31 +719,18 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -945,31 +768,18 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1005,25 +815,19 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1069,30 +873,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1138,29 +931,19 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1188,29 +971,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1242,25 +1015,19 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1304,21 +1071,17 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1111,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1399,28 +1153,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1450,28 +1195,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1509,36 +1245,20 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spirv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spirv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1564,20 +1284,16 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1606,25 +1322,19 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1653,23 +1363,19 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1698,23 +1404,19 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1743,23 +1445,19 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1788,25 +1486,19 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1836,25 +1528,19 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1883,25 +1569,19 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1930,25 +1610,19 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1975,29 +1649,19 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2026,23 +1690,19 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2072,25 +1732,19 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2119,25 +1773,19 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rint", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2165,25 +1813,19 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2212,25 +1854,19 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2259,25 +1895,19 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2303,25 +1933,19 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2347,25 +1971,19 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2394,23 +2012,19 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2439,25 +2053,19 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2486,25 +2094,19 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2530,25 +2132,19 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2574,25 +2170,19 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2630,24 +2220,18 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2680,24 +2264,18 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2730,24 +2308,18 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2787,21 +2359,17 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spirv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spirv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2851,28 +2419,18 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2901,21 +2459,17 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2945,21 +2499,17 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2988,21 +2538,17 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3031,21 +2577,17 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3078,37 +2620,22 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spirv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spirv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3150,31 +2677,18 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.EXT.AtomicFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.EXT.AtomicFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3224,21 +2738,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spirv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spirv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3276,21 +2782,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spirv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spirv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3318,28 +2816,19 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3369,21 +2858,17 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3413,28 +2898,19 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3465,28 +2941,19 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3516,28 +2983,19 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3565,25 +3023,19 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3613,28 +3065,18 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3664,28 +3106,18 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3715,28 +3147,18 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3766,28 +3188,18 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3817,28 +3229,18 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3868,28 +3270,18 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3921,28 +3313,19 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3971,28 +3354,19 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4022,28 +3396,18 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4073,28 +3437,18 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4124,28 +3478,18 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4175,28 +3519,18 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4226,28 +3560,18 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4277,28 +3601,18 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4331,36 +3645,20 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_name,
-    function_control,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "spirv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4394,28 +3692,19 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    return_value=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(return_value) && push!(results, return_value)
-
-    return IR.create_operation(
-        "spirv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4448,25 +3737,19 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4499,25 +3782,19 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4550,25 +3827,19 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4598,25 +3869,19 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4647,23 +3912,19 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4694,25 +3955,19 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4743,23 +3998,19 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4788,25 +4039,19 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4836,21 +4081,17 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4880,25 +4121,19 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4928,25 +4163,19 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4968,29 +4197,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5019,25 +4238,19 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5054,25 +4267,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5102,25 +4309,19 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5160,21 +4361,17 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5217,21 +4414,17 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5260,25 +4453,19 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5316,25 +4503,19 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spirv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5366,23 +4547,19 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5415,25 +4592,19 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5464,25 +4635,19 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.RoundEven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.RoundEven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5514,25 +4679,19 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5560,25 +4719,19 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5607,21 +4760,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5650,25 +4799,19 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5697,25 +4840,19 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5743,25 +4880,19 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5792,23 +4923,19 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5839,25 +4966,19 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5886,25 +5007,19 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5935,23 +5050,19 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5982,25 +5093,19 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6029,21 +5134,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6072,25 +5173,19 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6119,25 +5214,19 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6164,21 +5253,17 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtrExplicit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtrExplicit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6202,21 +5287,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6260,39 +5341,23 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-
-    return IR.create_operation(
-        "spirv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6341,29 +5406,19 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6399,32 +5454,19 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6460,32 +5502,19 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6521,32 +5550,19 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6583,32 +5599,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupFMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6644,32 +5647,19 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6706,32 +5696,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupIMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6764,24 +5741,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6826,29 +5797,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6873,25 +5834,19 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6937,33 +5892,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7012,33 +5953,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7087,33 +6014,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7159,33 +6072,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7229,33 +6128,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7299,33 +6184,19 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7369,33 +6240,19 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7439,33 +6296,19 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7494,29 +6337,19 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7543,29 +6376,19 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7593,29 +6416,19 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7643,29 +6456,19 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(
-    value::Value,
-    mask::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, mask]
+    operands = Value[value, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7710,33 +6513,19 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7781,33 +6570,19 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7844,32 +6619,19 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7906,32 +6668,19 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7967,32 +6716,19 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8029,32 +6765,19 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8088,21 +6811,17 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.IAddCarry",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAddCarry", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8137,28 +6856,19 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8188,28 +6898,18 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8244,28 +6944,19 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8299,36 +6990,20 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8366,30 +7041,19 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    scope,
-    location=Location(),
-)
+function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope),]
+    attributes = NamedAttribute[namedattribute("scope", scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixMad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixMad", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8427,36 +7091,20 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8481,25 +7129,19 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(;
-    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
-)
+function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8535,21 +7177,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8585,20 +7223,16 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8628,28 +7262,18 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8685,21 +7309,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8734,28 +7354,19 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8795,32 +7406,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spirv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spirv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8840,25 +7438,18 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(
-    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[sampledimage,]
+function Image(sampledimage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Image", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8897,21 +7488,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8937,28 +7524,18 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8988,23 +7565,18 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsInf(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsInf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9034,23 +7606,18 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsNan(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsNan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9073,20 +7640,16 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.AssumeTrue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.AssumeTrue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9121,21 +7684,17 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.SubgroupBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.SubgroupBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9172,31 +7731,20 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9225,28 +7773,18 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9275,28 +7813,18 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9325,28 +7853,18 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9372,25 +7890,18 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[operand,]
+function LogicalNot(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9419,28 +7930,18 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9474,19 +7975,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9519,24 +8016,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9567,28 +8058,19 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value,
-    scalar::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, scalar]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9631,20 +8113,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9663,16 +8138,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9719,34 +8190,20 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spirv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9771,27 +8228,19 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9848,31 +8297,19 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function NV_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9923,29 +8360,19 @@ For example:
   !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixMulAdd(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9988,31 +8415,19 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function NV_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10042,23 +8457,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10089,28 +8500,18 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Ordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10159,28 +8560,18 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10204,21 +8595,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrCastToGeneric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrCastToGeneric", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10248,21 +8635,17 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spirv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spirv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10283,16 +8666,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10319,20 +8698,16 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10362,21 +8737,17 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10408,28 +8779,19 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10472,30 +8834,19 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10533,25 +8884,19 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10581,28 +8926,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10632,28 +8967,18 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10683,28 +9008,18 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10734,28 +9049,18 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10788,28 +9093,19 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10838,24 +9134,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10879,25 +9169,19 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10930,28 +9214,19 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10996,30 +9271,19 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11059,25 +9323,19 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11120,29 +9378,19 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11170,19 +9418,15 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11222,28 +9466,19 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11280,28 +9515,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11339,28 +9565,19 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11405,21 +9622,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11459,19 +9668,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11545,21 +9748,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11592,27 +9791,20 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11645,21 +9837,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11690,21 +9878,17 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11735,28 +9919,19 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11801,30 +9976,19 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11864,25 +10028,19 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11912,28 +10070,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11963,28 +10111,18 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12014,28 +10152,18 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12065,28 +10193,18 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12117,28 +10235,19 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12168,24 +10277,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12212,21 +10315,17 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12257,28 +10356,18 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Unordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12299,16 +10388,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12346,28 +10431,19 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spirv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12393,25 +10469,18 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12449,29 +10518,19 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12512,24 +10571,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spirv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spirv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12551,24 +10604,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12593,20 +10640,16 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SPIRV.jl
+++ b/src/Dialects/16/SPIRV.jl
@@ -1,8 +1,8 @@
 module spirv
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `AccessChain`
@@ -46,18 +46,24 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
-    results = IR.Type[component_ptr, ]
-    operands = Value[base_ptr, indices..., ]
+function AccessChain(
+    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
+)
+    results = IR.Type[component_ptr,]
+    operands = Value[base_ptr, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.AccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.AccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,17 +92,21 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer, ]
+    results = IR.Type[pointer,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable), ]
-    
-    IR.create_operation(
-        "spirv.mlir.addressof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable),]
+
+    return IR.create_operation(
+        "spirv.mlir.addressof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -137,18 +147,31 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicAnd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicAnd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -198,18 +221,35 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, comparator, ]
+function AtomicCompareExchange(
+    pointer::Value,
+    value::Value,
+    comparator::Value;
+    result::IR.Type,
+    memory_scope,
+    equal_semantics,
+    unequal_semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value, comparator]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicCompareExchange", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("equal_semantics", equal_semantics),
+        namedattribute("unequal_semantics", unequal_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicCompareExchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -237,18 +277,35 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, comparator, ]
+function AtomicCompareExchangeWeak(
+    pointer::Value,
+    value::Value,
+    comparator::Value;
+    result::IR.Type,
+    memory_scope,
+    equal_semantics,
+    unequal_semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value, comparator]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("equal_semantics", equal_semantics),
+        namedattribute("unequal_semantics", unequal_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -285,18 +342,31 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicExchange(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicExchange", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicExchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -333,18 +403,31 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicIAdd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicIAdd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -380,18 +463,26 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+function AtomicIDecrement(
+    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicIDecrement", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicIDecrement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -426,18 +517,26 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+function AtomicIIncrement(
+    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicIIncrement", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicIIncrement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -475,18 +574,31 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicISub(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicISub", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicISub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -523,18 +635,31 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicOr(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicOr", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -572,18 +697,31 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicSMax(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicSMax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -621,18 +759,31 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicSMin(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicSMin", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -670,18 +821,31 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicUMax(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicUMax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -719,18 +883,31 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicUMin(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicUMin", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -768,18 +945,31 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicXor(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicXor", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -815,19 +1005,25 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitCount(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitCount", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitCount",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -873,19 +1069,30 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldInsert(
+    base::Value,
+    insert::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, insert, offset, count, ]
+    operands = Value[base, insert, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitFieldInsert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitFieldInsert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -931,19 +1138,29 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldSExtract(
+    base::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, offset, count, ]
+    operands = Value[base, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitFieldSExtract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitFieldSExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -971,19 +1188,29 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldUExtract(
+    base::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, offset, count, ]
+    operands = Value[base, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitFieldUExtract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitFieldUExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1015,19 +1242,25 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitReverse(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitReverse", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitReverse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1071,17 +1304,21 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1111,19 +1348,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseAnd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitwiseAnd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitwiseAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1153,19 +1399,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseOr(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitwiseOr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitwiseOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1195,19 +1450,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseXor(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitwiseXor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitwiseXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1245,20 +1509,36 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
+function BranchConditional(
+    condition::Value,
+    trueTargetOperands::Vector{Value},
+    falseTargetOperands::Vector{Value};
+    branch_weights=nothing,
+    trueTarget::Block,
+    falseTarget::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget, ]
+    successors = Block[trueTarget, falseTarget]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "spirv.BranchConditional", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
+    )
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "spirv.BranchConditional",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1284,16 +1564,20 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands..., ]
+    operands = Value[targetOperands...,]
     owned_regions = Region[]
-    successors = Block[target, ]
+    successors = Block[target,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Branch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1322,19 +1606,25 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_ceil(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1363,19 +1653,23 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1404,19 +1698,23 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1445,19 +1743,23 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1486,19 +1788,25 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fabs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fabs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fabs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1528,19 +1836,25 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fmax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fmax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1569,19 +1883,25 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fmin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fmin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fmin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1610,19 +1930,25 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_floor(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1649,19 +1975,29 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fma(
+    x::Value,
+    y::Value,
+    z::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, z, ]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1690,19 +2026,23 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1732,19 +2072,25 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1773,19 +2119,25 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_rint(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.rint", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.rint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1813,19 +2165,25 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_round(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1854,19 +2212,25 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_rsqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1895,19 +2259,25 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_abs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.s_abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.s_abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1933,19 +2303,25 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.s_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.s_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1971,19 +2347,25 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.s_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.s_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2012,19 +2394,23 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2053,19 +2439,25 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_sqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2094,19 +2486,25 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_tanh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2132,19 +2530,25 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_u_max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.u_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.u_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2170,19 +2574,25 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_u_min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.u_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.u_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2220,18 +2630,24 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[constituents..., ]
+function CompositeConstruct(
+    constituents::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[constituents...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.CompositeConstruct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CompositeConstruct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2264,18 +2680,24 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
-    results = IR.Type[component, ]
-    operands = Value[composite, ]
+function CompositeExtract(
+    composite::Value; component::IR.Type, indices, location=Location()
+)
+    results = IR.Type[component,]
+    operands = Value[composite,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices), ]
-    
-    IR.create_operation(
-        "spirv.CompositeExtract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices),]
+
+    return IR.create_operation(
+        "spirv.CompositeExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2308,18 +2730,24 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[object, composite, ]
+function CompositeInsert(
+    object::Value, composite::Value; result::IR.Type, indices, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[object, composite]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices), ]
-    
-    IR.create_operation(
-        "spirv.CompositeInsert", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices),]
+
+    return IR.create_operation(
+        "spirv.CompositeInsert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2359,17 +2787,21 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant, ]
+    results = IR.Type[constant,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "spirv.Constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "spirv.Constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2419,18 +2851,28 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
+function ControlBarrier(;
+    execution_scope, memory_scope, memory_semantics, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
-    
-    IR.create_operation(
-        "spirv.ControlBarrier", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("memory_semantics", memory_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.ControlBarrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2459,17 +2901,21 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertFToS", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertFToS",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2499,17 +2945,21 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertFToU", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertFToU",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2538,17 +2988,21 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertSToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertSToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2577,17 +3031,21 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertUToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertUToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2620,22 +3078,37 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
+function CopyMemory(
+    target::Value,
+    source::Value;
+    memory_access=nothing,
+    alignment=nothing,
+    source_memory_access=nothing,
+    source_alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, source, ]
+    operands = Value[target, source]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
-    
-    IR.create_operation(
-        "spirv.CopyMemory", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(source_memory_access) &&
+        push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) &&
+        push!(attributes, namedattribute("source_alignment", source_alignment))
+
+    return IR.create_operation(
+        "spirv.CopyMemory",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2677,18 +3150,31 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function EXT_AtomicFAdd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.EXT.AtomicFAdd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.EXT.AtomicFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2738,13 +3224,21 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
-    
-    IR.create_operation(
-        "spirv.EntryPoint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("execution_model", execution_model),
+        namedattribute("fn", fn),
+        namedattribute("interface", interface),
+    ]
+
+    return IR.create_operation(
+        "spirv.EntryPoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2782,13 +3276,21 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
-    
-    IR.create_operation(
-        "spirv.ExecutionMode", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("fn", fn),
+        namedattribute("execution_mode", execution_mode),
+        namedattribute("values", values),
+    ]
+
+    return IR.create_operation(
+        "spirv.ExecutionMode",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2816,19 +3318,28 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FAdd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2858,17 +3369,21 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2898,19 +3413,28 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2941,19 +3465,28 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2983,19 +3516,28 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FMul(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3023,19 +3565,25 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FNegate(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FNegate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FNegate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3065,18 +3613,28 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3106,18 +3664,28 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3147,18 +3715,28 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3188,18 +3766,28 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdLessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3229,18 +3817,28 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdLessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdLessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3270,18 +3868,28 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdNotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdNotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3313,19 +3921,28 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FRem(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FRem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FRem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3354,19 +3971,28 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FSub(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FSub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FSub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3396,18 +4022,28 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3437,18 +4073,28 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3478,18 +4124,28 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3519,18 +4175,28 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordLessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3560,18 +4226,28 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordLessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordLessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3601,18 +4277,28 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordNotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordNotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3645,20 +4331,36 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, body::Region, location=Location())
+function func(;
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_name,
+    function_control,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
+    attributes = NamedAttribute[
+        namedattribute("function_type", function_type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("function_control", function_control),
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "spirv.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3692,19 +4394,28 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
+function FunctionCall(
+    arguments::Vector{Value};
+    return_value=nothing::Union{Nothing,IR.Type},
+    callee,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arguments..., ]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    attributes = NamedAttribute[namedattribute("callee", callee),]
     !isnothing(return_value) && push!(results, return_value)
-    
-    IR.create_operation(
-        "spirv.FunctionCall", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FunctionCall",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3737,19 +4448,25 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Acos(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Acos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Acos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3782,19 +4499,25 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Asin(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Asin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Asin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3827,19 +4550,25 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Atan(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Atan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Atan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3869,19 +4598,25 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Ceil(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3912,19 +4647,23 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3955,19 +4694,25 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Cosh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Cosh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Cosh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3998,19 +4743,23 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4039,19 +4788,25 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FAbs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FAbs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FAbs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4081,17 +4836,21 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.FClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4121,19 +4880,25 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4163,19 +4928,25 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4197,19 +4968,29 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMix(
+    x::Value,
+    y::Value,
+    a::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, a, ]
+    operands = Value[x, y, a]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FMix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FMix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4238,19 +5019,25 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FSign(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FSign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FSign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4267,19 +5054,25 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FindUMsb(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FindUMsb", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FindUMsb",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4309,19 +5102,25 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Floor(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4361,17 +5160,21 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.Fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4414,17 +5217,21 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.FrexpStruct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FrexpStruct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4453,19 +5260,25 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_InverseSqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.InverseSqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.InverseSqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4503,19 +5316,25 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Ldexp(
+    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, exp, ]
+    operands = Value[x, exp]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-    
-    IR.create_operation(
-        "spirv.GL.Ldexp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Ldexp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4547,19 +5366,23 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4592,19 +5415,25 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4635,19 +5464,25 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_RoundEven(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.RoundEven", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.RoundEven",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4679,19 +5514,25 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Round(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4719,19 +5560,25 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SAbs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SAbs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SAbs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4760,17 +5607,21 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.SClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4799,19 +5650,25 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4840,19 +5697,25 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4880,19 +5743,25 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SSign(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SSign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SSign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4923,19 +5792,23 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4966,19 +5839,25 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sinh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Sinh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Sinh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5007,19 +5886,25 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5050,19 +5935,23 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5093,19 +5982,25 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Tanh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5134,17 +6029,21 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.UClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.UClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5173,19 +6072,25 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_UMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.UMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.UMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5214,19 +6119,25 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_UMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.UMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.UMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5253,17 +6164,21 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GenericCastToPtrExplicit", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GenericCastToPtrExplicit",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5287,17 +6202,21 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GenericCastToPtr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GenericCastToPtr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5341,23 +6260,39 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, location=Location())
+function GlobalVariable(;
+    type,
+    sym_name,
+    initializer=nothing,
+    location_=nothing,
+    binding=nothing,
+    descriptor_set=nothing,
+    builtin=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[
+        namedattribute("type", type), namedattribute("sym_name", sym_name)
+    ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) &&
+        push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-    
-    IR.create_operation(
-        "spirv.GlobalVariable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GlobalVariable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5406,19 +6341,29 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupBroadcast(
+    value::Value,
+    localid::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, localid, ]
+    operands = Value[value, localid]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupBroadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupBroadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5454,19 +6399,32 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupFAdd(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupFAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5502,19 +6460,32 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupFMax(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupFMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupFMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5550,19 +6521,32 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupFMin(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupFMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupFMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5599,19 +6583,32 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function KHR_GroupFMul(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.KHR.GroupFMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.GroupFMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5647,19 +6644,32 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupIAdd(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupIAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5696,19 +6706,32 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function KHR_GroupIMul(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.KHR.GroupIMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.GroupIMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5741,18 +6764,24 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[predicate, ]
+function GroupNonUniformBallot(
+    predicate::Value; result::IR.Type, execution_scope, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[predicate,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformBallot", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformBallot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5797,19 +6826,29 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformBroadcast(
+    value::Value,
+    id::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, id, ]
+    operands = Value[value, id]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformBroadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformBroadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5834,19 +6873,25 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformElect(;
+    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformElect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformElect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5892,19 +6937,33 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFAdd(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5953,19 +7012,33 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6014,19 +7087,33 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6072,19 +7159,33 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMul(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6128,19 +7229,33 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformIAdd(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformIAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6184,19 +7299,33 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformIMul(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformIMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformIMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6240,19 +7369,33 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformSMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformSMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6296,19 +7439,33 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformSMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformSMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6337,19 +7494,29 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffleDown(
+    value::Value,
+    delta::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, delta, ]
+    operands = Value[value, delta]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6376,19 +7543,29 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffle(
+    value::Value,
+    id::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, id, ]
+    operands = Value[value, id]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6416,19 +7593,29 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffleUp(
+    value::Value,
+    delta::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, delta, ]
+    operands = Value[value, delta]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6456,19 +7643,29 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffleXor(
+    value::Value,
+    mask::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, mask, ]
+    operands = Value[value, mask]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6513,19 +7710,33 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformUMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformUMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6570,19 +7781,33 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformUMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformUMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6619,19 +7844,32 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupSMax(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupSMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6668,19 +7906,32 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupSMin(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupSMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6716,19 +7967,32 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupUMax(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupUMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6765,19 +8029,32 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupUMin(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupUMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6811,17 +8088,21 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IAddCarry", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.IAddCarry",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6856,19 +8137,28 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function IAdd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.IAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.IAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6898,18 +8188,28 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function IEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.IEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6944,19 +8244,28 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function IMul(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.IMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.IMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6990,20 +8299,36 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, stride, ]
+function INTEL_JointMatrixLoad(
+    pointer::Value,
+    stride::Value;
+    result::IR.Type,
+    layout,
+    scope,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, stride]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[
+        namedattribute("layout", layout), namedattribute("scope", scope)
+    ]
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7041,19 +8366,30 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
+function INTEL_JointMatrixMad(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope), ]
+    attributes = NamedAttribute[namedattribute("scope", scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixMad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixMad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7091,20 +8427,36 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+function INTEL_JointMatrixStore(
+    pointer::Value,
+    object::Value,
+    stride::Value;
+    layout,
+    scope,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[pointer, object, stride, ]
+    operands = Value[pointer, object, stride]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[
+        namedattribute("layout", layout), namedattribute("scope", scope)
+    ]
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixStore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixStore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7129,19 +8481,25 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
+function INTEL_JointMatrixWorkItemLength(;
+    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7177,17 +8535,21 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[ptr, ]
+    results = IR.Type[value,]
+    operands = Value[ptr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7223,16 +8585,20 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value, ]
+    operands = Value[ptr, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7262,18 +8628,28 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function INotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.INotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7309,17 +8685,21 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ISubBorrow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ISubBorrow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7354,19 +8734,28 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ISub(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ISub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ISub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7406,19 +8795,32 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
+function ImageDrefGather(
+    sampledimage::Value,
+    coordinate::Value,
+    dref::Value,
+    operand_arguments::Vector{Value};
+    result::IR.Type,
+    imageoperands=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
-    
-    IR.create_operation(
-        "spirv.ImageDrefGather", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(imageoperands) &&
+        push!(attributes, namedattribute("imageoperands", imageoperands))
+
+    return IR.create_operation(
+        "spirv.ImageDrefGather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7438,18 +8840,25 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(sampledimage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sampledimage, ]
+function Image(
+    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[sampledimage,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Image", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.Image",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7488,17 +8897,21 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[image, ]
+    results = IR.Type[result,]
+    operands = Value[image,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ImageQuerySize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ImageQuerySize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7524,18 +8937,28 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base_ptr, element, indices..., ]
+function InBoundsPtrAccessChain(
+    base_ptr::Value,
+    element::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base_ptr, element, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.InBoundsPtrAccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.InBoundsPtrAccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7565,18 +8988,23 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IsInf", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.IsInf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7606,18 +9034,23 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IsNan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.IsNan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7640,16 +9073,20 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition, ]
+    operands = Value[condition,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.KHR.AssumeTrue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.AssumeTrue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7684,17 +9121,21 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[predicate, ]
+    results = IR.Type[result,]
+    operands = Value[predicate,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.KHR.SubgroupBallot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.SubgroupBallot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7731,20 +9172,31 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[ptr, ]
+function Load(
+    ptr::Value;
+    value::IR.Type,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[ptr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.Load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7773,18 +9225,28 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalAnd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalAnd", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7813,18 +9275,28 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7853,18 +9325,28 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalNotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalNotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7890,18 +9372,25 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+function LogicalNot(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalNot", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalNot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7930,18 +9419,28 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalOr(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalOr", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7975,15 +9474,19 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
-    
-    IR.create_operation(
-        "spirv.mlir.loop", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
+
+    return IR.create_operation(
+        "spirv.mlir.loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8016,18 +9519,24 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[leftmatrix, rightmatrix, ]
+function MatrixTimesMatrix(
+    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[leftmatrix, rightmatrix]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.MatrixTimesMatrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.MatrixTimesMatrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8058,19 +9567,28 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function MatrixTimesScalar(
+    matrix::Value,
+    scalar::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[matrix, scalar, ]
+    operands = Value[matrix, scalar]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.MatrixTimesScalar", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.MatrixTimesScalar",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8113,13 +9631,20 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
-    
-    IR.create_operation(
-        "spirv.MemoryBarrier", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("memory_semantics", memory_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.MemoryBarrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8138,12 +9663,16 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.mlir.merge", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.mlir.merge",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8190,20 +9719,34 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
+function module_(;
+    addressing_model,
+    memory_model,
+    vce_triple=nothing,
+    sym_name=nothing,
+    region_0::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0, ]
+    owned_regions = Region[region_0,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
+    attributes = NamedAttribute[
+        namedattribute("addressing_model", addressing_model),
+        namedattribute("memory_model", memory_model),
+    ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    
-    IR.create_operation(
-        "spirv.module", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8228,19 +9771,27 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
+function NV_CooperativeMatrixLength(;
+    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
+    attributes = NamedAttribute[namedattribute(
+        "cooperative_matrix_type", cooperative_matrix_type
+    ),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8297,19 +9848,31 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.coopmatrix<i32, Workgroup, 16, 8>
 ```
 """
-function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, stride, columnmajor, ]
+function NV_CooperativeMatrixLoad(
+    pointer::Value,
+    stride::Value,
+    columnmajor::Value;
+    result::IR.Type,
+    memory_access=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, stride, columnmajor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8360,19 +9923,29 @@ For example:
   !spirv.coopmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function NV_CooperativeMatrixMulAdd(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8415,19 +9988,31 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<Workgroup, i32, 16, 8>
 ```
 """
-function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
+function NV_CooperativeMatrixStore(
+    pointer::Value,
+    object::Value,
+    stride::Value,
+    columnmajor::Value;
+    memory_access=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor, ]
+    operands = Value[pointer, object, stride, columnmajor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8457,19 +10042,23 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.Not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8500,18 +10089,28 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function Ordered(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Ordered", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.Ordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8560,18 +10159,28 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base_ptr, element, indices..., ]
+function PtrAccessChain(
+    base_ptr::Value,
+    element::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base_ptr, element, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.PtrAccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.PtrAccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8595,17 +10204,21 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.PtrCastToGeneric", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.PtrCastToGeneric",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8635,17 +10248,21 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference, ]
+    results = IR.Type[reference,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
-    
-    IR.create_operation(
-        "spirv.mlir.referenceof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
+
+    return IR.create_operation(
+        "spirv.mlir.referenceof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8666,12 +10283,16 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8698,16 +10319,20 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ReturnValue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ReturnValue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8737,17 +10362,21 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8779,19 +10408,28 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8834,19 +10472,30 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, accumulator, ]
+function SDotAccSat(
+    vector1::Value,
+    vector2::Value,
+    accumulator::Value;
+    result::IR.Type,
+    format=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SDotAccSat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SDotAccSat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8884,19 +10533,25 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function SDot(
+    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SDot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SDot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8926,18 +10581,28 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8967,18 +10632,28 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9008,18 +10683,28 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SLessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9049,18 +10734,28 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SLessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SLessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9093,19 +10788,28 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9134,18 +10838,24 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SMulExtended(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SMulExtended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SMulExtended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9169,19 +10879,25 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SNegate(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SNegate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SNegate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9214,19 +10930,28 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SRem(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SRem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SRem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9271,19 +10996,30 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, accumulator, ]
+function SUDotAccSat(
+    vector1::Value,
+    vector2::Value,
+    accumulator::Value;
+    result::IR.Type,
+    format=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SUDotAccSat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SUDotAccSat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9323,19 +11059,25 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function SUDot(
+    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SUDot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SUDot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9378,19 +11120,29 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function Select(
+    condition::Value,
+    true_value::Value,
+    false_value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value, ]
+    operands = Value[condition, true_value, false_value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.Select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9418,15 +11170,19 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
-    
-    IR.create_operation(
-        "spirv.mlir.selection", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
+
+    return IR.create_operation(
+        "spirv.mlir.selection",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9466,19 +11222,28 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftLeftLogical(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ShiftLeftLogical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ShiftLeftLogical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9515,19 +11280,28 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftRightArithmetic(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ShiftRightArithmetic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ShiftRightArithmetic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9565,19 +11339,28 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftRightLogical(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ShiftRightLogical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ShiftRightLogical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9622,13 +11405,21 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
-    
-    IR.create_operation(
-        "spirv.SpecConstantComposite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("type", type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("constituents", constituents),
+    ]
+
+    return IR.create_operation(
+        "spirv.SpecConstantComposite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9668,13 +11459,19 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
-    
-    IR.create_operation(
-        "spirv.SpecConstant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
+    ]
+
+    return IR.create_operation(
+        "spirv.SpecConstant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9748,17 +11545,21 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SpecConstantOperation", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SpecConstantOperation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9791,20 +11592,27 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
+function Store(
+    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[ptr, value, ]
+    operands = Value[ptr, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.Store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9837,17 +11645,21 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[matrix, ]
+    results = IR.Type[result,]
+    operands = Value[matrix,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9878,17 +11690,21 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9919,19 +11735,28 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function UDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.UDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9976,19 +11801,30 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, accumulator, ]
+function UDotAccSat(
+    vector1::Value,
+    vector2::Value,
+    accumulator::Value;
+    result::IR.Type,
+    format=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.UDotAccSat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UDotAccSat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10028,19 +11864,25 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function UDot(
+    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.UDot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UDot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10070,18 +11912,28 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.UGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10111,18 +11963,28 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.UGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10152,18 +12014,28 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function ULessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ULessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.ULessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10193,18 +12065,28 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function ULessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ULessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.ULessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10235,19 +12117,28 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function UMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.UMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10277,18 +12168,24 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UMulExtended(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UMulExtended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UMulExtended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10315,17 +12212,21 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Undef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Undef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10356,18 +12257,28 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function Unordered(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Unordered", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.Unordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10388,12 +12299,16 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Unreachable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Unreachable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10431,19 +12346,28 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
-    results = IR.Type[pointer, ]
+function Variable(
+    initializer=nothing::Union{Nothing,Value};
+    pointer::IR.Type,
+    storage_class,
+    location=Location(),
+)
+    results = IR.Type[pointer,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
     !isnothing(initializer) && push!(operands, initializer)
-    
-    IR.create_operation(
-        "spirv.Variable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Variable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10469,18 +12393,25 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, index, ]
+function VectorExtractDynamic(
+    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[vector, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.VectorExtractDynamic", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.VectorExtractDynamic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10518,19 +12449,29 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function VectorInsertDynamic(
+    vector::Value,
+    component::Value,
+    index::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, component, index, ]
+    operands = Value[vector, component, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.VectorInsertDynamic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.VectorInsertDynamic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10571,18 +12512,24 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function VectorShuffle(
+    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components), ]
-    
-    IR.create_operation(
-        "spirv.VectorShuffle", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("components", components),]
+
+    return IR.create_operation(
+        "spirv.VectorShuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10604,18 +12551,24 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, scalar, ]
+function VectorTimesScalar(
+    vector::Value, scalar::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector, scalar]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.VectorTimesScalar", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.VectorTimesScalar",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10640,16 +12593,20 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.mlir.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.mlir.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Shape.jl
+++ b/src/Dialects/16/Shape.jl
@@ -1,9 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -15,25 +14,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -54,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -124,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -260,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -289,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -324,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -361,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -396,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -437,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -467,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -495,25 +422,19 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(
-    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, index]
+    operands = Value[value, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -534,25 +455,19 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -563,25 +478,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -598,25 +507,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -627,36 +530,21 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -679,28 +567,19 @@ shape.function_library {
 }
 ```
 """
-function function_library(;
-    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
-)
+function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,25 +589,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -741,25 +614,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -781,25 +648,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -811,25 +672,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -860,30 +715,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -895,25 +740,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -927,25 +766,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -958,25 +791,19 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -985,23 +812,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1039,28 +862,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1071,22 +884,18 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1099,25 +908,19 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1127,23 +930,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1155,25 +954,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1201,24 +994,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1232,21 +1019,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1269,21 +1052,17 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1295,21 +1074,17 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_of", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1123,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1377,22 +1143,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Shape.jl
+++ b/src/Dialects/16/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add`
@@ -14,19 +14,25 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -47,17 +53,21 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[inputs..., ]
+    results = IR.Type[result,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.any", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -81,19 +91,25 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function assuming_all(
+    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[inputs..., ]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.assuming_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -107,18 +123,24 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[witness, ]
-    owned_regions = Region[doRegion, ]
+function assuming(
+    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[witness,]
+    owned_regions = Region[doRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.assuming", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -130,18 +152,22 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands_::Vector{Value}; location=Location())
+function assuming_yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.assuming_yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming_yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -168,19 +194,25 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[shapes..., ]
+function broadcast(
+    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-    
-    IR.create_operation(
-        "shape.broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -196,17 +228,21 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.concat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.concat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -223,19 +259,23 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape), ]
+    attributes = NamedAttribute[namedattribute("shape", shape),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -248,19 +288,23 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -279,19 +323,25 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
+function const_witness(;
+    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing), ]
+    attributes = NamedAttribute[namedattribute("passing", passing),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_witness", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_witness",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -310,19 +360,25 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cstr_broadcastable(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_broadcastable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_broadcastable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -339,19 +395,25 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cstr_eq(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -374,19 +436,25 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
+function cstr_require(
+    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
+)
     results = IR.Type[]
-    operands = Value[pred, ]
+    operands = Value[pred,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    attributes = NamedAttribute[namedattribute("msg", msg),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_require", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_require",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -398,17 +466,21 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.debug_print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.debug_print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -422,19 +494,25 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, index, ]
+    operands = Value[value, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-    
-    IR.create_operation(
-        "shape.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -455,19 +533,25 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function div(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -478,19 +562,25 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function from_extent_tensor(
+    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.from_extent_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.from_extent_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -507,19 +597,25 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
+function from_extents(
+    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[extents..., ]
+    operands = Value[extents...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-    
-    IR.create_operation(
-        "shape.from_extents", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.from_extents",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -530,21 +626,36 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_visibility=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "shape.func", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "shape.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -567,19 +678,28 @@ shape.function_library {
 }
 ```
 """
-function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
+function function_library(;
+    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "shape.function_library", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "shape.function_library",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -589,19 +709,25 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
+function get_extent(
+    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shape, dim, ]
+    operands = Value[shape, dim]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-    
-    IR.create_operation(
-        "shape.get_extent", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.get_extent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -614,19 +740,25 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function index_to_size(
+    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.index_to_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.index_to_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -648,19 +780,25 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function is_broadcastable(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.is_broadcastable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.is_broadcastable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -672,19 +810,25 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -715,20 +859,30 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
+function meet(
+    arg0::Value,
+    arg1::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    error=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arg0, arg1, ]
+    operands = Value[arg0, arg1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-    
-    IR.create_operation(
-        "shape.meet", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.meet",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -740,19 +894,25 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -766,19 +926,25 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -791,19 +957,25 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function num_elements(
+    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shape, ]
+    operands = Value[shape,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.num_elements", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.num_elements",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -812,19 +984,23 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, ]
+    operands = Value[shape,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "shape.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -862,18 +1038,28 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[shape, initVals..., ]
-    owned_regions = Region[region, ]
+function reduce(
+    shape::Value,
+    initVals::Vector{Value};
+    result::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[shape, initVals...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -884,18 +1070,22 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -908,19 +1098,25 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shape_eq(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.shape_eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.shape_eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -930,19 +1126,23 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.shape_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.shape_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -954,19 +1154,25 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function size_to_index(
+    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.size_to_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.size_to_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -994,18 +1200,24 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
-    results = IR.Type[head, tail, ]
-    operands = Value[operand, index, ]
+function split_at(
+    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
+)
+    results = IR.Type[head, tail]
+    operands = Value[operand, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.split_at", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.split_at",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1019,17 +1231,21 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[input, ]
+    results = IR.Type[result,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.to_extent_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.to_extent_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1052,17 +1268,21 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arg, ]
+    results = IR.Type[result,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.value_as_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.value_as_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1074,17 +1294,21 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arg, ]
+    results = IR.Type[result,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.value_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.value_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1123,19 +1347,28 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function with_shape(
+    operand::Value,
+    shape::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, shape, ]
+    operands = Value[operand, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.with_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.with_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1143,18 +1376,22 @@ end
 `yield`
 
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Shape.jl
+++ b/src/Dialects/16/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -14,25 +14,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -53,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -91,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -123,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -228,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -259,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -288,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -360,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -395,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -436,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -466,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -494,25 +422,19 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(
-    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, index]
+    operands = Value[value, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -533,25 +455,19 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -562,25 +478,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -597,25 +507,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -626,36 +530,21 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -678,28 +567,19 @@ shape.function_library {
 }
 ```
 """
-function function_library(;
-    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
-)
+function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,25 +589,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -740,25 +614,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -780,25 +648,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -810,25 +672,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -859,30 +715,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,25 +740,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -926,25 +766,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -957,25 +791,19 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -984,23 +812,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1038,28 +862,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1070,22 +884,18 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1098,25 +908,19 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1126,23 +930,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1154,25 +954,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1200,24 +994,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1231,21 +1019,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1268,21 +1052,17 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1294,21 +1074,17 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_of", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1347,28 +1123,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1376,22 +1143,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SparseTensor.jl
+++ b/src/Dialects/16/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `binary`
@@ -105,20 +105,36 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[x, y, ]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
+function binary(
+    x::Value,
+    y::Value;
+    output::IR.Type,
+    left_identity=nothing,
+    right_identity=nothing,
+    overlapRegion::Region,
+    leftRegion::Region,
+    rightRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[x, y]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
-    
-    IR.create_operation(
-        "sparse_tensor.binary", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(left_identity) &&
+        push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) &&
+        push!(attributes, namedattribute("right_identity", right_identity))
+
+    return IR.create_operation(
+        "sparse_tensor.binary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -145,19 +161,32 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function compress(
+    values::Value,
+    filled::Value,
+    added::Value,
+    count::Value,
+    tensor::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, indices..., ]
+    operands = Value[values, filled, added, count, tensor, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "sparse_tensor.compress", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -181,17 +210,21 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[inputs..., ]
+    results = IR.Type[result,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
-    
-    IR.create_operation(
-        "sparse_tensor.concatenate", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+
+    return IR.create_operation(
+        "sparse_tensor.concatenate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -235,17 +268,21 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.convert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.convert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -281,18 +318,29 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
-    results = IR.Type[values, filled, added, count, ]
-    operands = Value[tensor, ]
+function expand(
+    tensor::Value;
+    values::IR.Type,
+    filled::IR.Type,
+    added::IR.Type,
+    count::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[values, filled, added, count]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.expand", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.expand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -358,18 +406,28 @@ sparse_tensor.foreach in %0 : tensor<2x3xf64, #ROW_MAJOR> do {
 
 ```
 """
-function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[tensor, initArgs..., ]
-    owned_regions = Region[region, ]
+function foreach(
+    tensor::Value,
+    initArgs::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[tensor, initArgs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -385,19 +443,25 @@ Example of querying the size of the index array for level 0:
      : !sparse_tensor.storage_specifier<#COO> to i64
 ```
 """
-function storage_specifier_get(specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[specifier, ]
+function storage_specifier_get(
+    specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[specifier,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-    
-    IR.create_operation(
-        "sparse_tensor.storage_specifier.get", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.storage_specifier.get",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -431,19 +495,29 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(value::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function insert(
+    value::Value,
+    tensor::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, tensor, indices..., ]
+    operands = Value[value, tensor, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "sparse_tensor.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -475,20 +549,29 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
+function load(
+    tensor::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    hasInserts=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-    
-    IR.create_operation(
-        "sparse_tensor.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -518,18 +601,23 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, expandSymmetry=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(expandSymmetry) && push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
-    
-    IR.create_operation(
-        "sparse_tensor.new", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(expandSymmetry) &&
+        push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
+
+    return IR.create_operation(
+        "sparse_tensor.new",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -547,19 +635,25 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function number_of_entries(
+    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "sparse_tensor.number_of_entries", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.number_of_entries",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -584,16 +678,20 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest, ]
+    operands = Value[tensor, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.out", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.out",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -641,9 +739,18 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
+function push_back(
+    curSize::Value,
+    inBuffer::Value,
+    value::Value,
+    n=nothing::Union{Nothing,Value};
+    outBuffer=nothing::Union{Nothing,IR.Type},
+    newSize=nothing::Union{Nothing,IR.Type},
+    inbounds=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value, ]
+    operands = Value[curSize, inBuffer, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -651,12 +758,16 @@ function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Uni
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-    
-    IR.create_operation(
-        "sparse_tensor.push_back", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.push_back",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -698,19 +809,30 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
+function reduce(
+    x::Value,
+    y::Value,
+    identity::Value;
+    output=nothing::Union{Nothing,IR.Type},
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, identity, ]
-    owned_regions = Region[region, ]
+    operands = Value[x, y, identity]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "sparse_tensor.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -764,19 +886,25 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
+function select(
+    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, ]
-    owned_regions = Region[region, ]
+    operands = Value[x,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "sparse_tensor.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -794,20 +922,31 @@ Example of updating the sizes of the index array for level 0:
 
 ```
 """
-function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, dim=nothing, location=Location())
+function storage_specifier_set(
+    specifier::Value,
+    value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    specifierKind,
+    dim=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[specifier, value, ]
+    operands = Value[specifier, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
     !isnothing(result) && push!(results, result)
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-    
-    IR.create_operation(
-        "sparse_tensor.storage_specifier.set", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.storage_specifier.set",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -838,21 +977,33 @@ sparse_tensor.sort %n, %xy jointly %y1 { nx = 2 : index, ny = 2 : index}
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, stable=nothing, location=Location())
+function sort_coo(
+    n::Value,
+    xy::Value,
+    ys::Vector{Value};
+    nx=nothing,
+    ny=nothing,
+    stable=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[n, xy, ys..., ]
+    operands = Value[n, xy, ys...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-    
-    IR.create_operation(
-        "sparse_tensor.sort_coo", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.sort_coo",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -895,20 +1046,26 @@ sparse_tensor.sort stable %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location())
+function sort(
+    n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[n, xs..., ys..., ]
+    operands = Value[n, xs..., ys...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-    
-    IR.create_operation(
-        "sparse_tensor.sort", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.sort",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -925,17 +1082,21 @@ the sizes for tensor dimensions, pointer arrays, index arrays, and the value arr
 ```
 """
 function storage_specifier_init(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.storage_specifier.init", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.storage_specifier.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -962,17 +1123,21 @@ and (3, 6).
 ```
 """
 function indices_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.indices_buffer", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.indices_buffer",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -995,17 +1160,21 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function indices(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
-    
-    IR.create_operation(
-        "sparse_tensor.indices", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+
+    return IR.create_operation(
+        "sparse_tensor.indices",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1028,17 +1197,21 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function pointers(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
-    
-    IR.create_operation(
-        "sparse_tensor.pointers", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+
+    return IR.create_operation(
+        "sparse_tensor.pointers",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1060,17 +1233,21 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.values", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.values",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1140,18 +1317,28 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[x, ]
-    owned_regions = Region[presentRegion, absentRegion, ]
+function unary(
+    x::Value;
+    output::IR.Type,
+    presentRegion::Region,
+    absentRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[x,]
+    owned_regions = Region[presentRegion, absentRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.unary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.unary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1172,19 +1359,23 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing, Value}; location=Location())
+function yield(result=nothing::Union{Nothing,Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-    
-    IR.create_operation(
-        "sparse_tensor.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/SparseTensor.jl
+++ b/src/Dialects/16/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `binary`
@@ -105,36 +105,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,32 +145,19 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value,
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, indices...]
+    operands = Value[values, filled, added, count, tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -210,21 +181,17 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.concatenate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.concatenate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -268,21 +235,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -318,29 +281,18 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -406,28 +358,18 @@ sparse_tensor.foreach in %0 : tensor<2x3xf64, #ROW_MAJOR> do {
 
 ```
 """
-function foreach(
-    tensor::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tensor, initArgs...]
-    owned_regions = Region[region,]
+function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tensor, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -443,25 +385,19 @@ Example of querying the size of the index array for level 0:
      : !sparse_tensor.storage_specifier<#COO> to i64
 ```
 """
-function storage_specifier_get(
-    specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[specifier,]
+function storage_specifier_get(specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[specifier, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.get",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.get", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -495,29 +431,19 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(
-    value::Value,
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert(value::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, tensor, indices...]
+    operands = Value[value, tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -549,29 +475,20 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -601,23 +518,18 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, expandSymmetry=nothing, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(expandSymmetry) &&
-        push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(expandSymmetry) && push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,25 +547,19 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(
-    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.number_of_entries",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.number_of_entries", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -678,20 +584,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -739,18 +641,9 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(
-    curSize::Value,
-    inBuffer::Value,
-    value::Value,
-    n=nothing::Union{Nothing,Value};
-    outBuffer=nothing::Union{Nothing,IR.Type},
-    newSize=nothing::Union{Nothing,IR.Type},
-    inbounds=nothing,
-    location=Location(),
-)
+function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value]
+    operands = Value[curSize, inBuffer, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -758,16 +651,12 @@ function push_back(
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "sparse_tensor.push_back",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.push_back", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -809,30 +698,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -886,25 +764,19 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(
-    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
-)
+function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -922,31 +794,20 @@ Example of updating the sizes of the index array for level 0:
 
 ```
 """
-function storage_specifier_set(
-    specifier::Value,
-    value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    dim=nothing,
-    location=Location(),
-)
+function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, dim=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier, value]
+    operands = Value[specifier, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.set",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.set", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -977,33 +838,21 @@ sparse_tensor.sort %n, %xy jointly %y1 { nx = 2 : index, ny = 2 : index}
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(
-    n::Value,
-    xy::Value,
-    ys::Vector{Value};
-    nx=nothing,
-    ny=nothing,
-    stable=nothing,
-    location=Location(),
-)
+function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, stable=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[n, xy, ys...]
+    operands = Value[n, xy, ys..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-
-    return IR.create_operation(
-        "sparse_tensor.sort_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1046,26 +895,20 @@ sparse_tensor.sort stable %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(
-    n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location()
-)
+function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[n, xs..., ys...]
+    operands = Value[n, xs..., ys..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-
-    return IR.create_operation(
-        "sparse_tensor.sort",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1082,21 +925,17 @@ the sizes for tensor dimensions, pointer arrays, index arrays, and the value arr
 ```
 """
 function storage_specifier_init(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1123,21 +962,17 @@ and (3, 6).
 ```
 """
 function indices_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.indices_buffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.indices_buffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1160,21 +995,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function indices(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.indices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.indices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1197,21 +1028,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function pointers(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.pointers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.pointers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1233,21 +1060,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1317,28 +1140,18 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1359,23 +1172,19 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing,Value}; location=Location())
+function yield(result=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/SparseTensor.jl
+++ b/src/Dialects/16/SparseTensor.jl
@@ -1,9 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `binary`
@@ -106,36 +105,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,32 +145,19 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value,
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, indices...]
+    operands = Value[values, filled, added, count, tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -211,21 +181,17 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.concatenate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.concatenate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -269,21 +235,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -319,29 +281,18 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,28 +358,18 @@ sparse_tensor.foreach in %0 : tensor<2x3xf64, #ROW_MAJOR> do {
 
 ```
 """
-function foreach(
-    tensor::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tensor, initArgs...]
-    owned_regions = Region[region,]
+function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tensor, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,25 +385,19 @@ Example of querying the size of the index array for level 0:
      : !sparse_tensor.storage_specifier<#COO> to i64
 ```
 """
-function storage_specifier_get(
-    specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[specifier,]
+function storage_specifier_get(specifier::Value; result::IR.Type, specifierKind, dim=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[specifier, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.get",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.get", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -496,29 +431,19 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(
-    value::Value,
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert(value::Value, tensor::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, tensor, indices...]
+    operands = Value[value, tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -550,29 +475,20 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -602,23 +518,18 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, expandSymmetry=nothing, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(expandSymmetry) &&
-        push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(expandSymmetry) && push!(attributes, namedattribute("expandSymmetry", expandSymmetry))
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -636,25 +547,19 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(
-    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.number_of_entries",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.number_of_entries", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -679,20 +584,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -740,18 +641,9 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(
-    curSize::Value,
-    inBuffer::Value,
-    value::Value,
-    n=nothing::Union{Nothing,Value};
-    outBuffer=nothing::Union{Nothing,IR.Type},
-    newSize=nothing::Union{Nothing,IR.Type},
-    inbounds=nothing,
-    location=Location(),
-)
+function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value]
+    operands = Value[curSize, inBuffer, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -759,16 +651,12 @@ function push_back(
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "sparse_tensor.push_back",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.push_back", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -810,30 +698,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -887,25 +764,19 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(
-    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
-)
+function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -923,31 +794,20 @@ Example of updating the sizes of the index array for level 0:
 
 ```
 """
-function storage_specifier_set(
-    specifier::Value,
-    value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    dim=nothing,
-    location=Location(),
-)
+function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, dim=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier, value]
+    operands = Value[specifier, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(dim) && push!(attributes, namedattribute("dim", dim))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.set",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.set", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -978,33 +838,21 @@ sparse_tensor.sort %n, %xy jointly %y1 { nx = 2 : index, ny = 2 : index}
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(
-    n::Value,
-    xy::Value,
-    ys::Vector{Value};
-    nx=nothing,
-    ny=nothing,
-    stable=nothing,
-    location=Location(),
-)
+function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, stable=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[n, xy, ys...]
+    operands = Value[n, xy, ys..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-
-    return IR.create_operation(
-        "sparse_tensor.sort_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1047,26 +895,20 @@ sparse_tensor.sort stable %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(
-    n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location()
-)
+function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; stable=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[n, xs..., ys...]
+    operands = Value[n, xs..., ys..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
     !isnothing(stable) && push!(attributes, namedattribute("stable", stable))
-
-    return IR.create_operation(
-        "sparse_tensor.sort",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,21 +925,17 @@ the sizes for tensor dimensions, pointer arrays, index arrays, and the value arr
 ```
 """
 function storage_specifier_init(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1124,21 +962,17 @@ and (3, 6).
 ```
 """
 function indices_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.indices_buffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.indices_buffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1161,21 +995,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function indices(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.indices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.indices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1198,21 +1028,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function pointers(tensor::Value; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.pointers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.pointers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1234,21 +1060,17 @@ scheme (either by calling a support library or through direct code).
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1318,28 +1140,18 @@ the output, while missing values are filled with 1):
   }
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1360,23 +1172,19 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing,Value}; location=Location())
+function yield(result=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Tensor.jl
+++ b/src/Dialects/16/Tensor.jl
@@ -1,9 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `cast`
@@ -29,21 +28,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +68,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -116,25 +107,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -155,21 +140,17 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[dynamicSizes...,]
+    results = IR.Type[result, ]
+    operands = Value[dynamicSizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,21 +180,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -232,28 +209,18 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -318,40 +285,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -374,21 +320,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -489,30 +431,19 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(
-    source::Value,
-    indices::Value;
-    result::IR.Type,
-    gather_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, indices]
+function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -538,24 +469,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -578,29 +503,18 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(
-    scalar::Value,
-    dest::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -659,42 +573,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -737,43 +628,21 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(
-    source::Value,
-    dest::Value,
-    padding_value=nothing::Union{Nothing,Value};
-    inner_tiles::Vector{Value},
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
-    )
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    push!(attributes, operandsegmentsizes([1, 1, (padding_value==nothing) ? 0 : 1length(inner_tiles), ]))
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.pack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -849,36 +718,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -943,40 +796,19 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -992,23 +824,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1047,21 +875,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1165,31 +989,19 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(
-    source::Value,
-    dest::Value,
-    indices::Value;
-    result::IR.Type,
-    scatter_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, indices]
+function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1219,21 +1031,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1261,37 +1069,19 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(
-    source::Value,
-    dest::Value,
-    inner_tiles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1304,20 +1094,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Tensor.jl
+++ b/src/Dialects/16/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `cast`
@@ -28,21 +28,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,21 +68,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,25 +107,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -154,21 +140,17 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[dynamicSizes...,]
+    results = IR.Type[result, ]
+    operands = Value[dynamicSizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,21 +180,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -231,28 +209,18 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -317,40 +285,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -373,21 +320,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -488,30 +431,19 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(
-    source::Value,
-    indices::Value;
-    result::IR.Type,
-    gather_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, indices]
+function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -537,24 +469,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -577,29 +503,18 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(
-    scalar::Value,
-    dest::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -658,42 +573,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -736,43 +628,21 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(
-    source::Value,
-    dest::Value,
-    padding_value=nothing::Union{Nothing,Value};
-    inner_tiles::Vector{Value},
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
-    )
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    push!(attributes, operandsegmentsizes([1, 1, (padding_value==nothing) ? 0 : 1length(inner_tiles), ]))
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.pack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -848,36 +718,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -942,40 +796,19 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -991,23 +824,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1046,21 +875,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1164,31 +989,19 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(
-    source::Value,
-    dest::Value,
-    indices::Value;
-    result::IR.Type,
-    scatter_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, indices]
+function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1218,21 +1031,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1260,37 +1069,19 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(
-    source::Value,
-    dest::Value,
-    inner_tiles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1303,20 +1094,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Tensor.jl
+++ b/src/Dialects/16/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `cast`
@@ -28,17 +28,21 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -68,17 +72,21 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "tensor.collapse_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "tensor.collapse_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -107,19 +115,25 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, index, ]
+    operands = Value[source, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "tensor.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -140,17 +154,21 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamicSizes..., ]
+    results = IR.Type[result,]
+    operands = Value[dynamicSizes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.empty", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.empty",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -180,17 +198,21 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "tensor.expand_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "tensor.expand_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -209,18 +231,28 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, indices..., ]
+function extract(
+    tensor::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[tensor, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.extract", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "tensor.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -285,19 +317,40 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function extract_slice(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.extract_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.extract_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -320,17 +373,21 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[elements..., ]
+    results = IR.Type[result,]
+    operands = Value[elements...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.from_elements", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.from_elements",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -431,19 +488,30 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, indices, ]
+function gather(
+    source::Value,
+    indices::Value;
+    result::IR.Type,
+    gather_dims,
+    unique=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, indices]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-    
-    IR.create_operation(
-        "tensor.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -469,18 +537,24 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamicExtents..., ]
-    owned_regions = Region[body, ]
+function generate(
+    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[dynamicExtents...,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.generate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.generate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -503,18 +577,29 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[scalar, dest, indices..., ]
+function insert(
+    scalar::Value,
+    dest::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[scalar, dest, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.insert", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "tensor.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -573,19 +658,42 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, offsets..., sizes..., strides..., ]
+function insert_slice(
+    source::Value,
+    dest::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[source, dest, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.insert_slice", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
+    )
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "tensor.insert_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -628,21 +736,43 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, inner_tiles..., ]
+function pack(
+    source::Value,
+    dest::Value,
+    padding_value=nothing::Union{Nothing,Value};
+    inner_tiles::Vector{Value},
+    result=nothing::Union{Nothing,IR.Type},
+    outer_dims_perm=nothing,
+    inner_dims_pos,
+    static_inner_tiles,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[source, dest, inner_tiles...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    attributes = NamedAttribute[
+        namedattribute("inner_dims_pos", inner_dims_pos),
+        namedattribute("static_inner_tiles", static_inner_tiles),
+    ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(attributes, operandsegmentsizes([1, 1, (padding_value==nothing) ? 0 : 1length(inner_tiles), ]))
-    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-    
-    IR.create_operation(
-        "tensor.pack", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
+    )
+    !isnothing(result) && push!(results, result)
+    !isnothing(outer_dims_perm) &&
+        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+
+    return IR.create_operation(
+        "tensor.pack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -718,20 +848,36 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, low..., high..., ]
-    owned_regions = Region[region, ]
+function pad(
+    source::Value,
+    low::Vector{Value},
+    high::Vector{Value};
+    result::IR.Type,
+    static_low,
+    static_high,
+    nofold=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, low..., high...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
+    attributes = NamedAttribute[
+        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
+    ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-    
-    IR.create_operation(
-        "tensor.pad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -796,19 +942,40 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
+function parallel_insert_slice(
+    source::Value,
+    dest::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides..., ]
+    operands = Value[source, dest, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.parallel_insert_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.parallel_insert_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -824,19 +991,23 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "tensor.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -875,17 +1046,21 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, shape, ]
+    results = IR.Type[result,]
+    operands = Value[source, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -989,19 +1164,31 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, indices, ]
+function scatter(
+    source::Value,
+    dest::Value,
+    indices::Value;
+    result::IR.Type,
+    scatter_dims,
+    unique=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, dest, indices]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-    
-    IR.create_operation(
-        "tensor.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1031,17 +1218,21 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate, ]
-    operands = Value[input, ]
+    results = IR.Type[aggregate,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.splat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.splat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1069,19 +1260,37 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, inner_tiles..., ]
+function unpack(
+    source::Value,
+    dest::Value,
+    inner_tiles::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    outer_dims_perm=nothing,
+    inner_dims_pos,
+    static_inner_tiles,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[source, dest, inner_tiles...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
-    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-    
-    IR.create_operation(
-        "tensor.unpack", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[
+        namedattribute("inner_dims_pos", inner_dims_pos),
+        namedattribute("static_inner_tiles", static_inner_tiles),
+    ]
+    !isnothing(result) && push!(results, result)
+    !isnothing(outer_dims_perm) &&
+        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+
+    return IR.create_operation(
+        "tensor.unpack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1094,16 +1303,20 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Tosa.jl
+++ b/src/Dialects/16/Tosa.jl
@@ -1,9 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -11,21 +10,17 @@ import ...API
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -121,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,36 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -213,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -305,21 +242,17 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,21 +262,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -356,29 +285,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -388,21 +306,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,21 +327,17 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1...,]
+    results = IR.Type[output, ]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,23 +347,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -463,38 +369,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -503,38 +390,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -560,33 +428,18 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    identifier,
-    config,
-    implementation_attrs,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("identifier", identifier),
-        namedattribute("config", config),
-        namedattribute("implementation_attrs", implementation_attrs),
-    ]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -596,38 +449,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -638,21 +472,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -661,28 +491,19 @@ end
 
 Elementwise comparison operation
 """
-function equal(
-    input1::Value,
-    input2::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1, input2]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -692,21 +513,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -716,21 +533,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -739,31 +552,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -774,21 +575,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -798,21 +595,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -822,21 +615,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -847,21 +636,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,29 +656,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -903,21 +677,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -928,21 +698,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -952,24 +718,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -978,25 +738,19 @@ end
 
 Elementwise logical NOT of input.
 """
-function logical_not(
-    input1::Value; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function logical_not(input1::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1,]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1007,21 +761,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1031,24 +781,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1059,21 +803,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1084,26 +824,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1116,25 +849,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1145,21 +870,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1170,21 +891,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1195,21 +912,17 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1218,26 +931,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1246,32 +952,20 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1282,21 +976,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1310,24 +1000,18 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(
-    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input,]
+function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rfft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rfft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1338,21 +1022,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1362,21 +1042,17 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1386,21 +1062,17 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1410,21 +1082,17 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1434,21 +1102,17 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1458,21 +1122,17 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1482,21 +1142,17 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1520,41 +1176,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1566,21 +1199,17 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1594,29 +1223,18 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(
-    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("scale", scale),
-        namedattribute("offset", offset),
-        namedattribute("border", border),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1628,21 +1246,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1653,21 +1267,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1677,24 +1287,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1703,24 +1307,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1734,21 +1332,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1760,23 +1354,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1787,21 +1375,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1824,21 +1408,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1851,21 +1431,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1875,21 +1451,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1899,38 +1471,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1940,21 +1493,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1966,28 +1515,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2000,20 +1539,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Tosa.jl
+++ b/src/Dialects/16/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -10,17 +10,21 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -31,17 +35,21 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -55,18 +63,29 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[value, multiplier, shift, ]
+function apply_scale(
+    value::Value,
+    multiplier::Value,
+    shift::Value;
+    output::IR.Type,
+    double_round,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[value, multiplier, shift]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
-    
-    IR.create_operation(
-        "tosa.apply_scale", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round),]
+
+    return IR.create_operation(
+        "tosa.apply_scale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -77,17 +96,21 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.argmax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.argmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -97,18 +120,24 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function arithmetic_right_shift(
+    input1::Value, input2::Value; output::IR.Type, round, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round), ]
-    
-    IR.create_operation(
-        "tosa.arithmetic_right_shift", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("round", round),]
+
+    return IR.create_operation(
+        "tosa.arithmetic_right_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -119,19 +148,36 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function avg_pool2d(
+    input::Value;
+    output::IR.Type,
+    kernel,
+    stride,
+    pad,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.avg_pool2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("kernel", kernel),
+        namedattribute("stride", stride),
+        namedattribute("pad", pad),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.avg_pool2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -142,17 +188,21 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -162,17 +212,21 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -183,17 +237,21 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -204,17 +262,21 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -242,17 +304,21 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -262,17 +328,21 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -285,18 +355,29 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function clamp(
+    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
-    
-    IR.create_operation(
-        "tosa.clamp", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("min_int", min_int),
+        namedattribute("max_int", max_int),
+        namedattribute("min_fp", min_fp),
+        namedattribute("max_fp", max_fp),
+    ]
+
+    return IR.create_operation(
+        "tosa.clamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -306,17 +387,21 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.clz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.clz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,17 +412,21 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1..., ]
+    results = IR.Type[output,]
+    operands = Value[input1...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.concat", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.concat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -347,19 +436,23 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.const", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.const",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -369,19 +462,38 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function conv2d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -390,19 +502,38 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function conv3d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.conv3d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.conv3d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -428,18 +559,33 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
+function custom(
+    inputs::Vector{Value};
+    outputs::Vector{IR.Type},
+    identifier,
+    config,
+    implementation_attrs,
+    location=Location(),
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
-    
-    IR.create_operation(
-        "tosa.custom", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("identifier", identifier),
+        namedattribute("config", config),
+        namedattribute("implementation_attrs", implementation_attrs),
+    ]
+
+    return IR.create_operation(
+        "tosa.custom",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -449,19 +595,38 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function depthwise_conv2d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.depthwise_conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.depthwise_conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -472,17 +637,21 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -491,19 +660,28 @@ end
 
 Elementwise comparison operation
 """
-function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
+function equal(
+    input1::Value,
+    input2::Value;
+    output=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[input1, input2, ]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -513,17 +691,21 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -533,17 +715,21 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -552,19 +738,31 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function fully_connected(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.fully_connected", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.fully_connected",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -575,17 +773,21 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[values, indices, ]
+    results = IR.Type[output,]
+    operands = Value[values, indices]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -595,17 +797,21 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.greater_equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.greater_equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -615,17 +821,21 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.greater", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.greater",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -636,17 +846,21 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.identity", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.identity",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -656,18 +870,29 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
-    results = IR.Type[output..., ]
-    operands = Value[cond, inputs..., ]
-    owned_regions = Region[then_branch, else_branch, ]
+function cond_if(
+    cond::Value,
+    inputs::Vector{Value};
+    output::Vector{IR.Type},
+    then_branch::Region,
+    else_branch::Region,
+    location=Location(),
+)
+    results = IR.Type[output...,]
+    operands = Value[cond, inputs...]
+    owned_regions = Region[then_branch, else_branch]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.cond_if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.cond_if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -677,17 +902,21 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -698,17 +927,21 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -718,18 +951,24 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function logical_left_shift(
+    input1::Value, input2::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_left_shift", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_left_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -738,19 +977,25 @@ end
 
 Elementwise logical NOT of input.
 """
-function logical_not(input1::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
+function logical_not(
+    input1::Value; output=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input1, ]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.logical_not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -761,17 +1006,21 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -781,18 +1030,24 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function logical_right_shift(
+    input1::Value, input2::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_right_shift", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_right_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -803,17 +1058,21 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -824,19 +1083,26 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[c, ]
-    operands = Value[a, b, ]
+function matmul(
+    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
+)
+    results = IR.Type[c,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.matmul", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -849,17 +1115,25 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
-    
-    IR.create_operation(
-        "tosa.max_pool2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("kernel", kernel),
+        namedattribute("stride", stride),
+        namedattribute("pad", pad),
+    ]
+
+    return IR.create_operation(
+        "tosa.max_pool2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -870,17 +1144,21 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.maximum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.maximum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -891,17 +1169,21 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.minimum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.minimum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -912,17 +1194,21 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift), ]
-    
-    IR.create_operation(
-        "tosa.mul", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift),]
+
+    return IR.create_operation(
+        "tosa.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -931,19 +1217,26 @@ end
 
 Elementwise negation operation
 """
-function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+function negate(
+    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.negate", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.negate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -952,20 +1245,32 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, padding, ]
+function pad(
+    input1::Value,
+    padding::Value,
+    pad_const=nothing::Union{Nothing,Value};
+    output::IR.Type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input1, padding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.pad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -976,17 +1281,21 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1000,18 +1309,24 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
-    results = IR.Type[output_real, output_imag, ]
-    operands = Value[input, ]
+function rfft2d(
+    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
+)
+    results = IR.Type[output_real, output_imag]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.rfft2d", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.rfft2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1022,17 +1337,21 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.reciprocal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reciprocal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1042,17 +1361,21 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_all", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1062,17 +1385,21 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_any", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1082,17 +1409,21 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_max", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1102,17 +1433,21 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_min", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1122,17 +1457,21 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_prod", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_prod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1142,17 +1481,21 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reduce_sum", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reduce_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1176,18 +1519,41 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function rescale(
+    input::Value;
+    output::IR.Type,
+    input_zp,
+    output_zp,
+    multiplier,
+    shift,
+    scale32,
+    double_round,
+    per_channel,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
-    
-    IR.create_operation(
-        "tosa.rescale", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("input_zp", input_zp),
+        namedattribute("output_zp", output_zp),
+        namedattribute("multiplier", multiplier),
+        namedattribute("shift", shift),
+        namedattribute("scale32", scale32),
+        namedattribute("double_round", double_round),
+        namedattribute("per_channel", per_channel),
+    ]
+
+    return IR.create_operation(
+        "tosa.rescale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1199,17 +1565,21 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
-    
-    IR.create_operation(
-        "tosa.reshape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
+
+    return IR.create_operation(
+        "tosa.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1223,18 +1593,29 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function resize(
+    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
-    
-    IR.create_operation(
-        "tosa.resize", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("scale", scale),
+        namedattribute("offset", offset),
+        namedattribute("border", border),
+        namedattribute("mode", mode),
+    ]
+
+    return IR.create_operation(
+        "tosa.resize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1246,17 +1627,21 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reverse", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reverse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1267,17 +1652,21 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1287,18 +1676,24 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
-    results = IR.Type[values_out, ]
-    operands = Value[values_in, indices, input, ]
+function scatter(
+    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
+)
+    results = IR.Type[values_out,]
+    operands = Value[values_in, indices, input]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1307,18 +1702,24 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[pred, on_true, on_false, ]
+function select(
+    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[pred, on_true, on_false]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1332,17 +1733,21 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.sigmoid", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.sigmoid",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1354,17 +1759,23 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
-    
-    IR.create_operation(
-        "tosa.slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("start", start), namedattribute("size", size)
+    ]
+
+    return IR.create_operation(
+        "tosa.slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1375,17 +1786,21 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1408,17 +1823,21 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, table, ]
+    results = IR.Type[output,]
+    operands = Value[input, table]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.table", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.table",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1431,17 +1850,21 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1451,17 +1874,21 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
-    
-    IR.create_operation(
-        "tosa.tile", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples),]
+
+    return IR.create_operation(
+        "tosa.tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1471,19 +1898,38 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, filter, bias, ]
+function transpose_conv2d(
+    input::Value,
+    filter::Value,
+    bias::Value;
+    output::IR.Type,
+    out_pad,
+    stride,
+    out_shape,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, filter, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.transpose_conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("out_pad", out_pad),
+        namedattribute("stride", stride),
+        namedattribute("out_shape", out_shape),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.transpose_conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1493,17 +1939,21 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, perms, ]
+    results = IR.Type[output,]
+    operands = Value[input1, perms]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1515,18 +1965,28 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
-    results = IR.Type[output..., ]
-    operands = Value[inputs..., ]
-    owned_regions = Region[cond, body, ]
+function while_loop(
+    inputs::Vector{Value};
+    output::Vector{IR.Type},
+    cond::Region,
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[output...,]
+    operands = Value[inputs...,]
+    owned_regions = Region[cond, body]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.while_loop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.while_loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1539,16 +1999,20 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., ]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Tosa.jl
+++ b/src/Dialects/16/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -10,21 +10,17 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -35,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -120,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,36 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -237,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -304,21 +242,17 @@ Performs a set of permissible cast operations
     signed 16 to float      int16   float
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -328,21 +262,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,29 +285,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -387,21 +306,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -412,21 +327,17 @@ Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
 function concat(input1::Vector{Value}; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1...,]
+    results = IR.Type[output, ]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,23 +347,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -462,38 +369,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,38 +390,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -559,33 +428,18 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    identifier,
-    config,
-    implementation_attrs,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("identifier", identifier),
-        namedattribute("config", config),
-        namedattribute("implementation_attrs", implementation_attrs),
-    ]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -595,38 +449,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -637,21 +472,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,28 +491,19 @@ end
 
 Elementwise comparison operation
 """
-function equal(
-    input1::Value,
-    input2::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1, input2]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -691,21 +513,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -715,21 +533,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -738,31 +552,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -773,21 +575,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -797,21 +595,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,21 +615,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -846,21 +636,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -870,29 +656,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -902,21 +677,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -927,21 +698,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -951,24 +718,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -977,25 +738,19 @@ end
 
 Elementwise logical NOT of input.
 """
-function logical_not(
-    input1::Value; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function logical_not(input1::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1,]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1006,21 +761,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1030,24 +781,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1058,21 +803,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,26 +824,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1115,25 +849,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1144,21 +870,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1169,21 +891,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1194,21 +912,17 @@ Elementwise multiplication (Hadamard product) of input1 and input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1217,26 +931,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1245,32 +952,20 @@ end
 
 Pads a tensor along borders of each dimension with pad_value.
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1281,21 +976,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1309,24 +1000,18 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(
-    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input,]
+function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rfft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rfft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1337,21 +1022,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1361,21 +1042,17 @@ end
 Reduce a tensor along the given axis with a logical AND operation
 """
 function reduce_all(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1385,21 +1062,17 @@ end
 Reduce a tensor along the given axis with a logical OR operation
 """
 function reduce_any(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1409,21 +1082,17 @@ end
 Reduce a tensor along the given axis with a maximum operation
 """
 function reduce_max(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1433,21 +1102,17 @@ end
 Reduce a tensor along the given axis with a minimum operation
 """
 function reduce_min(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1457,21 +1122,17 @@ end
 Reduce a tensor along the given axis by computing the product of the axis.
 """
 function reduce_prod(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1481,21 +1142,17 @@ end
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
 function reduce_sum(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1519,41 +1176,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1565,21 +1199,17 @@ specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
 function reshape(input1::Value; output::IR.Type, new_shape, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1593,29 +1223,18 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(
-    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("scale", scale),
-        namedattribute("offset", offset),
-        namedattribute("border", border),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1627,21 +1246,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1652,21 +1267,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1676,24 +1287,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1702,24 +1307,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1733,21 +1332,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1759,23 +1354,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1786,21 +1375,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1823,21 +1408,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1850,21 +1431,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1874,21 +1451,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1898,38 +1471,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1939,21 +1493,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1965,28 +1515,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1999,20 +1539,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Transform.jl
+++ b/src/Dialects/16/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -33,37 +33,24 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(
-    target::Value,
-    bounded_values::Vector{Value};
-    lower_bounds,
-    upper_bounds,
-    location=Location(),
-)
+function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
     results = IR.Type[]
-    operands = Value[target, bounded_values...]
+    operands = Value[target, bounded_values..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lower_bounds", lower_bounds),
-        namedattribute("upper_bounds", upper_bounds),
-    ]
-
-    return IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
+    
+    IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `bufferization_empty_tensor_to_alloc_tensor`
@@ -76,24 +63,18 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,61 +99,32 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    function_boundary_type_conversion=nothing,
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    target_is_module=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    location=Location(),
-)
+function bufferization_one_shot_bufferize(target::Value; function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(
-        attributes,
-        namedattribute(
-            "function_boundary_type_conversion", function_boundary_type_conversion
-        ),
-    )
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) &&
-        push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `gpu_map_foreach_to_blocks`
@@ -212,31 +164,20 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_foreach_to_blocks(
-    target::Value;
-    result::IR.Type,
-    gridDim=nothing,
-    generate_gpu_launch=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_foreach_to_blocks(target::Value; result::IR.Type, gridDim=nothing, generate_gpu_launch=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gridDim) && push!(attributes, namedattribute("gridDim", gridDim))
-    !isnothing(generate_gpu_launch) &&
-        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-
-    return IR.create_operation(
-        "transform.gpu.map_foreach_to_blocks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+    
+    IR.create_operation(
+        "transform.gpu.map_foreach_to_blocks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -319,37 +260,26 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_foreach_to_threads(
-    target::Value;
-    result::IR.Type,
-    blockDim=nothing,
-    syncAfterDistribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_nested_foreach_to_threads(target::Value; result::IR.Type, blockDim=nothing, syncAfterDistribute=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(blockDim) && push!(attributes, namedattribute("blockDim", blockDim))
-    !isnothing(syncAfterDistribute) &&
-        push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
-
-    return IR.create_operation(
-        "transform.gpu.map_nested_foreach_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(syncAfterDistribute) && push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
+    
+    IR.create_operation(
+        "transform.gpu.map_nested_foreach_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `structured_decompose`
@@ -367,21 +297,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -419,24 +345,18 @@ op are rejected by this operation.
 This operation reads and frees the producer handle.
 This operation reads the containing op handle.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
-)
-    results = IR.Type[fused_op,]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -446,32 +366,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -491,21 +399,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -525,26 +429,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -565,29 +462,19 @@ values) do not satify the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(
-    target::Value,
-    vector_sizes::Vector{Value};
-    static_vector_sizes=nothing,
-    location=Location(),
-)
+function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; static_vector_sizes=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, vector_sizes...]
+    operands = Value[target, vector_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_vector_sizes) &&
-        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-
-    return IR.create_operation(
-        "transform.structured.masked_vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+    
+    IR.create_operation(
+        "transform.structured.masked_vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -621,35 +508,22 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    op_attrs=nothing,
-    filter_result_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) &&
-        push!(attributes, namedattribute("filter_result_type", filter_result_type))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,34 +583,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -801,30 +660,19 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(
-    target::Value,
-    packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_packed_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, packed_sizes...]
+function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) &&
-        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-
-    return IR.create_operation(
-        "transform.structured.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+    
+    IR.create_operation(
+        "transform.structured.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -866,33 +714,20 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(
-    target_pack_or_un_pack_op::Value,
-    target_linalg_op::Value;
-    packed_op::IR.Type,
-    pack_op::IR.Type,
-    un_pack_op::IR.Type,
-    outer_perm=nothing,
-    inner_perm=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op, pack_op, un_pack_op]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
+function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
+    results = IR.Type[packed_op, pack_op, un_pack_op, ]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-
-    return IR.create_operation(
-        "transform.structured.pack_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pack_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -912,41 +747,23 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    transformed::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pack_paddings=nothing,
-    hoist_paddings=nothing,
-    transpose_paddings=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) &&
-        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -969,41 +786,23 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1020,24 +819,18 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(
-    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
-)
-    results = IR.Type[replacement,]
-    operands = Value[target,]
-    owned_regions = Region[bodyRegion,]
+function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
+    results = IR.Type[replacement, ]
+    operands = Value[target, ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1066,21 +859,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1105,34 +894,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1272,43 +1046,23 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    inner_parallel=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) &&
-        push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1351,33 +1105,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1448,35 +1189,21 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_foreach_thread(
-    target::Value;
-    foreach_thread_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_foreach_thread(target::Value; foreach_thread_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1550,31 +1277,19 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(
-    target::Value;
-    for_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    tile_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1635,56 +1350,24 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_foreach_thread_op(
-    target::Value,
-    num_threads::Vector{Value},
-    tile_sizes::Vector{Value},
-    packed_num_threads=nothing::Union{Nothing,Value};
-    packed_tile_sizes=nothing::Union{Nothing,Value},
-    foreach_thread_op::IR.Type,
-    tiled_op::IR.Type,
-    static_num_threads=nothing,
-    static_tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, tiled_op]
-    operands = Value[target, num_threads..., tile_sizes...]
+function structured_tile_to_foreach_thread_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, foreach_thread_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, tiled_op, ]
+    operands = Value[target, num_threads..., tile_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1,
-            length(num_threads),
-            length(tile_sizes),
-            if (packed_num_threads == nothing)
-                0
-            elseif 1(packed_tile_sizes == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(static_num_threads) &&
-        push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) &&
-        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), (packed_num_threads==nothing) ? 0 : 1(packed_tile_sizes==nothing) ? 0 : 1]))
+    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1727,33 +1410,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_scf_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_scf_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1794,54 +1464,28 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value;
-    transformed::IR.Type,
-    vectorize_padding=nothing,
-    vectorize_nd_extract=nothing,
-    disable_multi_reduction_to_contract_patterns=nothing,
-    disable_transfer_permutation_map_lowering_patterns=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_multi_reduction_to_contract_patterns",
-            disable_multi_reduction_to_contract_patterns,
-        ),
-    )
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_transfer_permutation_map_lowering_patterns",
-            disable_transfer_permutation_map_lowering_patterns,
-        ),
-    )
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `memref_multibuffer`
@@ -1857,30 +1501,24 @@ multibuffered allocation.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(
-    target::Value; transformed::IR.Type, factor, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_multibuffer(target::Value; transformed::IR.Type, factor, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.memref.multibuffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.memref.multibuffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `loop_get_parent_for`
@@ -1892,26 +1530,20 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1927,21 +1559,17 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.coalesce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.coalesce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1960,21 +1588,17 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2002,31 +1626,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2053,32 +1665,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2101,26 +1701,22 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alternatives`
@@ -2183,28 +1779,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2213,21 +1800,17 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2253,22 +1836,18 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results...,]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2291,21 +1870,17 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent,]
-    operands = Value[target,]
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_closest_isolated_parent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_closest_isolated_parent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2320,24 +1895,18 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(
-    target::Value; consumers::IR.Type, result_number, location=Location()
-)
-    results = IR.Type[consumers,]
-    operands = Value[target,]
+function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
+    results = IR.Type[consumers, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_consumers_of_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_consumers_of_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2351,24 +1920,18 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(
-    target::Value; producer::IR.Type, operand_number, location=Location()
-)
-    results = IR.Type[producer,]
-    operands = Value[target,]
+function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
+    results = IR.Type[producer, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
-
-    return IR.create_operation(
-        "transform.get_producer_of_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
+    
+    IR.create_operation(
+        "transform.get_producer_of_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2384,29 +1947,20 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    deduplicate=nothing,
-    location=Location(),
-)
+function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2429,21 +1983,17 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched,]
-    operands = Value[root,]
+    results = IR.Type[matched, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
-
-    return IR.create_operation(
-        "transform.pdl_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
+    
+    IR.create_operation(
+        "transform.pdl_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2456,7 +2006,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -2464,16 +2014,12 @@ function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Loca
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "transform.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2502,24 +2048,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2554,31 +2094,19 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    failure_propagation_mode,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "failure_propagation_mode", failure_propagation_mode
-    ),]
+    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2596,24 +2124,18 @@ This operation succeeds and returns `num_result_handles` if the statically
 specified `num_result_handles` corresponds to the dynamic number of
 operations contained in the source `handle`. Otherwise it silently fails.
 """
-function split_handles(
-    handle::Value; results::Vector{IR.Type}, num_result_handles, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[handle,]
+function split_handles(handle::Value; results_::Vector{IR.Type}, num_result_handles, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles),]
-
-    return IR.create_operation(
-        "transform.split_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles), ]
+    
+    IR.create_operation(
+        "transform.split_handles", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2653,25 +2175,19 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(
-    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
-)
+function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.with_pdl_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.with_pdl_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2682,28 +2198,24 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `vector_lower_vectors`
@@ -2716,47 +2228,24 @@ At this time, the transform is all or nothing.
 This is usally a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function vector_lower_vectors(
-    target::Value;
-    results::IR.Type,
-    contraction_lowering=nothing,
-    multireduction_lowering=nothing,
-    split_transfers=nothing,
-    transpose_lowering=nothing,
-    transpose_avx2_lowering=nothing,
-    unroll_vector_transfers=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function vector_lower_vectors(target::Value; results_::IR.Type, contraction_lowering=nothing, multireduction_lowering=nothing, split_transfers=nothing, transpose_lowering=nothing, transpose_avx2_lowering=nothing, unroll_vector_transfers=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(contraction_lowering) &&
-        push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
-    !isnothing(multireduction_lowering) && push!(
-        attributes, namedattribute("multireduction_lowering", multireduction_lowering)
-    )
-    !isnothing(split_transfers) &&
-        push!(attributes, namedattribute("split_transfers", split_transfers))
-    !isnothing(transpose_lowering) &&
-        push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
-    !isnothing(transpose_avx2_lowering) && push!(
-        attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering)
-    )
-    !isnothing(unroll_vector_transfers) && push!(
-        attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers)
-    )
-
-    return IR.create_operation(
-        "transform.vector.lower_vectors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(contraction_lowering) && push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
+    !isnothing(multireduction_lowering) && push!(attributes, namedattribute("multireduction_lowering", multireduction_lowering))
+    !isnothing(split_transfers) && push!(attributes, namedattribute("split_transfers", split_transfers))
+    !isnothing(transpose_lowering) && push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
+    !isnothing(transpose_avx2_lowering) && push!(attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering))
+    !isnothing(unroll_vector_transfers) && push!(attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers))
+    
+    IR.create_operation(
+        "transform.vector.lower_vectors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Transform.jl
+++ b/src/Dialects/16/Transform.jl
@@ -1,9 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -34,38 +33,24 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(
-    target::Value,
-    bounded_values::Vector{Value};
-    lower_bounds,
-    upper_bounds,
-    location=Location(),
-)
+function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
     results = IR.Type[]
-    operands = Value[target, bounded_values...]
+    operands = Value[target, bounded_values..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lower_bounds", lower_bounds),
-        namedattribute("upper_bounds", upper_bounds),
-    ]
-
-    return IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
+    
+    IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `bufferization_empty_tensor_to_alloc_tensor`
@@ -78,24 +63,18 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -120,62 +99,32 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    function_boundary_type_conversion=nothing,
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    target_is_module=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    location=Location(),
-)
+function bufferization_one_shot_bufferize(target::Value; function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(
-        attributes,
-        namedattribute(
-            "function_boundary_type_conversion", function_boundary_type_conversion
-        ),
-    )
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) &&
-        push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `gpu_map_foreach_to_blocks`
@@ -215,31 +164,20 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_foreach_to_blocks(
-    target::Value;
-    result::IR.Type,
-    gridDim=nothing,
-    generate_gpu_launch=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_foreach_to_blocks(target::Value; result::IR.Type, gridDim=nothing, generate_gpu_launch=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gridDim) && push!(attributes, namedattribute("gridDim", gridDim))
-    !isnothing(generate_gpu_launch) &&
-        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-
-    return IR.create_operation(
-        "transform.gpu.map_foreach_to_blocks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+    
+    IR.create_operation(
+        "transform.gpu.map_foreach_to_blocks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -322,38 +260,26 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_foreach_to_threads(
-    target::Value;
-    result::IR.Type,
-    blockDim=nothing,
-    syncAfterDistribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_nested_foreach_to_threads(target::Value; result::IR.Type, blockDim=nothing, syncAfterDistribute=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(blockDim) && push!(attributes, namedattribute("blockDim", blockDim))
-    !isnothing(syncAfterDistribute) &&
-        push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
-
-    return IR.create_operation(
-        "transform.gpu.map_nested_foreach_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(syncAfterDistribute) && push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
+    
+    IR.create_operation(
+        "transform.gpu.map_nested_foreach_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `structured_decompose`
@@ -371,21 +297,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -423,24 +345,18 @@ op are rejected by this operation.
 This operation reads and frees the producer handle.
 This operation reads the containing op handle.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
-)
-    results = IR.Type[fused_op,]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -450,32 +366,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -495,21 +399,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -529,26 +429,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -569,29 +462,19 @@ values) do not satify the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(
-    target::Value,
-    vector_sizes::Vector{Value};
-    static_vector_sizes=nothing,
-    location=Location(),
-)
+function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; static_vector_sizes=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, vector_sizes...]
+    operands = Value[target, vector_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_vector_sizes) &&
-        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-
-    return IR.create_operation(
-        "transform.structured.masked_vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+    
+    IR.create_operation(
+        "transform.structured.masked_vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -625,35 +508,22 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    op_attrs=nothing,
-    filter_result_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) &&
-        push!(attributes, namedattribute("filter_result_type", filter_result_type))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -713,34 +583,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -805,30 +660,19 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(
-    target::Value,
-    packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_packed_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, packed_sizes...]
+function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) &&
-        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-
-    return IR.create_operation(
-        "transform.structured.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+    
+    IR.create_operation(
+        "transform.structured.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -870,33 +714,20 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(
-    target_pack_or_un_pack_op::Value,
-    target_linalg_op::Value;
-    packed_op::IR.Type,
-    pack_op::IR.Type,
-    un_pack_op::IR.Type,
-    outer_perm=nothing,
-    inner_perm=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op, pack_op, un_pack_op]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
+function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
+    results = IR.Type[packed_op, pack_op, un_pack_op, ]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-
-    return IR.create_operation(
-        "transform.structured.pack_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pack_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -916,41 +747,23 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    transformed::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pack_paddings=nothing,
-    hoist_paddings=nothing,
-    transpose_paddings=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) &&
-        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -973,41 +786,23 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1024,24 +819,18 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(
-    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
-)
-    results = IR.Type[replacement,]
-    operands = Value[target,]
-    owned_regions = Region[bodyRegion,]
+function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
+    results = IR.Type[replacement, ]
+    operands = Value[target, ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1070,21 +859,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1109,34 +894,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1276,43 +1046,23 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    inner_parallel=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) &&
-        push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1355,33 +1105,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1452,35 +1189,21 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_foreach_thread(
-    target::Value;
-    foreach_thread_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_foreach_thread(target::Value; foreach_thread_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_foreach_thread",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_foreach_thread", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1554,31 +1277,19 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(
-    target::Value;
-    for_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    tile_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1639,56 +1350,24 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_foreach_thread_op(
-    target::Value,
-    num_threads::Vector{Value},
-    tile_sizes::Vector{Value},
-    packed_num_threads=nothing::Union{Nothing,Value};
-    packed_tile_sizes=nothing::Union{Nothing,Value},
-    foreach_thread_op::IR.Type,
-    tiled_op::IR.Type,
-    static_num_threads=nothing,
-    static_tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[foreach_thread_op, tiled_op]
-    operands = Value[target, num_threads..., tile_sizes...]
+function structured_tile_to_foreach_thread_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, foreach_thread_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[foreach_thread_op, tiled_op, ]
+    operands = Value[target, num_threads..., tile_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1,
-            length(num_threads),
-            length(tile_sizes),
-            if (packed_num_threads == nothing)
-                0
-            elseif 1(packed_tile_sizes == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(static_num_threads) &&
-        push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) &&
-        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), (packed_num_threads==nothing) ? 0 : 1(packed_tile_sizes==nothing) ? 0 : 1]))
+    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1731,33 +1410,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_scf_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_scf_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1798,55 +1464,28 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value;
-    transformed::IR.Type,
-    vectorize_padding=nothing,
-    vectorize_nd_extract=nothing,
-    disable_multi_reduction_to_contract_patterns=nothing,
-    disable_transfer_permutation_map_lowering_patterns=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_multi_reduction_to_contract_patterns",
-            disable_multi_reduction_to_contract_patterns,
-        ),
-    )
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_transfer_permutation_map_lowering_patterns",
-            disable_transfer_permutation_map_lowering_patterns,
-        ),
-    )
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `memref_multibuffer`
@@ -1862,31 +1501,24 @@ multibuffered allocation.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(
-    target::Value; transformed::IR.Type, factor, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_multibuffer(target::Value; transformed::IR.Type, factor, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.memref.multibuffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.memref.multibuffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `loop_get_parent_for`
@@ -1898,26 +1530,20 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1933,21 +1559,17 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.coalesce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.coalesce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1966,21 +1588,17 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2008,31 +1626,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2059,32 +1665,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2107,27 +1701,22 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `alternatives`
@@ -2190,28 +1779,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2220,21 +1800,17 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2260,22 +1836,18 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results...,]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2298,21 +1870,17 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent,]
-    operands = Value[target,]
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_closest_isolated_parent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_closest_isolated_parent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2327,24 +1895,18 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(
-    target::Value; consumers::IR.Type, result_number, location=Location()
-)
-    results = IR.Type[consumers,]
-    operands = Value[target,]
+function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
+    results = IR.Type[consumers, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_consumers_of_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_consumers_of_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2358,24 +1920,18 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(
-    target::Value; producer::IR.Type, operand_number, location=Location()
-)
-    results = IR.Type[producer,]
-    operands = Value[target,]
+function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
+    results = IR.Type[producer, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
-
-    return IR.create_operation(
-        "transform.get_producer_of_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
+    
+    IR.create_operation(
+        "transform.get_producer_of_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2391,29 +1947,20 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    deduplicate=nothing,
-    location=Location(),
-)
+function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2436,21 +1983,17 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched,]
-    operands = Value[root,]
+    results = IR.Type[matched, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
-
-    return IR.create_operation(
-        "transform.pdl_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
+    
+    IR.create_operation(
+        "transform.pdl_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2463,7 +2006,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -2471,16 +2014,12 @@ function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Loca
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "transform.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2509,24 +2048,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2561,31 +2094,19 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    failure_propagation_mode,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "failure_propagation_mode", failure_propagation_mode
-    ),]
+    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2603,24 +2124,18 @@ This operation succeeds and returns `num_result_handles` if the statically
 specified `num_result_handles` corresponds to the dynamic number of
 operations contained in the source `handle`. Otherwise it silently fails.
 """
-function split_handles(
-    handle::Value; results::Vector{IR.Type}, num_result_handles, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[handle,]
+function split_handles(handle::Value; results_::Vector{IR.Type}, num_result_handles, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles),]
-
-    return IR.create_operation(
-        "transform.split_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles), ]
+    
+    IR.create_operation(
+        "transform.split_handles", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2660,25 +2175,19 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(
-    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
-)
+function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-
-    return IR.create_operation(
-        "transform.with_pdl_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.with_pdl_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2689,29 +2198,24 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `vector_lower_vectors`
@@ -2724,47 +2228,24 @@ At this time, the transform is all or nothing.
 This is usally a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function vector_lower_vectors(
-    target::Value;
-    results::IR.Type,
-    contraction_lowering=nothing,
-    multireduction_lowering=nothing,
-    split_transfers=nothing,
-    transpose_lowering=nothing,
-    transpose_avx2_lowering=nothing,
-    unroll_vector_transfers=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function vector_lower_vectors(target::Value; results_::IR.Type, contraction_lowering=nothing, multireduction_lowering=nothing, split_transfers=nothing, transpose_lowering=nothing, transpose_avx2_lowering=nothing, unroll_vector_transfers=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(contraction_lowering) &&
-        push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
-    !isnothing(multireduction_lowering) && push!(
-        attributes, namedattribute("multireduction_lowering", multireduction_lowering)
-    )
-    !isnothing(split_transfers) &&
-        push!(attributes, namedattribute("split_transfers", split_transfers))
-    !isnothing(transpose_lowering) &&
-        push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
-    !isnothing(transpose_avx2_lowering) && push!(
-        attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering)
-    )
-    !isnothing(unroll_vector_transfers) && push!(
-        attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers)
-    )
-
-    return IR.create_operation(
-        "transform.vector.lower_vectors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(contraction_lowering) && push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
+    !isnothing(multireduction_lowering) && push!(attributes, namedattribute("multireduction_lowering", multireduction_lowering))
+    !isnothing(split_transfers) && push!(attributes, namedattribute("split_transfers", split_transfers))
+    !isnothing(transpose_lowering) && push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
+    !isnothing(transpose_avx2_lowering) && push!(attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering))
+    !isnothing(unroll_vector_transfers) && push!(attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers))
+    
+    IR.create_operation(
+        "transform.vector.lower_vectors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Transform.jl
+++ b/src/Dialects/16/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -33,24 +33,37 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
+function affine_simplify_bounded_affine_ops(
+    target::Value,
+    bounded_values::Vector{Value};
+    lower_bounds,
+    upper_bounds,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, bounded_values..., ]
+    operands = Value[target, bounded_values...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
-    
-    IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("lower_bounds", lower_bounds),
+        namedattribute("upper_bounds", upper_bounds),
+    ]
+
+    return IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `bufferization_empty_tensor_to_alloc_tensor`
@@ -63,18 +76,24 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function bufferization_empty_tensor_to_alloc_tensor(
+    target::Value; transformed::IR.Type, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -99,32 +118,61 @@ Many ops implement `BufferizableOpInterface` via an external model. These
 external models must be registered when applying this transform op;
 otherwise, said ops would be considered non-bufferizable.
 """
-function bufferization_one_shot_bufferize(target::Value; function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, target_is_module=nothing, test_analysis_only=nothing, print_conflicts=nothing, location=Location())
+function bufferization_one_shot_bufferize(
+    target::Value;
+    function_boundary_type_conversion=nothing,
+    allow_return_allocs=nothing,
+    allow_unknown_ops=nothing,
+    bufferize_function_boundaries=nothing,
+    create_deallocs=nothing,
+    target_is_module=nothing,
+    test_analysis_only=nothing,
+    print_conflicts=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
-    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
-    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(target_is_module) && push!(attributes, namedattribute("target_is_module", target_is_module))
-    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
-    
-    IR.create_operation(
-        "transform.bufferization.one_shot_bufferize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(function_boundary_type_conversion) && push!(
+        attributes,
+        namedattribute(
+            "function_boundary_type_conversion", function_boundary_type_conversion
+        ),
+    )
+    !isnothing(allow_return_allocs) &&
+        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) &&
+        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(
+        attributes,
+        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
+    )
+    !isnothing(create_deallocs) &&
+        push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(target_is_module) &&
+        push!(attributes, namedattribute("target_is_module", target_is_module))
+    !isnothing(test_analysis_only) &&
+        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) &&
+        push!(attributes, namedattribute("print_conflicts", print_conflicts))
+
+    return IR.create_operation(
+        "transform.bufferization.one_shot_bufferize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `gpu_map_foreach_to_blocks`
@@ -164,20 +212,31 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_foreach_to_blocks(target::Value; result::IR.Type, gridDim=nothing, generate_gpu_launch=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+function gpu_map_foreach_to_blocks(
+    target::Value;
+    result::IR.Type,
+    gridDim=nothing,
+    generate_gpu_launch=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gridDim) && push!(attributes, namedattribute("gridDim", gridDim))
-    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-    
-    IR.create_operation(
-        "transform.gpu.map_foreach_to_blocks", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(generate_gpu_launch) &&
+        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+
+    return IR.create_operation(
+        "transform.gpu.map_foreach_to_blocks",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -260,26 +319,37 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_foreach_to_threads(target::Value; result::IR.Type, blockDim=nothing, syncAfterDistribute=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+function gpu_map_nested_foreach_to_threads(
+    target::Value;
+    result::IR.Type,
+    blockDim=nothing,
+    syncAfterDistribute=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(blockDim) && push!(attributes, namedattribute("blockDim", blockDim))
-    !isnothing(syncAfterDistribute) && push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
-    
-    IR.create_operation(
-        "transform.gpu.map_nested_foreach_to_threads", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(syncAfterDistribute) &&
+        push!(attributes, namedattribute("syncAfterDistribute", syncAfterDistribute))
+
+    return IR.create_operation(
+        "transform.gpu.map_nested_foreach_to_threads",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `structured_decompose`
@@ -297,17 +367,21 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.decompose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.decompose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -345,18 +419,24 @@ op are rejected by this operation.
 This operation reads and frees the producer handle.
 This operation reads the containing op handle.
 """
-function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location())
-    results = IR.Type[fused_op, ]
-    operands = Value[producer_op, containing_op, ]
+function structured_fuse_into_containing_op(
+    producer_op::Value, containing_op::Value; fused_op::IR.Type, location=Location()
+)
+    results = IR.Type[fused_op,]
+    operands = Value[producer_op, containing_op]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.fuse_into_containing_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.fuse_into_containing_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -366,20 +446,32 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
-    results = IR.Type[transformed, loops..., ]
-    operands = Value[target, ]
+function structured_fuse(
+    target::Value;
+    transformed::IR.Type,
+    loops::Vector{IR.Type},
+    tile_sizes=nothing,
+    tile_interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed, loops...]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
-    
-    IR.create_operation(
-        "transform.structured.fuse", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(tile_interchange) &&
+        push!(attributes, namedattribute("tile_interchange", tile_interchange))
+
+    return IR.create_operation(
+        "transform.structured.fuse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -399,17 +491,21 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.generalize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.generalize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -429,19 +525,26 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_interchange(
+    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-    
-    IR.create_operation(
-        "transform.structured.interchange", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(iterator_interchange) &&
+        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+
+    return IR.create_operation(
+        "transform.structured.interchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -462,19 +565,29 @@ values) do not satify the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; static_vector_sizes=nothing, location=Location())
+function structured_masked_vectorize(
+    target::Value,
+    vector_sizes::Vector{Value};
+    static_vector_sizes=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, vector_sizes..., ]
+    operands = Value[target, vector_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-    
-    IR.create_operation(
-        "transform.structured.masked_vectorize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(static_vector_sizes) &&
+        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+
+    return IR.create_operation(
+        "transform.structured.masked_vectorize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -508,22 +621,35 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
-    results = IR.Type[results_, ]
-    operands = Value[target, ]
+function structured_match(
+    target::Value;
+    results::IR.Type,
+    ops=nothing,
+    interface=nothing,
+    op_attrs=nothing,
+    filter_result_type=nothing,
+    location=Location(),
+)
+    results = IR.Type[results,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
-    
-    IR.create_operation(
-        "transform.structured.match", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(filter_result_type) &&
+        push!(attributes, namedattribute("filter_result_type", filter_result_type))
+
+    return IR.create_operation(
+        "transform.structured.match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -583,19 +709,34 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
-    results = IR.Type[low_size, high_size, split_point, ]
-    operands = Value[target, ]
+function structured_multitile_sizes(
+    target::Value;
+    low_size::IR.Type,
+    high_size::IR.Type,
+    split_point::IR.Type,
+    dimension,
+    target_size,
+    divisor=nothing,
+    location=Location(),
+)
+    results = IR.Type[low_size, high_size, split_point]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
+    attributes = NamedAttribute[
+        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
+    ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-    
-    IR.create_operation(
-        "transform.structured.multitile_sizes", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.multitile_sizes",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -660,19 +801,30 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
-    results = IR.Type[packed_op, ]
-    operands = Value[target, packed_sizes..., ]
+function structured_pack(
+    target::Value,
+    packed_sizes::Vector{Value};
+    packed_op::IR.Type,
+    static_packed_sizes=nothing,
+    location=Location(),
+)
+    results = IR.Type[packed_op,]
+    operands = Value[target, packed_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-    
-    IR.create_operation(
-        "transform.structured.pack", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(static_packed_sizes) &&
+        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+
+    return IR.create_operation(
+        "transform.structured.pack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -714,20 +866,33 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
-    results = IR.Type[packed_op, pack_op, un_pack_op, ]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
+function structured_pack_transpose(
+    target_pack_or_un_pack_op::Value,
+    target_linalg_op::Value;
+    packed_op::IR.Type,
+    pack_op::IR.Type,
+    un_pack_op::IR.Type,
+    outer_perm=nothing,
+    inner_perm=nothing,
+    location=Location(),
+)
+    results = IR.Type[packed_op, pack_op, un_pack_op]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-    
-    IR.create_operation(
-        "transform.structured.pack_transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.pack_transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -747,23 +912,41 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(target::Value; transformed::IR.Type, padding_values=nothing, padding_dimensions=nothing, pack_paddings=nothing, hoist_paddings=nothing, transpose_paddings=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_pad(
+    target::Value;
+    transformed::IR.Type,
+    padding_values=nothing,
+    padding_dimensions=nothing,
+    pack_paddings=nothing,
+    hoist_paddings=nothing,
+    transpose_paddings=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(hoist_paddings) && push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
-    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
-    
-    IR.create_operation(
-        "transform.structured.pad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(padding_values) &&
+        push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) &&
+        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pack_paddings) &&
+        push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(hoist_paddings) &&
+        push!(attributes, namedattribute("hoist_paddings", hoist_paddings))
+    !isnothing(transpose_paddings) &&
+        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+
+    return IR.create_operation(
+        "transform.structured.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -786,23 +969,41 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, alignment=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_promote(
+    target::Value;
+    transformed::IR.Type,
+    operands_to_promote=nothing,
+    use_full_tile_buffers=nothing,
+    use_full_tiles_by_default=nothing,
+    use_alloca=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
+    !isnothing(operands_to_promote) &&
+        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) &&
+        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(
+        attributes,
+        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
+    )
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "transform.structured.promote", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.promote",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -819,18 +1020,24 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
-    results = IR.Type[replacement, ]
-    operands = Value[target, ]
-    owned_regions = Region[bodyRegion, ]
+function structured_replace(
+    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
+)
+    results = IR.Type[replacement,]
+    operands = Value[target,]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.replace", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -859,17 +1066,21 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.scalarize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.scalarize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -894,19 +1105,34 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
-    results = IR.Type[first, second, ]
-    operands = Value[target, ]
+function structured_split(
+    target::Value,
+    dynamic_split_point=nothing::Union{Nothing,Value};
+    first::IR.Type,
+    second::IR.Type,
+    dimension,
+    static_split_point,
+    location=Location(),
+)
+    results = IR.Type[first, second]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
+    attributes = NamedAttribute[
+        namedattribute("dimension", dimension),
+        namedattribute("static_split_point", static_split_point),
+    ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-    
-    IR.create_operation(
-        "transform.structured.split", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.split",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1046,23 +1272,43 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_split_reduction(
+    target::Value;
+    init_or_alloc_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    split_factor=nothing,
+    insert_split_dimension=nothing,
+    inner_parallel=nothing,
+    use_scaling_algorithm=nothing,
+    use_alloc=nothing,
+    location=Location(),
+)
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) &&
+        push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) &&
+        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) &&
+        push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) &&
+        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-    
-    IR.create_operation(
-        "transform.structured.split_reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.split_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1105,20 +1351,33 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
-    results = IR.Type[tiled_linalg_op, loops..., ]
-    operands = Value[target, dynamic_sizes..., ]
+function structured_tile(
+    target::Value,
+    dynamic_sizes::Vector{Value};
+    tiled_linalg_op::IR.Type,
+    loops::Vector{IR.Type},
+    static_sizes=nothing,
+    interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[tiled_linalg_op, loops...]
+    operands = Value[target, dynamic_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) &&
+        push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    
-    IR.create_operation(
-        "transform.structured.tile", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1189,21 +1448,35 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_foreach_thread(target::Value; foreach_thread_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
-    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_tile_reduction_using_foreach_thread(
+    target::Value;
+    foreach_thread_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    num_threads=nothing,
+    tile_sizes=nothing,
+    mapping=nothing,
+    location=Location(),
+)
+    results = IR.Type[foreach_thread_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-    
-    IR.create_operation(
-        "transform.structured.tile_reduction_using_foreach_thread", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_reduction_using_foreach_thread",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1277,19 +1550,31 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_tile_reduction_using_scf(
+    target::Value;
+    for_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    tile_sizes=nothing,
+    location=Location(),
+)
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    
-    IR.create_operation(
-        "transform.structured.tile_reduction_using_scf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_reduction_using_scf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1350,24 +1635,56 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_foreach_thread_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_foreach_thread_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, foreach_thread_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
-    results = IR.Type[foreach_thread_op, tiled_op, ]
-    operands = Value[target, num_threads..., tile_sizes..., ]
+function structured_tile_to_foreach_thread_op(
+    target::Value,
+    num_threads::Vector{Value},
+    tile_sizes::Vector{Value},
+    packed_num_threads=nothing::Union{Nothing,Value};
+    packed_tile_sizes=nothing::Union{Nothing,Value},
+    foreach_thread_op::IR.Type,
+    tiled_op::IR.Type,
+    static_num_threads=nothing,
+    static_tile_sizes=nothing,
+    mapping=nothing,
+    location=Location(),
+)
+    results = IR.Type[foreach_thread_op, tiled_op]
+    operands = Value[target, num_threads..., tile_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), (packed_num_threads==nothing) ? 0 : 1(packed_tile_sizes==nothing) ? 0 : 1]))
-    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            1,
+            length(num_threads),
+            length(tile_sizes),
+            if (packed_num_threads == nothing)
+                0
+            elseif 1(packed_tile_sizes == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+    !isnothing(static_num_threads) &&
+        push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) &&
+        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-    
-    IR.create_operation(
-        "transform.structured.tile_to_foreach_thread_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_to_foreach_thread_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1410,20 +1727,33 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
-    results = IR.Type[tiled_linalg_op, loops..., ]
-    operands = Value[target, dynamic_sizes..., ]
+function structured_tile_to_scf_for(
+    target::Value,
+    dynamic_sizes::Vector{Value};
+    tiled_linalg_op::IR.Type,
+    loops::Vector{IR.Type},
+    static_sizes=nothing,
+    interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[tiled_linalg_op, loops...]
+    operands = Value[target, dynamic_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) &&
+        push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    
-    IR.create_operation(
-        "transform.structured.tile_to_scf_for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_to_scf_for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1464,28 +1794,54 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_vectorize(
+    target::Value;
+    transformed::IR.Type,
+    vectorize_padding=nothing,
+    vectorize_nd_extract=nothing,
+    disable_multi_reduction_to_contract_patterns=nothing,
+    disable_transfer_permutation_map_lowering_patterns=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
-    
-    IR.create_operation(
-        "transform.structured.vectorize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(vectorize_padding) &&
+        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) &&
+        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
+        attributes,
+        namedattribute(
+            "disable_multi_reduction_to_contract_patterns",
+            disable_multi_reduction_to_contract_patterns,
+        ),
+    )
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
+        attributes,
+        namedattribute(
+            "disable_transfer_permutation_map_lowering_patterns",
+            disable_transfer_permutation_map_lowering_patterns,
+        ),
+    )
+
+    return IR.create_operation(
+        "transform.structured.vectorize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `memref_multibuffer`
@@ -1501,24 +1857,30 @@ multibuffered allocation.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(target::Value; transformed::IR.Type, factor, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function memref_multibuffer(
+    target::Value; transformed::IR.Type, factor, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor), ]
-    
-    IR.create_operation(
-        "transform.memref.multibuffer", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor),]
+
+    return IR.create_operation(
+        "transform.memref.multibuffer",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `loop_get_parent_for`
@@ -1530,20 +1892,26 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
-    results = IR.Type[parent, ]
-    operands = Value[target, ]
+function loop_get_parent_for(
+    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
+)
+    results = IR.Type[parent,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-    
-    IR.create_operation(
-        "transform.loop.get_parent_for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.loop.get_parent_for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1559,17 +1927,21 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.loop.coalesce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.loop.coalesce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1588,17 +1960,21 @@ module). Returns the handle to the list of outlined functions in the same
 order as the operand handle.
 """
 function loop_outline(target::Value; transformed::IR.Type, func_name, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
-    
-    IR.create_operation(
-        "transform.loop.outline", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name),]
+
+    return IR.create_operation(
+        "transform.loop.outline",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1626,19 +2002,31 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function loop_peel(
+    target::Value;
+    transformed::IR.Type,
+    fail_if_already_divisible=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
-    
-    IR.create_operation(
-        "transform.loop.peel", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fail_if_already_divisible) && push!(
+        attributes,
+        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
+    )
+
+    return IR.create_operation(
+        "transform.loop.peel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1665,20 +2053,32 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function loop_pipeline(
+    target::Value;
+    transformed::IR.Type,
+    iteration_interval=nothing,
+    read_latency=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
-    
-    IR.create_operation(
-        "transform.loop.pipeline", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(iteration_interval) &&
+        push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) &&
+        push!(attributes, namedattribute("read_latency", read_latency))
+
+    return IR.create_operation(
+        "transform.loop.pipeline",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1701,22 +2101,26 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor), ]
-    
-    IR.create_operation(
-        "transform.loop.unroll", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor),]
+
+    return IR.create_operation(
+        "transform.loop.unroll",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `alternatives`
@@ -1779,19 +2183,28 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
-    results = IR.Type[results_..., ]
+function alternatives(
+    scope=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    alternatives::Vector{Region},
+    location=Location(),
+)
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[alternatives..., ]
+    owned_regions = Region[alternatives...,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-    
-    IR.create_operation(
-        "transform.alternatives", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.alternatives",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1800,17 +2213,21 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1836,18 +2253,22 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[target, ]
-    owned_regions = Region[body, ]
+function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results...,]
+    operands = Value[target,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1870,17 +2291,21 @@ is applied, e.g., \"B\" may itself be a parent of \"A\". This may have an impact
 on the further transformation applied to the handle produced here.
 """
 function get_closest_isolated_parent(target::Value; parent::IR.Type, location=Location())
-    results = IR.Type[parent, ]
-    operands = Value[target, ]
+    results = IR.Type[parent,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.get_closest_isolated_parent", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.get_closest_isolated_parent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1895,18 +2320,24 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
-    results = IR.Type[consumers, ]
-    operands = Value[target, ]
+function get_consumers_of_result(
+    target::Value; consumers::IR.Type, result_number, location=Location()
+)
+    results = IR.Type[consumers,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
-    
-    IR.create_operation(
-        "transform.get_consumers_of_result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number),]
+
+    return IR.create_operation(
+        "transform.get_consumers_of_result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1920,18 +2351,24 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
-    results = IR.Type[producer, ]
-    operands = Value[target, ]
+function get_producer_of_operand(
+    target::Value; producer::IR.Type, operand_number, location=Location()
+)
+    results = IR.Type[producer,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
-    
-    IR.create_operation(
-        "transform.get_producer_of_operand", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
+
+    return IR.create_operation(
+        "transform.get_producer_of_operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1947,20 +2384,29 @@ and so on. If `deduplicate` is set, do not add the given Payload IR
 operation more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
+function merge_handles(
+    handles::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    deduplicate=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[handles..., ]
+    operands = Value[handles...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-    
-    IR.create_operation(
-        "transform.merge_handles", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.merge_handles",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1983,17 +2429,21 @@ Payload IR ops actually matched the pattern and only fails if the pattern
 could not be looked up or compiled.
 """
 function pdl_match(root::Value; matched::IR.Type, pattern_name, location=Location())
-    results = IR.Type[matched, ]
-    operands = Value[root, ]
+    results = IR.Type[matched,]
+    operands = Value[root,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name), ]
-    
-    IR.create_operation(
-        "transform.pdl_match", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("pattern_name", pattern_name),]
+
+    return IR.create_operation(
+        "transform.pdl_match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2006,7 +2456,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -2014,12 +2464,16 @@ function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Loc
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "transform.print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2048,18 +2502,24 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
-    results = IR.Type[replicated..., ]
-    operands = Value[pattern, handles..., ]
+function replicate(
+    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
+)
+    results = IR.Type[replicated...,]
+    operands = Value[pattern, handles...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.replicate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.replicate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2094,19 +2554,31 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(root=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
-    results = IR.Type[results_..., ]
+function sequence(
+    root=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    failure_propagation_mode,
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
+    attributes = NamedAttribute[namedattribute(
+        "failure_propagation_mode", failure_propagation_mode
+    ),]
     !isnothing(root) && push!(operands, root)
-    
-    IR.create_operation(
-        "transform.sequence", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.sequence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2124,18 +2596,24 @@ This operation succeeds and returns `num_result_handles` if the statically
 specified `num_result_handles` corresponds to the dynamic number of
 operations contained in the source `handle`. Otherwise it silently fails.
 """
-function split_handles(handle::Value; results_::Vector{IR.Type}, num_result_handles, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[handle, ]
+function split_handles(
+    handle::Value; results::Vector{IR.Type}, num_result_handles, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles), ]
-    
-    IR.create_operation(
-        "transform.split_handles", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("num_result_handles", num_result_handles),]
+
+    return IR.create_operation(
+        "transform.split_handles",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2175,19 +2653,25 @@ available. This op is a possible top-level Transform IR op, the argument of
 its entry block corresponds to either the root op of the payload IR or the
 ops associated with its operand when provided.
 """
-function with_pdl_patterns(root=nothing::Union{Nothing, Value}; body::Region, location=Location())
+function with_pdl_patterns(
+    root=nothing::Union{Nothing,Value}; body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    
-    IR.create_operation(
-        "transform.with_pdl_patterns", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.with_pdl_patterns",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2198,24 +2682,28 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `vector_lower_vectors`
@@ -2228,24 +2716,47 @@ At this time, the transform is all or nothing.
 This is usally a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function vector_lower_vectors(target::Value; results_::IR.Type, contraction_lowering=nothing, multireduction_lowering=nothing, split_transfers=nothing, transpose_lowering=nothing, transpose_avx2_lowering=nothing, unroll_vector_transfers=nothing, location=Location())
-    results = IR.Type[results_, ]
-    operands = Value[target, ]
+function vector_lower_vectors(
+    target::Value;
+    results::IR.Type,
+    contraction_lowering=nothing,
+    multireduction_lowering=nothing,
+    split_transfers=nothing,
+    transpose_lowering=nothing,
+    transpose_avx2_lowering=nothing,
+    unroll_vector_transfers=nothing,
+    location=Location(),
+)
+    results = IR.Type[results,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(contraction_lowering) && push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
-    !isnothing(multireduction_lowering) && push!(attributes, namedattribute("multireduction_lowering", multireduction_lowering))
-    !isnothing(split_transfers) && push!(attributes, namedattribute("split_transfers", split_transfers))
-    !isnothing(transpose_lowering) && push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
-    !isnothing(transpose_avx2_lowering) && push!(attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering))
-    !isnothing(unroll_vector_transfers) && push!(attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers))
-    
-    IR.create_operation(
-        "transform.vector.lower_vectors", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(contraction_lowering) &&
+        push!(attributes, namedattribute("contraction_lowering", contraction_lowering))
+    !isnothing(multireduction_lowering) && push!(
+        attributes, namedattribute("multireduction_lowering", multireduction_lowering)
+    )
+    !isnothing(split_transfers) &&
+        push!(attributes, namedattribute("split_transfers", split_transfers))
+    !isnothing(transpose_lowering) &&
+        push!(attributes, namedattribute("transpose_lowering", transpose_lowering))
+    !isnothing(transpose_avx2_lowering) && push!(
+        attributes, namedattribute("transpose_avx2_lowering", transpose_avx2_lowering)
+    )
+    !isnothing(unroll_vector_transfers) && push!(
+        attributes, namedattribute("unroll_vector_transfers", unroll_vector_transfers)
+    )
+
+    return IR.create_operation(
+        "transform.vector.lower_vectors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Vector.jl
+++ b/src/Dialects/16/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `vscale`
@@ -18,19 +18,23 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.vscale", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.vscale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -59,17 +63,21 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -105,17 +113,21 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[source, ]
+    results = IR.Type[vector,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -150,18 +162,28 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
+function compressstore(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore, ]
+    operands = Value[base, indices..., mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.compressstore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.compressstore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -197,17 +219,21 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
-    
-    IR.create_operation(
-        "vector.constant_mask", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
+
+    return IR.create_operation(
+        "vector.constant_mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -329,19 +355,36 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, acc, masks..., ]
+function contract(
+    lhs::Value,
+    rhs::Value,
+    acc::Value,
+    masks::Vector{Value};
+    result_0::IR.Type,
+    indexing_maps,
+    iterator_types,
+    kind=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs, acc, masks...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    attributes = NamedAttribute[
+        namedattribute("indexing_maps", indexing_maps),
+        namedattribute("iterator_types", iterator_types),
+    ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-    
-    IR.create_operation(
-        "vector.contract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.contract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -375,18 +418,22 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.create_mask", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.create_mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -421,18 +468,29 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., mask, pass_thru, ]
+function expandload(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.expandload", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.expandload",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,19 +516,29 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, ]
+function extractelement(
+    vector::Value,
+    position=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    
-    IR.create_operation(
-        "vector.extractelement", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "vector.extractelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -487,19 +555,25 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function extract(
+    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
+)
     results = IR.Type[]
-    operands = Value[vector, ]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "vector.extract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -529,18 +603,28 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[vector, ]
+function extract_strided_slice(
+    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
+)
+    results = IR.Type[result_0,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
-    
-    IR.create_operation(
-        "vector.extract_strided_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("offsets", offsets),
+        namedattribute("sizes", sizes),
+        namedattribute("strides", strides),
+    ]
+
+    return IR.create_operation(
+        "vector.extract_strided_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -561,19 +645,29 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function fma(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc, ]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -603,17 +697,23 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrix, ]
+    results = IR.Type[res,]
+    operands = Value[matrix,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
-    
-    IR.create_operation(
-        "vector.flat_transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("rows", rows), namedattribute("columns", columns)
+    ]
+
+    return IR.create_operation(
+        "vector.flat_transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -646,18 +746,30 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
+function gather(
+    base::Value,
+    indices::Vector{Value},
+    index_vec::Value,
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., index_vec, mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -682,20 +794,30 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function insertelement(
+    source::Value,
+    dest::Value,
+    position=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.insertelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insertelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -713,19 +835,29 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function insert(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    position,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -751,19 +883,32 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
+function insert_strided_slice(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    offsets,
+    strides,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
+    attributes = NamedAttribute[
+        namedattribute("offsets", offsets), namedattribute("strides", strides)
+    ]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.insert_strided_slice", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert_strided_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -824,17 +969,21 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -886,19 +1035,29 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[mask, ]
-    owned_regions = Region[maskRegion, ]
+function mask(
+    mask::Value,
+    passthru=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    maskRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[mask,]
+    owned_regions = Region[maskRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-    
-    IR.create_operation(
-        "vector.mask", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -930,18 +1089,29 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., mask, pass_thru, ]
+function maskedload(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.maskedload", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.maskedload",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -973,18 +1143,28 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
+function maskedstore(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore, ]
+    operands = Value[base, indices..., mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.maskedstore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.maskedstore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1015,18 +1195,34 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function matrix_multiply(
+    lhs::Value,
+    rhs::Value;
+    res::IR.Type,
+    lhs_rows,
+    lhs_columns,
+    rhs_columns,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
-    
-    IR.create_operation(
-        "vector.matrix_multiply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("lhs_rows", lhs_rows),
+        namedattribute("lhs_columns", lhs_columns),
+        namedattribute("rhs_columns", rhs_columns),
+    ]
+
+    return IR.create_operation(
+        "vector.matrix_multiply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1047,19 +1243,32 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
+function multi_reduction(
+    source::Value,
+    acc::Value;
+    dest=nothing::Union{Nothing,IR.Type},
+    kind,
+    reduction_dims,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, acc, ]
+    operands = Value[source, acc]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
+    attributes = NamedAttribute[
+        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
+    ]
     !isnothing(dest) && push!(results, dest)
-    
-    IR.create_operation(
-        "vector.multi_reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.multi_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1113,19 +1322,30 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, acc..., ]
+function outerproduct(
+    lhs::Value,
+    rhs::Value,
+    acc::Vector{Value};
+    result_0::IR.Type,
+    kind=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs, acc...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-    
-    IR.create_operation(
-        "vector.outerproduct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.outerproduct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1155,16 +1375,20 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1190,19 +1414,29 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[vector, ]
+function reduction(
+    vector::Value,
+    acc=nothing::Union{Nothing,Value};
+    dest::IR.Type,
+    kind,
+    location=Location(),
+)
+    results = IR.Type[dest,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    attributes = NamedAttribute[namedattribute("kind", kind),]
     !isnothing(acc) && push!(operands, acc)
-    
-    IR.create_operation(
-        "vector.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1290,19 +1524,30 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, input_shape..., output_shape..., ]
+function reshape(
+    vector::Value,
+    input_shape::Vector{Value},
+    output_shape::Vector{Value};
+    result::IR.Type,
+    fixed_vector_sizes,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector, input_shape..., output_shape...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
-    
-    IR.create_operation(
-        "vector.reshape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
+
+    return IR.create_operation(
+        "vector.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1331,17 +1576,21 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[source, ]
+    results = IR.Type[res,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos), ]
-    
-    IR.create_operation(
-        "vector.scalable.extract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos),]
+
+    return IR.create_operation(
+        "vector.scalable.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1373,19 +1622,29 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
+function scalable_insert(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    pos,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    attributes = NamedAttribute[namedattribute("pos", pos),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.scalable.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scalable.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1406,20 +1665,37 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
+function scan(
+    source::Value,
+    initial_value::Value;
+    dest=nothing::Union{Nothing,IR.Type},
+    accumulated_value=nothing::Union{Nothing,IR.Type},
+    kind,
+    reduction_dim,
+    inclusive,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, initial_value, ]
+    operands = Value[source, initial_value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
+    attributes = NamedAttribute[
+        namedattribute("kind", kind),
+        namedattribute("reduction_dim", reduction_dim),
+        namedattribute("inclusive", inclusive),
+    ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-    
-    IR.create_operation(
-        "vector.scan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1456,18 +1732,29 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
+function scatter(
+    base::Value,
+    indices::Vector{Value},
+    index_vec::Value,
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
+    operands = Value[base, indices..., index_vec, mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1507,17 +1794,21 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.shape_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.shape_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1556,19 +1847,25 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
+function shuffle(
+    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
+)
     results = IR.Type[]
-    operands = Value[v1, v2, ]
+    operands = Value[v1, v2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    attributes = NamedAttribute[namedattribute("mask", mask),]
     !isnothing(vector) && push!(results, vector)
-    
-    IR.create_operation(
-        "vector.shuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.shuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1586,17 +1883,21 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate, ]
-    operands = Value[input, ]
+    results = IR.Type[aggregate,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.splat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.splat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1654,18 +1955,24 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
+function store(
+    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices..., ]
+    operands = Value[valueToStore, base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1841,21 +2148,36 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[source, indices..., padding, ]
+function transfer_read(
+    source::Value,
+    indices::Vector{Value},
+    padding::Value,
+    mask=nothing::Union{Nothing,Value};
+    vector::IR.Type,
+    permutation_map,
+    in_bounds=nothing,
+    location=Location(),
+)
+    results = IR.Type[vector,]
+    operands = Value[source, indices..., padding]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
     !isnothing(mask) && push!(operands, mask)
-    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
+    push!(
+        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
+    )
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-    
-    IR.create_operation(
-        "vector.transfer_read", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.transfer_read",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1958,22 +2280,37 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
+function transfer_write(
+    vector::Value,
+    source::Value,
+    indices::Vector{Value},
+    mask=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    permutation_map,
+    in_bounds=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, source, indices..., ]
+    operands = Value[vector, source, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
     !isnothing(mask) && push!(operands, mask)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
+    push!(
+        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
+    )
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-    
-    IR.create_operation(
-        "vector.transfer_write", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.transfer_write",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2004,17 +2341,21 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, ]
+    results = IR.Type[result,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp), ]
-    
-    IR.create_operation(
-        "vector.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp),]
+
+    return IR.create_operation(
+        "vector.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2041,17 +2382,21 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, ]
+    results = IR.Type[result,]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.type_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.type_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2157,18 +2502,29 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[laneid, args..., ]
-    owned_regions = Region[warpRegion, ]
+function warp_execute_on_lane_0(
+    laneid::Value,
+    args::Vector{Value};
+    results::Vector{IR.Type},
+    warp_size,
+    warpRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[laneid, args...]
+    owned_regions = Region[warpRegion,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
-    
-    IR.create_operation(
-        "vector.warp_execute_on_lane_0", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
+
+    return IR.create_operation(
+        "vector.warp_execute_on_lane_0",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2183,18 +2539,22 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/Vector.jl
+++ b/src/Dialects/16/Vector.jl
@@ -1,9 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `vscale`
@@ -19,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -163,28 +150,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,21 +197,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -356,36 +329,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value,
-    masks::Vector{Value};
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc, masks...]
+function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, masks..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -419,22 +375,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -469,29 +421,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -517,29 +458,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -556,25 +487,19 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -604,28 +529,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,29 +561,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -698,23 +603,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -747,30 +646,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -795,30 +682,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -836,29 +713,19 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -884,32 +751,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -970,21 +824,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1036,29 +886,19 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(
-    mask::Value,
-    passthru=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    maskRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mask,]
-    owned_regions = Region[maskRegion,]
+function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mask, ]
+    owned_regions = Region[maskRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-
-    return IR.create_operation(
-        "vector.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1090,29 +930,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1144,28 +973,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1196,34 +1015,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1244,32 +1047,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1323,30 +1113,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1376,20 +1155,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1415,29 +1190,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1525,30 +1290,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1577,21 +1331,17 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res,]
-    operands = Value[source,]
+    results = IR.Type[res, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
-
-    return IR.create_operation(
-        "vector.scalable.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    
+    IR.create_operation(
+        "vector.scalable.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1623,29 +1373,19 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    pos,
-    location=Location(),
-)
+function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.scalable.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scalable.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1666,37 +1406,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1733,29 +1456,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1795,21 +1507,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1848,25 +1556,19 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1884,21 +1586,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1956,24 +1654,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2149,36 +1841,21 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2281,37 +1958,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2342,21 +2004,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2383,21 +2041,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2503,29 +2157,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2540,22 +2183,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/Vector.jl
+++ b/src/Dialects/16/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `vscale`
@@ -18,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -113,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,28 +150,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -219,21 +197,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,36 +329,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value,
-    masks::Vector{Value};
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc, masks...]
+function contract(lhs::Value, rhs::Value, acc::Value, masks::Vector{Value}; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, masks..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -418,22 +375,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,29 +421,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -516,29 +458,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -555,25 +487,19 @@ the proper position. Degenerates to an element type in the 0-D case.
 %2 = vector.extract %0[3, 3, 3]: vector<4x8x16xf32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -603,28 +529,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,29 +561,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -697,23 +603,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -746,30 +646,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -794,30 +682,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -835,29 +713,19 @@ position. Degenerates to a scalar source type when n = 0.
 %5 = vector.insert %3, %4[3, 3, 3] : f32 into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -883,32 +751,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -969,21 +824,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1035,29 +886,19 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(
-    mask::Value,
-    passthru=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    maskRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mask,]
-    owned_regions = Region[maskRegion,]
+function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mask, ]
+    owned_regions = Region[maskRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-
-    return IR.create_operation(
-        "vector.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1089,29 +930,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1143,28 +973,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1195,34 +1015,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1243,32 +1047,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1322,30 +1113,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1375,20 +1155,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,29 +1190,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1524,30 +1290,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1576,21 +1331,17 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res,]
-    operands = Value[source,]
+    results = IR.Type[res, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
-
-    return IR.create_operation(
-        "vector.scalable.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    
+    IR.create_operation(
+        "vector.scalable.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1622,29 +1373,19 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    pos,
-    location=Location(),
-)
+function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.scalable.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scalable.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1665,37 +1406,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1732,29 +1456,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1794,21 +1507,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1847,25 +1556,19 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1883,21 +1586,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1955,24 +1654,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2148,36 +1841,21 @@ for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2280,37 +1958,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2341,21 +2004,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2382,21 +2041,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2502,29 +2157,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2539,22 +2183,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/X86Vector.jl
+++ b/src/Dialects/16/X86Vector.jl
@@ -1,26 +1,32 @@
 module x86vector
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_dp_ps_256(
+    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -42,19 +48,25 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_dot(
+    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, b, ]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.dot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.dot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -62,19 +74,25 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_compress(
+    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, src, k, ]
+    operands = Value[a, src, k]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.compress", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -93,21 +111,33 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
+function avx512_mask_compress(
+    k::Value,
+    a::Value,
+    src=nothing::Union{Nothing,Value};
+    dst=nothing::Union{Nothing,IR.Type},
+    constant_src=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[k, a, ]
+    operands = Value[k, a]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.compress", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constant_src) &&
+        push!(attributes, namedattribute("constant_src", constant_src))
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -125,19 +155,31 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_mask_rndscale(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    dst=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.rndscale", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.rndscale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -145,19 +187,31 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_rndscale_pd_512(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -165,19 +219,31 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_rndscale_ps_512(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -195,19 +261,31 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_mask_scalef(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    dst=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.scalef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.scalef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -215,19 +293,31 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_scalef_pd_512(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -235,19 +325,31 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_scalef_ps_512(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -255,19 +357,25 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_rsqrt_ps_256(
+    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, ]
+    operands = Value[a,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -275,19 +383,23 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, ]
+    operands = Value[a,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-    
-    IR.create_operation(
-        "x86vector.avx.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -295,18 +407,24 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+function avx512_intr_vp2intersect_d_512(
+    a::Value, b::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -326,18 +444,30 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
-    results = IR.Type[k1, k2, ]
-    operands = Value[a, b, ]
+function avx512_vp2intersect(
+    a::Value,
+    b::Value;
+    k1=nothing::Union{Nothing,IR.Type},
+    k2=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.vp2intersect", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(k1) && push!(results, k1)
+    !isnothing(k2) && push!(results, k2)
+
+    return IR.create_operation(
+        "x86vector.avx512.vp2intersect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -345,18 +475,24 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+function avx512_intr_vp2intersect_q_512(
+    a::Value, b::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/16/X86Vector.jl
+++ b/src/Dialects/16/X86Vector.jl
@@ -1,33 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -49,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -75,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -112,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -156,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -188,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -220,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -262,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -294,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -326,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -358,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -384,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -408,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -445,30 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value,
-    b::Value;
-    k1=nothing::Union{Nothing,IR.Type},
-    k2=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(k1) && push!(results, k1)
-    !isnothing(k2) && push!(results, k2)
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -476,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/16/X86Vector.jl
+++ b/src/Dialects/16/X86Vector.jl
@@ -1,32 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -74,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -111,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -155,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -219,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -261,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -293,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -325,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -357,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -383,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,30 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value,
-    b::Value;
-    k1=nothing::Union{Nothing,IR.Type},
-    k2=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(k1) && push!(results, k1)
-    !isnothing(k2) && push!(results, k2)
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -475,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/AMDGPU.jl
+++ b/src/Dialects/17/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `lds_barrier`
@@ -25,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -67,52 +63,25 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    m,
-    n,
-    k,
-    blocks,
-    cbsz=nothing,
-    abid=nothing,
-    blgp=nothing,
-    reducePrecision=nothing,
-    negateA=nothing,
-    negateB=nothing,
-    negateC=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("blocks", blocks),
-    ]
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) &&
-        push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-
-    return IR.create_operation(
-        "amdgpu.mfma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.mfma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -135,39 +104,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_cmpswap(
-    src::Value,
-    cmp::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[src, cmp, memref, indices...]
+function raw_buffer_atomic_cmpswap(src::Value, cmp::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[src, cmp, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_cmpswap",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_cmpswap", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -191,37 +143,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,37 +181,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fmax(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fmax(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,37 +219,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_smax(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_smax(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_smax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -350,37 +257,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_umin(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_umin(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_umin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,37 +308,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,37 +347,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,37 +383,22 @@ containing only 8 valid values:
 The `clamp` flag is used to saturate the output of type T to numeric_limits<T>::max()
 in case of overflow.
 """
-function wmma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    subwordOffset=nothing,
-    unsignedA=nothing,
-    unsignedB=nothing,
-    clamp=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function wmma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, subwordOffset=nothing, unsignedA=nothing, unsignedB=nothing, clamp=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(subwordOffset) &&
-        push!(attributes, namedattribute("subwordOffset", subwordOffset))
+    !isnothing(subwordOffset) && push!(attributes, namedattribute("subwordOffset", subwordOffset))
     !isnothing(unsignedA) && push!(attributes, namedattribute("unsignedA", unsignedA))
     !isnothing(unsignedB) && push!(attributes, namedattribute("unsignedB", unsignedB))
     !isnothing(clamp) && push!(attributes, namedattribute("clamp", clamp))
-
-    return IR.create_operation(
-        "amdgpu.wmma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.wmma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/AMDGPU.jl
+++ b/src/Dialects/17/AMDGPU.jl
@@ -1,8 +1,8 @@
 module amdgpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `lds_barrier`
@@ -25,12 +25,16 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amdgpu.lds_barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.lds_barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -63,25 +67,52 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
-    results = IR.Type[destD, ]
-    operands = Value[sourceA, sourceB, destC, ]
+function mfma(
+    sourceA::Value,
+    sourceB::Value,
+    destC::Value;
+    destD::IR.Type,
+    m,
+    n,
+    k,
+    blocks,
+    cbsz=nothing,
+    abid=nothing,
+    blgp=nothing,
+    reducePrecision=nothing,
+    negateA=nothing,
+    negateB=nothing,
+    negateC=nothing,
+    location=Location(),
+)
+    results = IR.Type[destD,]
+    operands = Value[sourceA, sourceB, destC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
+    attributes = NamedAttribute[
+        namedattribute("m", m),
+        namedattribute("n", n),
+        namedattribute("k", k),
+        namedattribute("blocks", blocks),
+    ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) &&
+        push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-    
-    IR.create_operation(
-        "amdgpu.mfma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.mfma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -104,22 +135,39 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_cmpswap(src::Value, cmp::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[src, cmp, memref, indices..., ]
+function raw_buffer_atomic_cmpswap(
+    src::Value,
+    cmp::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    value::IR.Type,
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[src, cmp, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_cmpswap", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_cmpswap",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -143,22 +191,37 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_atomic_fadd(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -181,22 +244,37 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fmax(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_atomic_fmax(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fmax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -219,22 +297,37 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_smax(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_atomic_smax(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_smax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_smax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -257,22 +350,37 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_umin(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_atomic_umin(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_atomic_umin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_atomic_umin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -308,22 +416,37 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[memref, indices..., ]
+function raw_buffer_load(
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    value::IR.Type,
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -347,22 +470,37 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
+function raw_buffer_store(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value},
+    sgprOffset=nothing::Union{Nothing,Value};
+    boundsCheck=nothing,
+    indexOffset=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
+    )
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-    
-    IR.create_operation(
-        "amdgpu.raw_buffer_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.raw_buffer_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -383,22 +521,37 @@ containing only 8 valid values:
 The `clamp` flag is used to saturate the output of type T to numeric_limits<T>::max()
 in case of overflow.
 """
-function wmma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, subwordOffset=nothing, unsignedA=nothing, unsignedB=nothing, clamp=nothing, location=Location())
-    results = IR.Type[destD, ]
-    operands = Value[sourceA, sourceB, destC, ]
+function wmma(
+    sourceA::Value,
+    sourceB::Value,
+    destC::Value;
+    destD::IR.Type,
+    subwordOffset=nothing,
+    unsignedA=nothing,
+    unsignedB=nothing,
+    clamp=nothing,
+    location=Location(),
+)
+    results = IR.Type[destD,]
+    operands = Value[sourceA, sourceB, destC]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(subwordOffset) && push!(attributes, namedattribute("subwordOffset", subwordOffset))
+    !isnothing(subwordOffset) &&
+        push!(attributes, namedattribute("subwordOffset", subwordOffset))
     !isnothing(unsignedA) && push!(attributes, namedattribute("unsignedA", unsignedA))
     !isnothing(unsignedB) && push!(attributes, namedattribute("unsignedB", unsignedB))
     !isnothing(clamp) && push!(attributes, namedattribute("clamp", clamp))
-    
-    IR.create_operation(
-        "amdgpu.wmma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amdgpu.wmma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/AMDGPU.jl
+++ b/src/Dialects/17/AMDGPU.jl
@@ -1,9 +1,8 @@
 module amdgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `lds_barrier`
@@ -26,16 +25,12 @@ function lds_barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amdgpu.lds_barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.lds_barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -68,52 +63,25 @@ order (that is, v[0] will go to arg[7:0], v[1] to arg[15:8] and so on).
 The negateA, negateB, and negateC flags are only supported for double-precision
 operations on gfx940+.
 """
-function mfma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    m,
-    n,
-    k,
-    blocks,
-    cbsz=nothing,
-    abid=nothing,
-    blgp=nothing,
-    reducePrecision=nothing,
-    negateA=nothing,
-    negateB=nothing,
-    negateC=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function mfma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, m, n, k, blocks, cbsz=nothing, abid=nothing, blgp=nothing, reducePrecision=nothing, negateA=nothing, negateB=nothing, negateC=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("m", m),
-        namedattribute("n", n),
-        namedattribute("k", k),
-        namedattribute("blocks", blocks),
-    ]
+    attributes = NamedAttribute[namedattribute("m", m), namedattribute("n", n), namedattribute("k", k), namedattribute("blocks", blocks), ]
     !isnothing(cbsz) && push!(attributes, namedattribute("cbsz", cbsz))
     !isnothing(abid) && push!(attributes, namedattribute("abid", abid))
     !isnothing(blgp) && push!(attributes, namedattribute("blgp", blgp))
-    !isnothing(reducePrecision) &&
-        push!(attributes, namedattribute("reducePrecision", reducePrecision))
+    !isnothing(reducePrecision) && push!(attributes, namedattribute("reducePrecision", reducePrecision))
     !isnothing(negateA) && push!(attributes, namedattribute("negateA", negateA))
     !isnothing(negateB) && push!(attributes, namedattribute("negateB", negateB))
     !isnothing(negateC) && push!(attributes, namedattribute("negateC", negateC))
-
-    return IR.create_operation(
-        "amdgpu.mfma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.mfma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,39 +104,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_cmpswap(
-    src::Value,
-    cmp::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[src, cmp, memref, indices...]
+function raw_buffer_atomic_cmpswap(src::Value, cmp::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[src, cmp, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_cmpswap",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_cmpswap", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -192,37 +143,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fadd(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fadd(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,37 +181,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_fmax(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_fmax(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_fmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -298,37 +219,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_smax(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_smax(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_smax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_smax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -351,37 +257,22 @@ Out of bounds atomic operations are ignored in hardware.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_atomic_umin(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_atomic_umin(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_atomic_umin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_atomic_umin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,37 +308,22 @@ are translated to intrinsic arguments as follows:
   to 2 to disable bounds checks, otherwise it is 3
 - The cache coherency bits are off
 """
-function raw_buffer_load(
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    value::IR.Type,
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[memref, indices...]
+function raw_buffer_load(memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; value::IR.Type, boundsCheck=nothing, indexOffset=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -471,37 +347,22 @@ components is partically completed is chipset-dependent.
 See `amdgpu.raw_buffer_load` for a description of how the underlying
 instruction is constructed.
 """
-function raw_buffer_store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value},
-    sgprOffset=nothing::Union{Nothing,Value};
-    boundsCheck=nothing,
-    indexOffset=nothing,
-    location=Location(),
-)
+function raw_buffer_store(value::Value, memref::Value, indices::Vector{Value}, sgprOffset=nothing::Union{Nothing, Value}; boundsCheck=nothing, indexOffset=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sgprOffset) && push!(operands, sgprOffset)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(indices), (sgprOffset == nothing) ? 0 : 1]),
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (sgprOffset==nothing) ? 0 : 1]))
     !isnothing(boundsCheck) && push!(attributes, namedattribute("boundsCheck", boundsCheck))
     !isnothing(indexOffset) && push!(attributes, namedattribute("indexOffset", indexOffset))
-
-    return IR.create_operation(
-        "amdgpu.raw_buffer_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.raw_buffer_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,37 +383,22 @@ containing only 8 valid values:
 The `clamp` flag is used to saturate the output of type T to numeric_limits<T>::max()
 in case of overflow.
 """
-function wmma(
-    sourceA::Value,
-    sourceB::Value,
-    destC::Value;
-    destD::IR.Type,
-    subwordOffset=nothing,
-    unsignedA=nothing,
-    unsignedB=nothing,
-    clamp=nothing,
-    location=Location(),
-)
-    results = IR.Type[destD,]
-    operands = Value[sourceA, sourceB, destC]
+function wmma(sourceA::Value, sourceB::Value, destC::Value; destD::IR.Type, subwordOffset=nothing, unsignedA=nothing, unsignedB=nothing, clamp=nothing, location=Location())
+    results = IR.Type[destD, ]
+    operands = Value[sourceA, sourceB, destC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(subwordOffset) &&
-        push!(attributes, namedattribute("subwordOffset", subwordOffset))
+    !isnothing(subwordOffset) && push!(attributes, namedattribute("subwordOffset", subwordOffset))
     !isnothing(unsignedA) && push!(attributes, namedattribute("unsignedA", unsignedA))
     !isnothing(unsignedB) && push!(attributes, namedattribute("unsignedB", unsignedB))
     !isnothing(clamp) && push!(attributes, namedattribute("clamp", clamp))
-
-    return IR.create_operation(
-        "amdgpu.wmma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amdgpu.wmma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/AMX.jl
+++ b/src/Dialects/17/AMX.jl
@@ -1,38 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -40,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -104,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -296,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -332,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -377,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/AMX.jl
+++ b/src/Dialects/17/AMX.jl
@@ -1,25 +1,38 @@
 module amx
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbf16ps(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbf16ps", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbf16ps",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -27,18 +40,31 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbssd(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbssd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbssd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -46,18 +72,31 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbsud(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbsud", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbsud",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -65,18 +104,31 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbusd(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbusd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbusd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -84,18 +136,31 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
+function tdpbuud(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value,
+    operand_5::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tdpbuud", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tdpbuud",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -103,18 +168,29 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+function tileloadd64(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    res::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tileloadd64", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tileloadd64",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -122,18 +198,29 @@ end
 `tilestored64`
 
 """
-function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function tilestored64(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tilestored64", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tilestored64",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -142,17 +229,21 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, ]
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tilezero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tilezero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -171,17 +262,21 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[base, indices..., ]
+    results = IR.Type[res,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -201,17 +296,21 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, acc, ]
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -233,20 +332,32 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, acc, ]
+function tile_muli(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    res::IR.Type,
+    isZextLhs=nothing,
+    isZextRhs=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-    
-    IR.create_operation(
-        "amx.tile_muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -266,16 +377,20 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val, ]
+    operands = Value[base, indices..., val]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -293,17 +408,21 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "amx.tile_zero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "amx.tile_zero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/AMX.jl
+++ b/src/Dialects/17/AMX.jl
@@ -1,39 +1,25 @@
 module amx
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `tdpbf16ps`
 
 """
-function tdpbf16ps(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbf16ps(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbf16ps",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbf16ps", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -41,31 +27,18 @@ end
 `tdpbssd`
 
 """
-function tdpbssd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbssd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbssd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbssd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,31 +46,18 @@ end
 `tdpbsud`
 
 """
-function tdpbsud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbsud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbsud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbsud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -105,31 +65,18 @@ end
 `tdpbusd`
 
 """
-function tdpbusd(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbusd(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbusd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbusd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -137,31 +84,18 @@ end
 `tdpbuud`
 
 """
-function tdpbuud(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value,
-    operand_5::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5]
+function tdpbuud(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value, operand_5::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, operand_5, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tdpbuud",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tdpbuud", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -169,29 +103,18 @@ end
 `tileloadd64`
 
 """
-function tileloadd64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    res::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+function tileloadd64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tileloadd64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tileloadd64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,29 +122,18 @@ end
 `tilestored64`
 
 """
-function tilestored64(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function tilestored64(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilestored64",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilestored64", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -230,21 +142,17 @@ end
 
 """
 function tilezero(operand_0::Value, operand_1::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tilezero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tilezero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,21 +171,17 @@ corresponding tile configuration.
 ```
 """
 function tile_load(base::Value, indices::Vector{Value}; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[base, indices...]
+    results = IR.Type[res, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -297,21 +201,17 @@ pairs of \"bf16\"). The operation is eventually lowered into the
 ```
 """
 function tile_mulf(lhs::Value, rhs::Value, acc::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,32 +233,20 @@ instructions with the corresponding tile configuration.
     : vector<16x64xi8>, vector<16x64xi8>, vector<16x16xi32>
 ```
 """
-function tile_muli(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    res::IR.Type,
-    isZextLhs=nothing,
-    isZextRhs=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs, acc]
+function tile_muli(lhs::Value, rhs::Value, acc::Value; res::IR.Type, isZextLhs=nothing, isZextRhs=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(isZextLhs) && push!(attributes, namedattribute("isZextLhs", isZextLhs))
     !isnothing(isZextRhs) && push!(attributes, namedattribute("isZextRhs", isZextRhs))
-
-    return IR.create_operation(
-        "amx.tile_muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -378,20 +266,16 @@ corresponding tile configuration.
 """
 function tile_store(base::Value, indices::Vector{Value}, val::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., val]
+    operands = Value[base, indices..., val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -409,21 +293,17 @@ vector type of the result. This is eventually lowered into the
 ```
 """
 function tile_zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "amx.tile_zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "amx.tile_zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Affine.jl
+++ b/src/Dialects/17/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply`
@@ -27,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -68,27 +64,18 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(
-    linear_index::Value,
-    basis::Vector{Value};
-    multi_index::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[multi_index...,]
-    operands = Value[linear_index, basis...]
+function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
+    results = IR.Type[multi_index..., ]
+    operands = Value[linear_index, basis..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.delinearize_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.delinearize_index", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,24 +186,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -290,28 +271,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -344,21 +315,17 @@ Example 2: Uses `symbol` keyword for symbols `%n` and `%m`.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -374,22 +341,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -415,22 +378,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -499,40 +458,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,33 +491,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -614,20 +536,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -670,24 +588,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-mlirvectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -732,24 +644,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-mlirvectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -766,22 +672,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Affine.jl
+++ b/src/Dialects/17/Affine.jl
@@ -1,8 +1,8 @@
 module affine
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply`
@@ -27,17 +27,21 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[mapOperands..., ]
+    results = IR.Type[result_0,]
+    operands = Value[mapOperands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.apply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.apply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -64,18 +68,27 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
-    results = IR.Type[multi_index..., ]
-    operands = Value[linear_index, basis..., ]
+function delinearize_index(
+    linear_index::Value,
+    basis::Vector{Value};
+    multi_index::Vector{IR.Type},
+    location=Location(),
+)
+    results = IR.Type[multi_index...,]
+    operands = Value[linear_index, basis...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.delinearize_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.delinearize_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -186,18 +199,24 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operand_0..., ]
-    owned_regions = Region[region, ]
+function for_(
+    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[operand_0...,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -271,18 +290,28 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operand_0..., ]
-    owned_regions = Region[thenRegion, elseRegion, ]
+function if_(
+    operand_0::Vector{Value};
+    results::Vector{IR.Type},
+    thenRegion::Region,
+    elseRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[operand_0...,]
+    owned_regions = Region[thenRegion, elseRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -315,17 +344,21 @@ Example 2: Uses `symbol` keyword for symbols `%n` and `%m`.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -341,18 +374,22 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.max", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -378,18 +415,22 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map), ]
-    
-    IR.create_operation(
-        "affine.min", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("map", map),]
+
+    return IR.create_operation(
+        "affine.min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,18 +499,40 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[mapOperands..., ]
-    owned_regions = Region[region, ]
+function parallel(
+    mapOperands::Vector{Value};
+    results::Vector{IR.Type},
+    reductions,
+    lowerBoundsMap,
+    lowerBoundsGroups,
+    upperBoundsMap,
+    upperBoundsGroups,
+    steps,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[mapOperands...,]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
-    
-    IR.create_operation(
-        "affine.parallel", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("reductions", reductions),
+        namedattribute("lowerBoundsMap", lowerBoundsMap),
+        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
+        namedattribute("upperBoundsMap", upperBoundsMap),
+        namedattribute("upperBoundsGroups", upperBoundsGroups),
+        namedattribute("steps", steps),
+    ]
+
+    return IR.create_operation(
+        "affine.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -491,18 +554,33 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
+function prefetch(
+    memref::Value,
+    indices::Vector{Value};
+    isWrite,
+    localityHint,
+    isDataCache,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memref, indices..., ]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
-    
-    IR.create_operation(
-        "affine.prefetch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("isWrite", isWrite),
+        namedattribute("localityHint", localityHint),
+        namedattribute("isDataCache", isDataCache),
+    ]
+
+    return IR.create_operation(
+        "affine.prefetch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -536,16 +614,20 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -588,18 +670,24 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-mlirvectortransferreadop)).
 """
-function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+function vector_load(
+    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.vector_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.vector_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -644,18 +732,24 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-mlirvectortransferwriteop)).
 """
-function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
+function vector_store(
+    value::Value, memref::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.vector_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.vector_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -672,18 +766,22 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "affine.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "affine.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Affine.jl
+++ b/src/Dialects/17/Affine.jl
@@ -1,9 +1,8 @@
 module affine
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply`
@@ -28,21 +27,17 @@ have ‘index’ type.
 ```
 """
 function apply(mapOperands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[mapOperands...,]
+    results = IR.Type[result_0, ]
+    operands = Value[mapOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -69,27 +64,18 @@ In the above example, `%indices:3` conceptually holds the following:
 %indices_2 = affine.apply #map2()[%linear_index]
 ```
 """
-function delinearize_index(
-    linear_index::Value,
-    basis::Vector{Value};
-    multi_index::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[multi_index...,]
-    operands = Value[linear_index, basis...]
+function delinearize_index(linear_index::Value, basis::Vector{Value}; multi_index::Vector{IR.Type}, location=Location())
+    results = IR.Type[multi_index..., ]
+    operands = Value[linear_index, basis..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.delinearize_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.delinearize_index", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -200,24 +186,18 @@ If the `affine.for` defines any values, a yield terminator must be
 explicitly present. The number and types of the \"affine.for\" results must
 match the initial values in the `iter_args` binding and the yield operands.
 """
-function for_(
-    operand_0::Vector{Value}; results::Vector{IR.Type}, region::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[region,]
+function for_(operand_0::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -291,28 +271,18 @@ func.func @pad_edges(%I : memref<10x10xf32>) -> (memref<12x12xf32) {
 }
 ```
 """
-function if_(
-    operand_0::Vector{Value};
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operand_0...,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(operand_0::Vector{Value}; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operand_0..., ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -345,21 +315,17 @@ Example 2: Uses `symbol` keyword for symbols `%n` and `%m`.
 ```
 """
 function load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -375,22 +341,18 @@ affine map.
 %0 = affine.max (d0) -> (1000, d0 + 512) (%i0) : index
 ```
 """
-function max(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function max(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,22 +378,18 @@ input operands and result must all have \'index\' type.
 %0 = affine.min affine_map<(d0)[s0] -> (1000, d0 + 512, s0)> (%arg0)[%arg1]
 ```
 """
-function min(operands::Vector{Value}; result_0::IR.Type, map, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function min(operands_::Vector{Value}; result_0::IR.Type, map, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map", map),]
-
-    return IR.create_operation(
-        "affine.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("map", map), ]
+    
+    IR.create_operation(
+        "affine.min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -500,40 +458,18 @@ affine.parallel (%ii, %jj) = (0, 0) to (%N, %M) step (32, 32) {
 }
 ```
 """
-function parallel(
-    mapOperands::Vector{Value};
-    results::Vector{IR.Type},
-    reductions,
-    lowerBoundsMap,
-    lowerBoundsGroups,
-    upperBoundsMap,
-    upperBoundsGroups,
-    steps,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mapOperands...,]
-    owned_regions = Region[region,]
+function parallel(mapOperands::Vector{Value}; results_::Vector{IR.Type}, reductions, lowerBoundsMap, lowerBoundsGroups, upperBoundsMap, upperBoundsGroups, steps, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mapOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("reductions", reductions),
-        namedattribute("lowerBoundsMap", lowerBoundsMap),
-        namedattribute("lowerBoundsGroups", lowerBoundsGroups),
-        namedattribute("upperBoundsMap", upperBoundsMap),
-        namedattribute("upperBoundsGroups", upperBoundsGroups),
-        namedattribute("steps", steps),
-    ]
-
-    return IR.create_operation(
-        "affine.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reductions", reductions), namedattribute("lowerBoundsMap", lowerBoundsMap), namedattribute("lowerBoundsGroups", lowerBoundsGroups), namedattribute("upperBoundsMap", upperBoundsMap), namedattribute("upperBoundsGroups", upperBoundsGroups), namedattribute("steps", steps), ]
+    
+    IR.create_operation(
+        "affine.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,33 +491,18 @@ local keep in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "affine.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "affine.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -615,20 +536,16 @@ affine.store %v0, %0[%i0 + symbol(%n), %i1 + symbol(%m)] : memref<100x100xf32>
 """
 function store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -671,24 +588,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is read from memory
 (see [vector.transfer_read](../Vector/#vectortransfer_read-mlirvectortransferreadop)).
 """
-function vector_load(
-    memref::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
+function vector_load(memref::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -733,24 +644,18 @@ TODOs:
 * Consider adding a permutation map to permute the slice that is written to memory
 (see [vector.transfer_write](../Vector/#vectortransfer_write-mlirvectortransferwriteop)).
 """
-function vector_store(
-    value::Value, memref::Value, indices::Vector{Value}; location=Location()
-)
+function vector_store(value::Value, memref::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.vector_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.vector_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -767,22 +672,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "affine.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "affine.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Arith.jl
+++ b/src/Dialects/17/Arith.jl
@@ -1,9 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `addf`
@@ -29,30 +28,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -77,25 +66,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -120,24 +103,18 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(
-    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
-)
-    results = IR.Type[sum, overflow]
-    operands = Value[lhs, rhs]
+function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
+    results = IR.Type[sum, overflow, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.addui_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addui_extended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -162,25 +139,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -203,21 +174,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -236,25 +203,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -275,25 +236,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -324,29 +279,18 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -415,29 +359,18 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -458,23 +391,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -482,30 +411,20 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,25 +450,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -576,25 +489,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -606,21 +513,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,21 +548,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -683,21 +582,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,21 +604,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -735,21 +626,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -769,25 +656,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -800,21 +681,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -827,21 +704,17 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_castui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_castui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -864,30 +737,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -895,25 +758,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -921,25 +778,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -962,30 +813,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -993,25 +834,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1019,25 +854,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1065,30 +894,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1096,25 +915,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1139,30 +952,20 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mulsi_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulsi_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1187,30 +990,20 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mului_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mului_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1235,29 +1028,20 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1282,25 +1066,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1308,30 +1086,20 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1357,25 +1125,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1401,25 +1163,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1432,21 +1188,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1464,25 +1216,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1504,25 +1250,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1541,25 +1281,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1587,30 +1321,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1618,25 +1342,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1649,21 +1367,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1686,21 +1400,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1713,21 +1423,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1752,25 +1458,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1804,29 +1504,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/Arith.jl
+++ b/src/Dialects/17/Arith.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `addf`
@@ -28,20 +28,30 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function addf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.addf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -66,19 +76,25 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function addi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.addi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -103,18 +119,24 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
-    results = IR.Type[sum, overflow, ]
-    operands = Value[lhs, rhs, ]
+function addui_extended(
+    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
+)
+    results = IR.Type[sum, overflow]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.addui_extended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.addui_extended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -139,19 +161,25 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function andi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.andi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.andi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -174,17 +202,21 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -203,19 +235,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ceildivsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ceildivsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -236,19 +274,25 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ceildivui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ceildivui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -279,18 +323,29 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+function cmpf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    predicate,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "arith.cmpf", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "arith.cmpf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -359,18 +414,29 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+function cmpi(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    predicate,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "arith.cmpi", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "arith.cmpi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -391,19 +457,23 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -411,20 +481,30 @@ end
 `divf`
 
 """
-function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function divf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.divf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -450,19 +530,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -489,19 +575,25 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.divui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.divui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -513,17 +605,21 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -548,17 +644,21 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -582,17 +682,21 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.extui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.extui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -604,17 +708,21 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.fptosi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.fptosi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -626,17 +734,21 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.fptoui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.fptoui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -656,19 +768,25 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function floordivsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.floordivsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.floordivsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -681,17 +799,21 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.index_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.index_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -704,17 +826,21 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.index_castui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.index_castui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -737,20 +863,30 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function maxf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.maxf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -758,19 +894,25 @@ end
 `maxsi`
 
 """
-function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -778,19 +920,25 @@ end
 `maxui`
 
 """
-function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.maxui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.maxui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -813,20 +961,30 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function minf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.minf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -834,19 +992,25 @@ end
 `minsi`
 
 """
-function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -854,19 +1018,25 @@ end
 `minui`
 
 """
-function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.minui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.minui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -894,20 +1064,30 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function mulf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -915,19 +1095,25 @@ end
 `muli`
 
 """
-function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function muli(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -952,20 +1138,30 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
+function mulsi_extended(
+    lhs::Value,
+    rhs::Value;
+    low=nothing::Union{Nothing,IR.Type},
+    high=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-    
-    IR.create_operation(
-        "arith.mulsi_extended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mulsi_extended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -990,20 +1186,30 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
+function mului_extended(
+    lhs::Value,
+    rhs::Value;
+    low=nothing::Union{Nothing,IR.Type},
+    high=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-    
-    IR.create_operation(
-        "arith.mului_extended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.mului_extended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1028,20 +1234,29 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function negf(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.negf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.negf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1066,19 +1281,25 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ori(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.ori", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.ori",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1086,20 +1307,30 @@ end
 `remf`
 
 """
-function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function remf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.remf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1125,19 +1356,25 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1163,19 +1400,25 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.remui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.remui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1188,17 +1431,21 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.sitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.sitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1216,19 +1463,25 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shli(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1250,19 +1503,25 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrsi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shrsi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shrsi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1281,19 +1540,25 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrui(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.shrui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.shrui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1321,20 +1586,30 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function subf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "arith.subf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.subf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1342,19 +1617,25 @@ end
 `subi`
 
 """
-function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.subi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.subi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1367,17 +1648,21 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.truncf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.truncf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1400,17 +1685,21 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.trunci", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.trunci",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1423,17 +1712,21 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out, ]
-    operands = Value[in, ]
+    results = IR.Type[out,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arith.uitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.uitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1458,19 +1751,25 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function xori(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.xori", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.xori",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1504,19 +1803,29 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function select(
+    condition::Value,
+    true_value::Value,
+    false_value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value, ]
+    operands = Value[condition, true_value, false_value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "arith.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arith.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/17/Arith.jl
+++ b/src/Dialects/17/Arith.jl
@@ -1,8 +1,8 @@
 module arith
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `addf`
@@ -28,30 +28,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function addf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function addf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -76,25 +66,19 @@ has no standard attributes.
 %x = arith.addi %y, %z : tensor<4x?xi8>
 ```
 """
-function addi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function addi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -119,24 +103,18 @@ indicates no overflow.
 %x:2 = arith.addui_extended %y, %z : tensor<4x?xi8>, tensor<4x?xi1>
 ```
 """
-function addui_extended(
-    lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location()
-)
-    results = IR.Type[sum, overflow]
-    operands = Value[lhs, rhs]
+function addui_extended(lhs::Value, rhs::Value; sum::IR.Type, overflow::IR.Type, location=Location())
+    results = IR.Type[sum, overflow, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.addui_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.addui_extended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,25 +139,19 @@ has no standard attributes.
 %x = arith.andi %y, %z : tensor<4x?xi8>
 ```
 """
-function andi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function andi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.andi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.andi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -202,21 +174,17 @@ integer is little-endian) a proper lowering would add operations to swap the
 order of words in addition to the bitcast.
 """
 function bitcast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,25 +203,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %a = arith.ceildivsi %b, %c : i64
 ```
 """
-function ceildivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -274,25 +236,19 @@ behavior.
 %a = arith.ceildivui %b, %c : i64
 ```
 """
-function ceildivui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ceildivui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ceildivui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,29 +279,18 @@ attribute by the parser.
 %r3 = \"arith.cmpf\"(%0, %1) {predicate: 0} : (f8, f8) -> i1
 ```
 """
-function cmpf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpf(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -414,29 +359,18 @@ complement or large positives
     : (vector<4xi64>, vector<4xi64>) -> vector<4xi1>
 ```
 """
-function cmpi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function cmpi(lhs::Value, rhs::Value; result::IR.Type, predicate, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "arith.cmpi", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -457,23 +391,19 @@ forms simple integer and floating point constants.
 %1 = \"arith.constant\"() {value = 42 : i32} : () -> i32
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -481,30 +411,20 @@ end
 `divf`
 
 """
-function divf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function divf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -530,25 +450,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 %x = arith.divsi %y, %z : tensor<4x?xi8>
 ```
 """
-function divsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -575,25 +489,19 @@ behavior.
 %x = arith.divui %y, %z : tensor<4x?xi8>
 ```
 """
-function divui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.divui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.divui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -605,21 +513,17 @@ The destination type must to be strictly wider than the source type.
 When operating on vectors, casts elementwise.
 """
 function extf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -644,21 +548,17 @@ of the most-significant bit of the input.
 ```
 """
 function extsi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extsi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -682,21 +582,17 @@ The top-most (N - M) bits of the output are filled with zeros.
 ```
 """
 function extui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.extui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.extui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -708,21 +604,17 @@ towards zero) signed integer value. When operating on vectors, casts
 elementwise.
 """
 function fptosi(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -734,21 +626,17 @@ towards zero) unsigned integer value. When operating on vectors, casts
 elementwise.
 """
 function fptoui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,25 +656,19 @@ value divided by -1) is TBD; do NOT assume any specific behavior.
 
 ```
 """
-function floordivsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.floordivsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.floordivsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -799,21 +681,17 @@ a wider integer, the value is sign-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_cast(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -826,21 +704,17 @@ a wider integer, the value is zero-extended. If casting to a narrower
 integer, the value is truncated.
 """
 function index_castui(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.index_castui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.index_castui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -863,30 +737,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.maxf %b, %c : f64
 ```
 """
-function maxf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function maxf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.maxf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,25 +758,19 @@ end
 `maxsi`
 
 """
-function maxsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -920,25 +778,19 @@ end
 `maxui`
 
 """
-function maxui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.maxui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.maxui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -961,30 +813,20 @@ If one of the arguments is NaN, then the result is also NaN.
 %a = arith.minf %b, %c : f64
 ```
 """
-function minf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function minf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.minf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -992,25 +834,19 @@ end
 `minsi`
 
 """
-function minsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1018,25 +854,19 @@ end
 `minui`
 
 """
-function minui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.minui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.minui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1064,30 +894,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function mulf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function mulf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1095,25 +915,19 @@ end
 `muli`
 
 """
-function muli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function muli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.muli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1138,30 +952,20 @@ the same operands.
 %x:2 = arith.mulsi_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mulsi_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mulsi_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mulsi_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mulsi_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1186,30 +990,20 @@ the same operands.
 %x:2 = arith.mului_extended %y, %z : tensor<4x?xi8>
 ```
 """
-function mului_extended(
-    lhs::Value,
-    rhs::Value;
-    low=nothing::Union{Nothing,IR.Type},
-    high=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function mului_extended(lhs::Value, rhs::Value; low=nothing::Union{Nothing, IR.Type}, high=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(low) && push!(results, low)
     !isnothing(high) && push!(results, high)
-
-    return IR.create_operation(
-        "arith.mului_extended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.mului_extended", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1234,29 +1028,20 @@ It has no standard attributes.
 %x = arith.negf %y : tensor<4x?xf8>
 ```
 """
-function negf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function negf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.negf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1281,25 +1066,19 @@ standard attributes.
 %x = arith.ori %y, %z : tensor<4x?xi8>
 ```
 """
-function ori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.ori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.ori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1307,30 +1086,20 @@ end
 `remf`
 
 """
-function remf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function remf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.remf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1356,25 +1125,19 @@ behavior.
 %x = arith.remsi %y, %z : tensor<4x?xi8>
 ```
 """
-function remsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1400,25 +1163,19 @@ behavior.
 %x = arith.remui %y, %z : tensor<4x?xi8>
 ```
 """
-function remui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.remui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.remui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1431,21 +1188,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function sitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1463,25 +1216,19 @@ amount. The low order bits are filled with zeros.
 %3 = arith.shli %1, %2 : (i8, i8) -> i8    // %3 is 0b00101000
 ```
 """
-function shli(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shli(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shli", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1503,25 +1250,19 @@ value (which means that the sign of the value is preserved).
 %5 = arith.shrsi %4, %2 : (i8, i8) -> i8   // %5 is 0b00001100
 ```
 """
-function shrsi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrsi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrsi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrsi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1540,25 +1281,19 @@ always filled with zeros.
 %3 = arith.shrui %1, %2 : (i8, i8) -> i8   // %3 is 0b00010100
 ```
 """
-function shrui(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrui(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.shrui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.shrui", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1586,30 +1321,20 @@ floating point tensor.
 TODO: In the distant future, this will accept optional attributes for fast
 math, contraction, rounding mode, and other controls.
 """
-function subf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function subf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "arith.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1617,25 +1342,19 @@ end
 `subi`
 
 """
-function subi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function subi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.subi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1648,21 +1367,17 @@ If the value cannot be exactly represented, it is rounded using the default
 rounding mode. When operating on vectors, casts elementwise.
 """
 function truncf(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.truncf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.truncf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1685,21 +1400,17 @@ The top-most (N - M) bits of the input are discarded.
 ```
 """
 function trunci(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.trunci",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.trunci", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1712,21 +1423,17 @@ rounded using the default rounding mode. When operating on vectors, casts
 elementwise.
 """
 function uitofp(in::Value; out::IR.Type, location=Location())
-    results = IR.Type[out,]
-    operands = Value[in,]
+    results = IR.Type[out, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arith.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1751,25 +1458,19 @@ has no standard attributes.
 %x = arith.xori %y, %z : tensor<4x?xi8>
 ```
 """
-function xori(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xori(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.xori",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.xori", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1803,29 +1504,19 @@ or tensor is chosen.
 %vx = arith.select %cond, %vtrue, %vfalse : vector<42xf32>
 ```
 """
-function select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "arith.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arith.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/ArmNeon.jl
+++ b/src/Dialects/17/ArmNeon.jl
@@ -1,9 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_smull`
@@ -17,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -48,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/ArmNeon.jl
+++ b/src/Dialects/17/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_smull`
@@ -16,21 +16,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b]
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.smull",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.smull", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -47,21 +43,17 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.2d.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.2d.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,21 +68,17 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[a, b, c]
+    results = IR.Type[res, ]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_neon.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_neon.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/ArmNeon.jl
+++ b/src/Dialects/17/ArmNeon.jl
@@ -1,8 +1,8 @@
 module arm_neon
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `intr_smull`
@@ -16,17 +16,21 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_smull(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.intr.smull", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.intr.smull",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -43,17 +47,21 @@ res[i] := a[i] + dot_product(b[i, ...], c[i, ...])
 ```
 """
 function _2d_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, c, ]
+    results = IR.Type[res,]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.2d.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.2d.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -68,17 +76,21 @@ Source:
 https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics
 """
 function intr_sdot(a::Value, b::Value, c::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, c, ]
+    results = IR.Type[res,]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_neon.intr.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_neon.intr.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/ArmSME.jl
+++ b/src/Dialects/17/ArmSME.jl
@@ -1,8 +1,8 @@
 module arm_sme
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `cast_tile_to_vector`
@@ -43,17 +43,21 @@ Canonicalization will look through `arm_sme.cast_tile_to_vector` and fold
 the cast away if it comes from a `arm_sme.cast_vector_to_tile`.
 """
 function cast_tile_to_vector(tile_id::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[tile_id, ]
+    results = IR.Type[vector,]
+    operands = Value[tile_id,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.cast_tile_to_vector", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.cast_tile_to_vector",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,17 +90,21 @@ Canonicalization will look through `arm_sme.cast_vector_to_tile` and fold
 the cast away if it comes from a `arm_sme.cast_tile_to_vector`.
 """
 function cast_vector_to_tile(vector::Value; tile_id::IR.Type, location=Location())
-    results = IR.Type[tile_id, ]
-    operands = Value[vector, ]
+    results = IR.Type[tile_id,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.cast_vector_to_tile", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.cast_vector_to_tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -130,17 +138,21 @@ functions.
 ```
 """
 function get_tile_id(; tile_id::IR.Type, location=Location())
-    results = IR.Type[tile_id, ]
+    results = IR.Type[tile_id,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.get_tile_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.get_tile_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -148,18 +160,28 @@ end
 `intr_ld1b_horiz`
 
 """
-function intr_ld1b_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1b_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1b.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1b.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -167,18 +189,28 @@ end
 `intr_ld1b_vert`
 
 """
-function intr_ld1b_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1b_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1b.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1b.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -186,18 +218,28 @@ end
 `intr_ld1d_horiz`
 
 """
-function intr_ld1d_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1d_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1d.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1d.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -205,18 +247,28 @@ end
 `intr_ld1d_vert`
 
 """
-function intr_ld1d_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1d_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1d.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1d.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -224,18 +276,28 @@ end
 `intr_ld1h_horiz`
 
 """
-function intr_ld1h_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1h_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1h.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1h.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -243,18 +305,28 @@ end
 `intr_ld1h_vert`
 
 """
-function intr_ld1h_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1h_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1h.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1h.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -262,18 +334,28 @@ end
 `intr_ld1q_horiz`
 
 """
-function intr_ld1q_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1q_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1q.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1q.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -281,18 +363,28 @@ end
 `intr_ld1q_vert`
 
 """
-function intr_ld1q_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1q_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1q.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1q.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -300,18 +392,28 @@ end
 `intr_ld1w_horiz`
 
 """
-function intr_ld1w_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1w_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1w.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1w.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -319,18 +421,28 @@ end
 `intr_ld1w_vert`
 
 """
-function intr_ld1w_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_ld1w_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.ld1w.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.ld1w.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -338,18 +450,29 @@ end
 `intr_mopa`
 
 """
-function intr_mopa(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_mopa(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.mopa", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.mopa",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -357,18 +480,29 @@ end
 `intr_mopa_wide`
 
 """
-function intr_mopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_mopa_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.mopa.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.mopa.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -376,18 +510,29 @@ end
 `intr_mops`
 
 """
-function intr_mops(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_mops(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.mops", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.mops",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -395,18 +540,29 @@ end
 `intr_mops_wide`
 
 """
-function intr_mops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_mops_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.mops.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.mops.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -414,18 +570,29 @@ end
 `intr_smopa_wide`
 
 """
-function intr_smopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_smopa_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.smopa.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.smopa.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -433,18 +600,29 @@ end
 `intr_smops_wide`
 
 """
-function intr_smops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_smops_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.smops.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.smops.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -452,18 +630,28 @@ end
 `intr_st1b_horiz`
 
 """
-function intr_st1b_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1b_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1b.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1b.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -471,18 +659,28 @@ end
 `intr_st1b_vert`
 
 """
-function intr_st1b_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1b_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1b.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1b.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -490,18 +688,28 @@ end
 `intr_st1d_horiz`
 
 """
-function intr_st1d_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1d_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1d.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1d.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -509,18 +717,28 @@ end
 `intr_st1d_vert`
 
 """
-function intr_st1d_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1d_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1d.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1d.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -528,18 +746,28 @@ end
 `intr_st1h_horiz`
 
 """
-function intr_st1h_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1h_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1h.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1h.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -547,18 +775,28 @@ end
 `intr_st1h_vert`
 
 """
-function intr_st1h_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1h_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1h.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1h.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -566,18 +804,28 @@ end
 `intr_st1q_horiz`
 
 """
-function intr_st1q_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1q_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1q.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1q.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -585,18 +833,28 @@ end
 `intr_st1q_vert`
 
 """
-function intr_st1q_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1q_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1q.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1q.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -604,18 +862,28 @@ end
 `intr_st1w_horiz`
 
 """
-function intr_st1w_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1w_horiz(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1w.horiz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1w.horiz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -623,18 +891,28 @@ end
 `intr_st1w_vert`
 
 """
-function intr_st1w_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
+function intr_st1w_vert(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.st1w.vert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.st1w.vert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -644,16 +922,20 @@ end
 """
 function intr_str(operand_0::Value, operand_1::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, ]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.str", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.str",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -661,18 +943,29 @@ end
 `intr_sumopa_wide`
 
 """
-function intr_sumopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_sumopa_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.sumopa.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.sumopa.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -680,18 +973,29 @@ end
 `intr_sumops_wide`
 
 """
-function intr_sumops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_sumops_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.sumops.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.sumops.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -699,18 +1003,29 @@ end
 `intr_umopa_wide`
 
 """
-function intr_umopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_umopa_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.umopa.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.umopa.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -718,18 +1033,29 @@ end
 `intr_umops_wide`
 
 """
-function intr_umops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_umops_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.umops.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.umops.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -737,18 +1063,29 @@ end
 `intr_usmopa_wide`
 
 """
-function intr_usmopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_usmopa_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.usmopa.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.usmopa.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -756,18 +1093,29 @@ end
 `intr_usmops_wide`
 
 """
-function intr_usmops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
+function intr_usmops_wide(
+    operand_0::Value,
+    operand_1::Value,
+    operand_2::Value,
+    operand_3::Value,
+    operand_4::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.usmops.wide", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.usmops.wide",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -781,12 +1129,16 @@ function intr_za_disable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.za.disable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.za.disable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -800,12 +1152,16 @@ function intr_za_enable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.za.enable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.za.enable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -815,16 +1171,20 @@ end
 """
 function intr_zero(operand_0::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, ]
+    operands = Value[operand_0,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.intr.zero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.intr.zero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -852,18 +1212,24 @@ Example 3: Load a 128-bit element ZA tile from memory.
 %tile = arm_sme.tile_load %base[%c0, %c0] : memref<?x?xi128>, vector<[1]x[1]xi128>
 ```
 """
-function tile_load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., ]
+function tile_load(
+    base::Value, indices::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.tile_load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.tile_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -892,18 +1258,24 @@ Example 3: Store a 128-bit element ZA tile to memory.
 arm_sme.tile_store %tile, %base[%c0, %c0] : vector<[1]x[1]xi128>, memref<?x?xi128>
 ```
 """
-function tile_store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
+function tile_store(
+    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices..., ]
+    operands = Value[valueToStore, base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.tile_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.tile_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -923,17 +1295,21 @@ there\'s only one \"virtual tile\".
 ```
 """
 function zero(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sme.zero", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sme.zero",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/ArmSME.jl
+++ b/src/Dialects/17/ArmSME.jl
@@ -1,9 +1,8 @@
 module arm_sme
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `cast_tile_to_vector`
@@ -44,21 +43,17 @@ Canonicalization will look through `arm_sme.cast_tile_to_vector` and fold
 the cast away if it comes from a `arm_sme.cast_vector_to_tile`.
 """
 function cast_tile_to_vector(tile_id::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[tile_id,]
+    results = IR.Type[vector, ]
+    operands = Value[tile_id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.cast_tile_to_vector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.cast_tile_to_vector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -91,21 +86,17 @@ Canonicalization will look through `arm_sme.cast_vector_to_tile` and fold
 the cast away if it comes from a `arm_sme.cast_tile_to_vector`.
 """
 function cast_vector_to_tile(vector::Value; tile_id::IR.Type, location=Location())
-    results = IR.Type[tile_id,]
-    operands = Value[vector,]
+    results = IR.Type[tile_id, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.cast_vector_to_tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.cast_vector_to_tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -139,21 +130,17 @@ functions.
 ```
 """
 function get_tile_id(; tile_id::IR.Type, location=Location())
-    results = IR.Type[tile_id,]
+    results = IR.Type[tile_id, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.get_tile_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.get_tile_id", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -161,28 +148,18 @@ end
 `intr_ld1b_horiz`
 
 """
-function intr_ld1b_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1b_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1b.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1b.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -190,28 +167,18 @@ end
 `intr_ld1b_vert`
 
 """
-function intr_ld1b_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1b_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1b.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1b.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -219,28 +186,18 @@ end
 `intr_ld1d_horiz`
 
 """
-function intr_ld1d_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1d_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1d.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1d.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,28 +205,18 @@ end
 `intr_ld1d_vert`
 
 """
-function intr_ld1d_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1d_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1d.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1d.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -277,28 +224,18 @@ end
 `intr_ld1h_horiz`
 
 """
-function intr_ld1h_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1h_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1h.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1h.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -306,28 +243,18 @@ end
 `intr_ld1h_vert`
 
 """
-function intr_ld1h_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1h_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1h.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1h.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -335,28 +262,18 @@ end
 `intr_ld1q_horiz`
 
 """
-function intr_ld1q_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1q_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1q.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1q.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -364,28 +281,18 @@ end
 `intr_ld1q_vert`
 
 """
-function intr_ld1q_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1q_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1q.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1q.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -393,28 +300,18 @@ end
 `intr_ld1w_horiz`
 
 """
-function intr_ld1w_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1w_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1w.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1w.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -422,28 +319,18 @@ end
 `intr_ld1w_vert`
 
 """
-function intr_ld1w_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1w_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1w.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1w.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -451,29 +338,18 @@ end
 `intr_mopa`
 
 """
-function intr_mopa(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mopa(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mopa",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mopa", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -481,29 +357,18 @@ end
 `intr_mopa_wide`
 
 """
-function intr_mopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -511,29 +376,18 @@ end
 `intr_mops`
 
 """
-function intr_mops(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mops(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -541,29 +395,18 @@ end
 `intr_mops_wide`
 
 """
-function intr_mops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -571,29 +414,18 @@ end
 `intr_smopa_wide`
 
 """
-function intr_smopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_smopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.smopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.smopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -601,29 +433,18 @@ end
 `intr_smops_wide`
 
 """
-function intr_smops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_smops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.smops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.smops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -631,28 +452,18 @@ end
 `intr_st1b_horiz`
 
 """
-function intr_st1b_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1b_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1b.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1b.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,28 +471,18 @@ end
 `intr_st1b_vert`
 
 """
-function intr_st1b_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1b_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1b.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1b.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -689,28 +490,18 @@ end
 `intr_st1d_horiz`
 
 """
-function intr_st1d_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1d_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1d.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1d.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -718,28 +509,18 @@ end
 `intr_st1d_vert`
 
 """
-function intr_st1d_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1d_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1d.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1d.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -747,28 +528,18 @@ end
 `intr_st1h_horiz`
 
 """
-function intr_st1h_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1h_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1h.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1h.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -776,28 +547,18 @@ end
 `intr_st1h_vert`
 
 """
-function intr_st1h_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1h_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1h.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1h.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -805,28 +566,18 @@ end
 `intr_st1q_horiz`
 
 """
-function intr_st1q_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1q_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1q.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1q.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -834,28 +585,18 @@ end
 `intr_st1q_vert`
 
 """
-function intr_st1q_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1q_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1q.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1q.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -863,28 +604,18 @@ end
 `intr_st1w_horiz`
 
 """
-function intr_st1w_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1w_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1w.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1w.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -892,28 +623,18 @@ end
 `intr_st1w_vert`
 
 """
-function intr_st1w_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1w_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1w.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1w.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -923,20 +644,16 @@ end
 """
 function intr_str(operand_0::Value, operand_1::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.str",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.str", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -944,29 +661,18 @@ end
 `intr_sumopa_wide`
 
 """
-function intr_sumopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_sumopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.sumopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.sumopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -974,29 +680,18 @@ end
 `intr_sumops_wide`
 
 """
-function intr_sumops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_sumops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.sumops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.sumops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1004,29 +699,18 @@ end
 `intr_umopa_wide`
 
 """
-function intr_umopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_umopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.umopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.umopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1034,29 +718,18 @@ end
 `intr_umops_wide`
 
 """
-function intr_umops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_umops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.umops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.umops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1064,29 +737,18 @@ end
 `intr_usmopa_wide`
 
 """
-function intr_usmopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_usmopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.usmopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.usmopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1094,29 +756,18 @@ end
 `intr_usmops_wide`
 
 """
-function intr_usmops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_usmops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.usmops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.usmops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1130,16 +781,12 @@ function intr_za_disable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.za.disable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.za.disable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1153,16 +800,12 @@ function intr_za_enable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.za.enable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.za.enable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1172,20 +815,16 @@ end
 """
 function intr_zero(operand_0::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0,]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1213,24 +852,18 @@ Example 3: Load a 128-bit element ZA tile from memory.
 %tile = arm_sme.tile_load %base[%c0, %c0] : memref<?x?xi128>, vector<[1]x[1]xi128>
 ```
 """
-function tile_load(
-    base::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+function tile_load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1259,24 +892,18 @@ Example 3: Store a 128-bit element ZA tile to memory.
 arm_sme.tile_store %tile, %base[%c0, %c0] : vector<[1]x[1]xi128>, memref<?x?xi128>
 ```
 """
-function tile_store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function tile_store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1296,21 +923,17 @@ there\'s only one \"virtual tile\".
 ```
 """
 function zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/ArmSME.jl
+++ b/src/Dialects/17/ArmSME.jl
@@ -1,8 +1,8 @@
 module arm_sme
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `cast_tile_to_vector`
@@ -43,21 +43,17 @@ Canonicalization will look through `arm_sme.cast_tile_to_vector` and fold
 the cast away if it comes from a `arm_sme.cast_vector_to_tile`.
 """
 function cast_tile_to_vector(tile_id::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[tile_id,]
+    results = IR.Type[vector, ]
+    operands = Value[tile_id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.cast_tile_to_vector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.cast_tile_to_vector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -90,21 +86,17 @@ Canonicalization will look through `arm_sme.cast_vector_to_tile` and fold
 the cast away if it comes from a `arm_sme.cast_tile_to_vector`.
 """
 function cast_vector_to_tile(vector::Value; tile_id::IR.Type, location=Location())
-    results = IR.Type[tile_id,]
-    operands = Value[vector,]
+    results = IR.Type[tile_id, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.cast_vector_to_tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.cast_vector_to_tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -138,21 +130,17 @@ functions.
 ```
 """
 function get_tile_id(; tile_id::IR.Type, location=Location())
-    results = IR.Type[tile_id,]
+    results = IR.Type[tile_id, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.get_tile_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.get_tile_id", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,28 +148,18 @@ end
 `intr_ld1b_horiz`
 
 """
-function intr_ld1b_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1b_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1b.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1b.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,28 +167,18 @@ end
 `intr_ld1b_vert`
 
 """
-function intr_ld1b_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1b_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1b.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1b.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -218,28 +186,18 @@ end
 `intr_ld1d_horiz`
 
 """
-function intr_ld1d_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1d_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1d.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1d.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -247,28 +205,18 @@ end
 `intr_ld1d_vert`
 
 """
-function intr_ld1d_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1d_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1d.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1d.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -276,28 +224,18 @@ end
 `intr_ld1h_horiz`
 
 """
-function intr_ld1h_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1h_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1h.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1h.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -305,28 +243,18 @@ end
 `intr_ld1h_vert`
 
 """
-function intr_ld1h_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1h_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1h.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1h.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,28 +262,18 @@ end
 `intr_ld1q_horiz`
 
 """
-function intr_ld1q_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1q_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1q.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1q.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -363,28 +281,18 @@ end
 `intr_ld1q_vert`
 
 """
-function intr_ld1q_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1q_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1q.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1q.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -392,28 +300,18 @@ end
 `intr_ld1w_horiz`
 
 """
-function intr_ld1w_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1w_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1w.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1w.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -421,28 +319,18 @@ end
 `intr_ld1w_vert`
 
 """
-function intr_ld1w_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_ld1w_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.ld1w.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.ld1w.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -450,29 +338,18 @@ end
 `intr_mopa`
 
 """
-function intr_mopa(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mopa(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mopa",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mopa", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -480,29 +357,18 @@ end
 `intr_mopa_wide`
 
 """
-function intr_mopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -510,29 +376,18 @@ end
 `intr_mops`
 
 """
-function intr_mops(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mops(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -540,29 +395,18 @@ end
 `intr_mops_wide`
 
 """
-function intr_mops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_mops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.mops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.mops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -570,29 +414,18 @@ end
 `intr_smopa_wide`
 
 """
-function intr_smopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_smopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.smopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.smopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -600,29 +433,18 @@ end
 `intr_smops_wide`
 
 """
-function intr_smops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_smops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.smops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.smops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -630,28 +452,18 @@ end
 `intr_st1b_horiz`
 
 """
-function intr_st1b_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1b_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1b.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1b.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,28 +471,18 @@ end
 `intr_st1b_vert`
 
 """
-function intr_st1b_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1b_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1b.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1b.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -688,28 +490,18 @@ end
 `intr_st1d_horiz`
 
 """
-function intr_st1d_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1d_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1d.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1d.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -717,28 +509,18 @@ end
 `intr_st1d_vert`
 
 """
-function intr_st1d_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1d_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1d.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1d.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -746,28 +528,18 @@ end
 `intr_st1h_horiz`
 
 """
-function intr_st1h_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1h_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1h.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1h.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -775,28 +547,18 @@ end
 `intr_st1h_vert`
 
 """
-function intr_st1h_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1h_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1h.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1h.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -804,28 +566,18 @@ end
 `intr_st1q_horiz`
 
 """
-function intr_st1q_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1q_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1q.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1q.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -833,28 +585,18 @@ end
 `intr_st1q_vert`
 
 """
-function intr_st1q_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1q_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1q.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1q.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -862,28 +604,18 @@ end
 `intr_st1w_horiz`
 
 """
-function intr_st1w_horiz(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1w_horiz(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1w.horiz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1w.horiz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -891,28 +623,18 @@ end
 `intr_st1w_vert`
 
 """
-function intr_st1w_vert(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value;
-    location=Location(),
-)
+function intr_st1w_vert(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.st1w.vert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.st1w.vert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -922,20 +644,16 @@ end
 """
 function intr_str(operand_0::Value, operand_1::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.str",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.str", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -943,29 +661,18 @@ end
 `intr_sumopa_wide`
 
 """
-function intr_sumopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_sumopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.sumopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.sumopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -973,29 +680,18 @@ end
 `intr_sumops_wide`
 
 """
-function intr_sumops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_sumops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.sumops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.sumops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1003,29 +699,18 @@ end
 `intr_umopa_wide`
 
 """
-function intr_umopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_umopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.umopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.umopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1033,29 +718,18 @@ end
 `intr_umops_wide`
 
 """
-function intr_umops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_umops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.umops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.umops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1063,29 +737,18 @@ end
 `intr_usmopa_wide`
 
 """
-function intr_usmopa_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_usmopa_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.usmopa.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.usmopa.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1093,29 +756,18 @@ end
 `intr_usmops_wide`
 
 """
-function intr_usmops_wide(
-    operand_0::Value,
-    operand_1::Value,
-    operand_2::Value,
-    operand_3::Value,
-    operand_4::Value;
-    location=Location(),
-)
+function intr_usmops_wide(operand_0::Value, operand_1::Value, operand_2::Value, operand_3::Value, operand_4::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4]
+    operands = Value[operand_0, operand_1, operand_2, operand_3, operand_4, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.usmops.wide",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.usmops.wide", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1129,16 +781,12 @@ function intr_za_disable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.za.disable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.za.disable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1152,16 +800,12 @@ function intr_za_enable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.za.enable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.za.enable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1171,20 +815,16 @@ end
 """
 function intr_zero(operand_0::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand_0,]
+    operands = Value[operand_0, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.intr.zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.intr.zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1212,24 +852,18 @@ Example 3: Load a 128-bit element ZA tile from memory.
 %tile = arm_sme.tile_load %base[%c0, %c0] : memref<?x?xi128>, vector<[1]x[1]xi128>
 ```
 """
-function tile_load(
-    base::Value, indices::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+function tile_load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.tile_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.tile_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1258,24 +892,18 @@ Example 3: Store a 128-bit element ZA tile to memory.
 arm_sme.tile_store %tile, %base[%c0, %c0] : vector<[1]x[1]xi128>, memref<?x?xi128>
 ```
 """
-function tile_store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function tile_store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.tile_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.tile_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1295,21 +923,17 @@ there\'s only one \"virtual tile\".
 ```
 """
 function zero(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sme.zero",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sme.zero", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/ArmSVE.jl
+++ b/src/Dialects/17/ArmSVE.jl
@@ -1,25 +1,31 @@
 module arm_sve
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fadd(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fadd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -30,18 +36,24 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_addf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.addf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.addf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -49,18 +61,24 @@ end
 `intr_add`
 
 """
-function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_add(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -71,18 +89,24 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_addi(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.addi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.addi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -90,18 +114,24 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fdiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -112,18 +142,24 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -131,18 +167,24 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fmul(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fmul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -153,18 +195,24 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_mulf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.mulf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.mulf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -172,18 +220,24 @@ end
 `intr_mul`
 
 """
-function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_mul(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,18 +248,24 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_muli(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.muli", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.muli",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -213,18 +273,24 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sdiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -235,18 +301,24 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divi_signed(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divi_signed", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divi_signed",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -254,18 +326,24 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_fsub(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.fsub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.fsub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -276,18 +354,24 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_subf(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.subf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.subf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -295,18 +379,24 @@ end
 `intr_sub`
 
 """
-function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sub(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,18 +407,24 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_subi(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.subi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.subi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -336,18 +432,24 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_udiv(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.udiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.udiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -358,18 +460,24 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[mask, src1, src2, ]
+function masked_divi_unsigned(
+    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[mask, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.masked.divi_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.masked.divi_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -377,18 +485,24 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_sdot(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -407,17 +521,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.sdot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.sdot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -425,18 +543,24 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_smmla(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.smmla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.smmla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,17 +582,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.smmla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.smmla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -476,18 +604,24 @@ end
 `intr_udot`
 
 """
-function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_udot(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.udot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.udot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -506,17 +640,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.udot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.udot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -524,18 +662,24 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0, operand_1, operand_2, ]
+function intr_ummla(
+    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0, operand_1, operand_2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.intr.ummla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.intr.ummla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -557,17 +701,21 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst, ]
-    operands = Value[acc, src1, src2, ]
+    results = IR.Type[dst,]
+    operands = Value[acc, src1, src2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "arm_sve.ummla", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "arm_sve.ummla",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/ArmSVE.jl
+++ b/src/Dialects/17/ArmSVE.jl
@@ -1,32 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -37,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -90,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -115,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -143,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -196,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -249,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -274,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -302,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -327,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -380,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -408,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -433,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -461,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -486,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -544,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -583,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -663,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -702,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/ArmSVE.jl
+++ b/src/Dialects/17/ArmSVE.jl
@@ -1,31 +1,25 @@
 module arm_sve
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `intr_fadd`
 
 """
-function intr_fadd(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fadd(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,24 +30,18 @@ The `arm_sve.masked.addf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,24 +49,18 @@ end
 `intr_add`
 
 """
-function intr_add(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_add(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -89,24 +71,18 @@ The `arm_sve.masked.addi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer addition on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_addi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_addi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.addi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.addi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,24 +90,18 @@ end
 `intr_fdiv`
 
 """
-function intr_fdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -142,24 +112,18 @@ The `arm_sve.masked.divf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,24 +131,18 @@ end
 `intr_fmul`
 
 """
-function intr_fmul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fmul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,24 +153,18 @@ The `arm_sve.masked.mulf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_mulf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_mulf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.mulf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.mulf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,24 +172,18 @@ end
 `intr_mul`
 
 """
-function intr_mul(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_mul(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,24 +194,18 @@ The `arm_sve.masked.muli` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer multiplication on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_muli(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_muli(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.muli",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.muli", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,24 +213,18 @@ end
 `intr_sdiv`
 
 """
-function intr_sdiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,24 +235,18 @@ The `arm_sve.masked.divi_signed` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer signed division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_signed(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_signed(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_signed",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_signed", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +254,18 @@ end
 `intr_fsub`
 
 """
-function intr_fsub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_fsub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,24 +276,18 @@ The `arm_sve.masked.subf` operation takes one scalable vector mask
 and two scalable vector operands, and perform floating point subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subf(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subf(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -379,24 +295,18 @@ end
 `intr_sub`
 
 """
-function intr_sub(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sub(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -407,24 +317,18 @@ The `arm_sve.masked.subi` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer subtraction on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_subi(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_subi(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.subi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.subi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -432,24 +336,18 @@ end
 `intr_udiv`
 
 """
-function intr_udiv(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udiv(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -460,24 +358,18 @@ The `arm_sve.masked.divi_unsigned` operation takes one scalable vector mask
 and two scalable vector operands, and perform integer unsigned division on active lanes. Inactive lanes will keep the value of
 the first operand.
 """
-function masked_divi_unsigned(
-    mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[mask, src1, src2]
+function masked_divi_unsigned(mask::Value, src1::Value, src2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[mask, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.masked.divi_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.masked.divi_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -485,24 +377,18 @@ end
 `intr_sdot`
 
 """
-function intr_sdot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_sdot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,21 +407,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function sdot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.sdot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.sdot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -543,24 +425,18 @@ end
 `intr_smmla`
 
 """
-function intr_smmla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_smmla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -582,21 +458,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function smmla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.smmla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.smmla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,24 +476,18 @@ end
 `intr_udot`
 
 """
-function intr_udot(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_udot(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,21 +506,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function udot(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.udot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.udot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -662,24 +524,18 @@ end
 `intr_ummla`
 
 """
-function intr_ummla(
-    operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0, operand_1, operand_2]
+function intr_ummla(operand_0::Value, operand_1::Value, operand_2::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0, operand_1, operand_2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.intr.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.intr.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -701,21 +557,17 @@ Source:
 https://developer.arm.com/documentation/100987/0000
 """
 function ummla(acc::Value, src1::Value, src2::Value; dst::IR.Type, location=Location())
-    results = IR.Type[dst,]
-    operands = Value[acc, src1, src2]
+    results = IR.Type[dst, ]
+    operands = Value[acc, src1, src2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "arm_sve.ummla",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "arm_sve.ummla", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Async.jl
+++ b/src/Dialects/17/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add_to_group`
@@ -19,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -130,24 +116,18 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "async.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "async.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -157,23 +137,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -186,20 +162,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -211,20 +183,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -233,23 +201,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -258,25 +222,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -292,28 +250,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,25 +282,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -397,30 +339,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    bodyOperands::Vector{Value};
-    token::IR.Type,
-    bodyResults::Vector{IR.Type},
-    bodyRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[token, bodyResults...]
-    operands = Value[dependencies..., bodyOperands...]
-    owned_regions = Region[bodyRegion,]
+function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[token, bodyResults..., ]
+    operands = Value[dependencies..., bodyOperands..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -455,36 +386,21 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "async.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,22 +417,18 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -528,20 +440,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -551,25 +459,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -582,20 +484,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -607,20 +505,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -630,25 +524,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -659,21 +547,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -685,20 +569,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,25 +590,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -738,25 +612,18 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(
-    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[storage,]
+function runtime_load(storage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -766,25 +633,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -796,20 +657,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,20 +678,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -846,20 +699,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -871,20 +720,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,22 +739,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Async.jl
+++ b/src/Dialects/17/Async.jl
@@ -1,9 +1,8 @@
 module async
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add_to_group`
@@ -20,25 +19,19 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,20 +57,16 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.await_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await_all", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,23 +86,19 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -131,24 +116,18 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "async.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "async.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -158,23 +137,19 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id,]
+    operands = Value[id, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-
-    return IR.create_operation(
-        "async.coro.begin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.begin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,20 +162,16 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,20 +183,16 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle]
+    operands = Value[id, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.free",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.free", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -234,23 +201,19 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-
-    return IR.create_operation(
-        "async.coro.id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -259,25 +222,19 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(
-    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-
-    return IR.create_operation(
-        "async.coro.save",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.save", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -293,28 +250,18 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(
-    state::Value;
-    suspendDest::Block,
-    resumeDest::Block,
-    cleanupDest::Block,
-    location=Location(),
-)
+function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[state,]
+    operands = Value[state, ]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest]
+    successors = Block[suspendDest, resumeDest, cleanupDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.coro.suspend",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.coro.suspend", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -335,25 +282,19 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -398,30 +339,19 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(
-    dependencies::Vector{Value},
-    bodyOperands::Vector{Value};
-    token::IR.Type,
-    bodyResults::Vector{IR.Type},
-    bodyRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[token, bodyResults...]
-    operands = Value[dependencies..., bodyOperands...]
-    owned_regions = Region[bodyRegion,]
+function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[token, bodyResults..., ]
+    operands = Value[dependencies..., bodyOperands..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
-
-    return IR.create_operation(
-        "async.execute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
+    
+    IR.create_operation(
+        "async.execute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -456,36 +386,21 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "async.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,22 +417,18 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -529,20 +440,16 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.add_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.add_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -552,25 +459,19 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(
-    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, group]
+    operands = Value[operand, group, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "async.runtime.add_to_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.add_to_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -583,20 +484,16 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle]
+    operands = Value[operand, handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await_and_resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await_and_resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -608,20 +505,16 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.await",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.await", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -631,25 +524,19 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(
-    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[size,]
+    operands = Value[size, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create_group", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -660,21 +547,17 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -686,20 +569,16 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count),]
-
-    return IR.create_operation(
-        "async.runtime.drop_ref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    
+    IR.create_operation(
+        "async.runtime.drop_ref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -711,25 +590,19 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(
-    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-
-    return IR.create_operation(
-        "async.runtime.is_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.is_error", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -739,25 +612,18 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(
-    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[storage,]
+function runtime_load(storage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "async.runtime.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -767,25 +633,19 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(;
-    result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "async.runtime.num_worker_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.num_worker_threads", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -797,20 +657,16 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle,]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -822,20 +678,16 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_available",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_available", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -847,20 +699,16 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.set_error",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.set_error", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -872,20 +720,16 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage]
+    operands = Value[value, storage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.runtime.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.runtime.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -895,22 +739,18 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "async.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "async.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Async.jl
+++ b/src/Dialects/17/Async.jl
@@ -1,8 +1,8 @@
 module async
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add_to_group`
@@ -19,19 +19,25 @@ for the group lifetime.
 %2 = async.add_to_group %1, %0 : !async.token
 ```
 """
-function add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function add_to_group(
+    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, group, ]
+    operands = Value[operand, group]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "async.add_to_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.add_to_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -57,16 +63,20 @@ async.await_all %0
 """
 function await_all(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.await_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.await_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,19 +96,23 @@ async.await %0 : !async.token
 %2 = async.await %1 : !async.value<f32>
 ```
 """
-function await(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function await(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.await", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.await",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -116,18 +130,24 @@ is encoded as a symbol reference attribute named \"callee\".
 %2 = async.call @my_add(%0, %1) : (f32, f32) -> !async.value<f32>
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
-    
-    IR.create_operation(
-        "async.call", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee),]
+
+    return IR.create_operation(
+        "async.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -137,19 +157,23 @@ end
 The `async.coro.begin` allocates a coroutine frame and returns a handle to
 the coroutine.
 """
-function coro_begin(id::Value; handle=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_begin(id::Value; handle=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[id, ]
+    operands = Value[id,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(handle) && push!(results, handle)
-    
-    IR.create_operation(
-        "async.coro.begin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.begin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -162,16 +186,20 @@ coroutine. It the start part of the coroutine is is no-op.
 """
 function coro_end(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.end", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.end",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -183,16 +211,20 @@ async.coro.begin operation.
 """
 function coro_free(id::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[id, handle, ]
+    operands = Value[id, handle]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.free", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.free",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -201,19 +233,23 @@ end
 
 The `async.coro.id` returns a switched-resume coroutine identifier.
 """
-function coro_id(; id=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_id(; id=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(id) && push!(results, id)
-    
-    IR.create_operation(
-        "async.coro.id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -222,19 +258,25 @@ end
 
 The `async.coro.saves` saves the coroutine state.
 """
-function coro_save(handle::Value; state=nothing::Union{Nothing, IR.Type}, location=Location())
+function coro_save(
+    handle::Value; state=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(state) && push!(results, state)
-    
-    IR.create_operation(
-        "async.coro.save", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.save",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -250,18 +292,28 @@ In switched-resume lowering coroutine can be already in resumed state when
 suspend operation is called, in this case control will be transferred to the
 `resume` successor skipping the `suspend` successor.
 """
-function coro_suspend(state::Value; suspendDest::Block, resumeDest::Block, cleanupDest::Block, location=Location())
+function coro_suspend(
+    state::Value;
+    suspendDest::Block,
+    resumeDest::Block,
+    cleanupDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[state, ]
+    operands = Value[state,]
     owned_regions = Region[]
-    successors = Block[suspendDest, resumeDest, cleanupDest, ]
+    successors = Block[suspendDest, resumeDest, cleanupDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.coro.suspend", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.coro.suspend",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -282,19 +334,25 @@ wait until the number of added tokens or values reaches the group size.
 async.await_all %group
 ```
 """
-function create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function create_group(
+    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[size, ]
+    operands = Value[size,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -339,19 +397,30 @@ In the example above asynchronous execution starts only after dependency
 token and value argument become ready. Unwrapped value passed to the
 attached body region as an %unwrapped value of f32 type.
 """
-function execute(dependencies::Vector{Value}, bodyOperands::Vector{Value}; token::IR.Type, bodyResults::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[token, bodyResults..., ]
-    operands = Value[dependencies..., bodyOperands..., ]
-    owned_regions = Region[bodyRegion, ]
+function execute(
+    dependencies::Vector{Value},
+    bodyOperands::Vector{Value};
+    token::IR.Type,
+    bodyResults::Vector{IR.Type},
+    bodyRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[token, bodyResults...]
+    operands = Value[dependencies..., bodyOperands...]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands), ]))
-    
-    IR.create_operation(
-        "async.execute", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(dependencies), length(bodyOperands)]))
+
+    return IR.create_operation(
+        "async.execute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -386,21 +455,36 @@ async.func @async.2() -> !async.token, !async.value<i32> {
 }
 ```
 """
-function func(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    sym_visibility=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "async.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -417,18 +501,22 @@ async.func @foo() : !async.token {
 }
 ```
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -440,16 +528,20 @@ The `async.runtime.add_ref` operation adds a reference(s) to async value
 """
 function runtime_add_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    
-    IR.create_operation(
-        "async.runtime.add_ref", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("count", count),]
+
+    return IR.create_operation(
+        "async.runtime.add_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -459,19 +551,25 @@ end
 The `async.runtime.add_to_group` adds an async token or value to the async
 group. Returns the rank of the added element in the group.
 """
-function runtime_add_to_group(operand::Value, group::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_add_to_group(
+    operand::Value, group::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, group, ]
+    operands = Value[operand, group]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "async.runtime.add_to_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.add_to_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -484,16 +582,20 @@ the runtime.
 """
 function runtime_await_and_resume(operand::Value, handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, handle, ]
+    operands = Value[operand, handle]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.await_and_resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.await_and_resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -505,16 +607,20 @@ operand becomes available or error.
 """
 function runtime_await(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.await", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.await",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -524,19 +630,25 @@ end
 The `async.runtime.create_group` operation creates an async dialect group
 of the given size. Group created in the empty state.
 """
-function runtime_create_group(size::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_create_group(
+    size::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[size, ]
+    operands = Value[size,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.runtime.create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -547,17 +659,21 @@ The `async.runtime.create` operation creates an async dialect token or
 value. Tokens and values are created in the non-ready state.
 """
 function runtime_create(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -569,16 +685,20 @@ The `async.runtime.drop_ref` operation drops a reference(s) to async value
 """
 function runtime_drop_ref(operand::Value; count, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    
-    IR.create_operation(
-        "async.runtime.drop_ref", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("count", count),]
+
+    return IR.create_operation(
+        "async.runtime.drop_ref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -590,19 +710,25 @@ group (any of the async runtime values) is in the error state. It is the
 caller responsibility to check error state after the call to `await` or
 resuming after `await_and_resume`.
 """
-function runtime_is_error(operand::Value; is_error=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_is_error(
+    operand::Value; is_error=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(is_error) && push!(results, is_error)
-    
-    IR.create_operation(
-        "async.runtime.is_error", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.is_error",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -612,18 +738,25 @@ end
 The `async.runtime.load` operation loads the value from the runtime
 async.value storage.
 """
-function runtime_load(storage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[storage, ]
+function runtime_load(
+    storage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[storage,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.load", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "async.runtime.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -633,19 +766,25 @@ end
 The `async.runtime.num_worker_threads` operation gets the number of threads
 in the threadpool from the runtime.
 """
-function runtime_num_worker_threads(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function runtime_num_worker_threads(;
+    result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "async.runtime.num_worker_threads", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.num_worker_threads",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -657,16 +796,20 @@ managed by the runtime.
 """
 function runtime_resume(handle::Value; location=Location())
     results = IR.Type[]
-    operands = Value[handle, ]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -678,16 +821,20 @@ state to available.
 """
 function runtime_set_available(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.set_available", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.set_available",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -699,16 +846,20 @@ state to error.
 """
 function runtime_set_error(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.set_error", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.set_error",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -720,16 +871,20 @@ async.value storage.
 """
 function runtime_store(value::Value, storage::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, storage, ]
+    operands = Value[value, storage]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.runtime.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.runtime.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -739,18 +894,22 @@ end
 The `async.yield` is a special terminator operation for the block inside
 `async.execute` operation.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "async.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "async.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Bufferization.jl
+++ b/src/Dialects/17/Bufferization.jl
@@ -1,8 +1,8 @@
 module bufferization
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `alloc_tensor`
@@ -58,22 +58,45 @@ return %0 : tensor<?x?xf32, #SparseMatrix>
 Note: An `alloc_tensor` with a `copy` should also be expressed as an
 `alloc_tensor` without `copy`, followed by a `copy_tensor`.
 """
-function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; size_hint=nothing::Union{Nothing, Value}, result::IR.Type, memory_space=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamic_sizes..., ]
+function alloc_tensor(
+    dynamic_sizes::Vector{Value},
+    copy=nothing::Union{Nothing,Value};
+    size_hint=nothing::Union{Nothing,Value},
+    result::IR.Type,
+    memory_space=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[dynamic_sizes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
     !isnothing(size_hint) && push!(operands, size_hint)
-    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1(size_hint==nothing) ? 0 : 1]))
-    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
-    
-    IR.create_operation(
-        "bufferization.alloc_tensor", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(dynamic_sizes), if (copy == nothing)
+                0
+            elseif 1(size_hint == nothing)
+                0
+            else
+                1
+            end
+        ]),
+    )
+    !isnothing(memory_space) &&
+        push!(attributes, namedattribute("memory_space", memory_space))
+
+    return IR.create_operation(
+        "bufferization.alloc_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -94,17 +117,21 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "bufferization.clone", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.clone",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -114,19 +141,25 @@ end
 Copy the contents of the source tensor into the destination tensor. This
 operation is guaranteed to bufferize to a memory copy.
 """
-function copy_tensor(source::Value, dest::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function copy_tensor(
+    source::Value, dest::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "bufferization.copy_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.copy_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -157,20 +190,33 @@ Deallocation will be called on `%a0` if `%cond0` is \'true\' and neither `%r0`
 or `%r1` are aliases of `%a0`. `%a1` will be deallocated when `%cond1` is
 set to \'true\' and none of `%r0`, %r1` and `%a0` are aliases.
 """
-function dealloc(memrefs::Vector{Value}, conditions::Vector{Value}, retained::Vector{Value}; updatedConditions=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
+function dealloc(
+    memrefs::Vector{Value},
+    conditions::Vector{Value},
+    retained::Vector{Value};
+    updatedConditions=nothing::Union{Nothing,Vector{IR.Type}},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memrefs..., conditions..., retained..., ]
+    operands = Value[memrefs..., conditions..., retained...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(memrefs), length(conditions), length(retained), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([length(memrefs), length(conditions), length(retained)]),
+    )
     !isnothing(updatedConditions) && push!(results, updatedConditions...)
-    
-    IR.create_operation(
-        "bufferization.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -202,16 +248,20 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "bufferization.dealloc_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.dealloc_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -234,18 +284,22 @@ bufferization that the buffer returned by this op (or an alias created from
 the returned buffer) will not be written to.
 """
 function to_memref(tensor::Value; memref::IR.Type, read_only=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[tensor, ]
+    results = IR.Type[memref,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(read_only) && push!(attributes, namedattribute("read_only", read_only))
-    
-    IR.create_operation(
-        "bufferization.to_memref", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "bufferization.to_memref",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -292,20 +346,31 @@ bufferization. If there are non-bufferizable ops in the IR and
 `allowUnknownOps` is set, they may be part of the resulting IR and not fold
 away. However, such IR is no longer bufferizable with One-Shot Bufferize.
 """
-function to_tensor(memref::Value; result::IR.Type, restrict=nothing, writable=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, ]
+function to_tensor(
+    memref::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    restrict=nothing,
+    writable=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
+    !isnothing(result) && push!(results, result)
     !isnothing(restrict) && push!(attributes, namedattribute("restrict", restrict))
     !isnothing(writable) && push!(attributes, namedattribute("writable", writable))
-    
-    IR.create_operation(
-        "bufferization.to_tensor", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+
+    return IR.create_operation(
+        "bufferization.to_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/17/Bufferization.jl
+++ b/src/Dialects/17/Bufferization.jl
@@ -1,8 +1,8 @@
 module bufferization
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alloc_tensor`
@@ -58,45 +58,22 @@ return %0 : tensor<?x?xf32, #SparseMatrix>
 Note: An `alloc_tensor` with a `copy` should also be expressed as an
 `alloc_tensor` without `copy`, followed by a `copy_tensor`.
 """
-function alloc_tensor(
-    dynamic_sizes::Vector{Value},
-    copy=nothing::Union{Nothing,Value};
-    size_hint=nothing::Union{Nothing,Value},
-    result::IR.Type,
-    memory_space=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[dynamic_sizes...,]
+function alloc_tensor(dynamic_sizes::Vector{Value}, copy=nothing::Union{Nothing, Value}; size_hint=nothing::Union{Nothing, Value}, result::IR.Type, memory_space=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(copy) && push!(operands, copy)
     !isnothing(size_hint) && push!(operands, size_hint)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(dynamic_sizes), if (copy == nothing)
-                0
-            elseif 1(size_hint == nothing)
-                0
-            else
-                1
-            end
-        ]),
-    )
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
-
-    return IR.create_operation(
-        "bufferization.alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(dynamic_sizes), (copy==nothing) ? 0 : 1(size_hint==nothing) ? 0 : 1]))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    
+    IR.create_operation(
+        "bufferization.alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -117,21 +94,17 @@ of the clone operation after the clone operation thus leads to undefined
 behavior.
 """
 function clone(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.clone",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.clone", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,25 +114,19 @@ end
 Copy the contents of the source tensor into the destination tensor. This
 operation is guaranteed to bufferize to a memory copy.
 """
-function copy_tensor(
-    source::Value, dest::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function copy_tensor(source::Value, dest::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "bufferization.copy_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.copy_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -190,33 +157,20 @@ Deallocation will be called on `%a0` if `%cond0` is \'true\' and neither `%r0`
 or `%r1` are aliases of `%a0`. `%a1` will be deallocated when `%cond1` is
 set to \'true\' and none of `%r0`, %r1` and `%a0` are aliases.
 """
-function dealloc(
-    memrefs::Vector{Value},
-    conditions::Vector{Value},
-    retained::Vector{Value};
-    updatedConditions=nothing::Union{Nothing,Vector{IR.Type}},
-    location=Location(),
-)
+function dealloc(memrefs::Vector{Value}, conditions::Vector{Value}, retained::Vector{Value}; updatedConditions=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
     results = IR.Type[]
-    operands = Value[memrefs..., conditions..., retained...]
+    operands = Value[memrefs..., conditions..., retained..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([length(memrefs), length(conditions), length(retained)]),
-    )
+    push!(attributes, operandsegmentsizes([length(memrefs), length(conditions), length(retained), ]))
     !isnothing(updatedConditions) && push!(results, updatedConditions...)
-
-    return IR.create_operation(
-        "bufferization.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -248,20 +202,16 @@ bufferization.dealloc_tensor %tensor : tensor<1024x1024xf64, #CSR>
 """
 function dealloc_tensor(tensor::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "bufferization.dealloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.dealloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -284,22 +234,18 @@ bufferization that the buffer returned by this op (or an alias created from
 the returned buffer) will not be written to.
 """
 function to_memref(tensor::Value; memref::IR.Type, read_only=nothing, location=Location())
-    results = IR.Type[memref,]
-    operands = Value[tensor,]
+    results = IR.Type[memref, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(read_only) && push!(attributes, namedattribute("read_only", read_only))
-
-    return IR.create_operation(
-        "bufferization.to_memref",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "bufferization.to_memref", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,31 +292,20 @@ bufferization. If there are non-bufferizable ops in the IR and
 `allowUnknownOps` is set, they may be part of the resulting IR and not fold
 away. However, such IR is no longer bufferizable with One-Shot Bufferize.
 """
-function to_tensor(
-    memref::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    restrict=nothing,
-    writable=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[memref,]
+function to_tensor(memref::Value; result::IR.Type, restrict=nothing, writable=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
     !isnothing(restrict) && push!(attributes, namedattribute("restrict", restrict))
     !isnothing(writable) && push!(attributes, namedattribute("writable", writable))
-
-    return IR.create_operation(
-        "bufferization.to_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "bufferization.to_tensor", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Builtin.jl
+++ b/src/Dialects/17/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `module_`
@@ -23,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -81,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Builtin.jl
+++ b/src/Dialects/17/Builtin.jl
@@ -1,8 +1,8 @@
 module builtin
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `module_`
@@ -23,20 +23,27 @@ module {
 }
 ```
 """
-function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
+function module_(;
+    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "builtin.module", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "builtin.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -74,18 +81,24 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
+function unrealized_conversion_cast(
+    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "builtin.unrealized_conversion_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "builtin.unrealized_conversion_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Builtin.jl
+++ b/src/Dialects/17/Builtin.jl
@@ -1,9 +1,8 @@
 module builtin
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `module_`
@@ -24,27 +23,20 @@ module {
 }
 ```
 """
-function module_(;
-    sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location()
-)
+function module_(; sym_name=nothing, sym_visibility=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "builtin.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "builtin.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -82,24 +74,18 @@ operands of arity 0-N.
 %result3 = unrealized_conversion_cast %operand, %operand : !foo.type, !foo.type to !bar.tuple_type<!foo.type, !foo.type>
 ```
 """
-function unrealized_conversion_cast(
-    inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function unrealized_conversion_cast(inputs::Vector{Value}; outputs::Vector{IR.Type}, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "builtin.unrealized_conversion_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "builtin.unrealized_conversion_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Complex.jl
+++ b/src/Dialects/17/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -15,23 +15,18 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function abs(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -46,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -79,23 +68,18 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function angle(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -111,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -144,21 +122,17 @@ end
 ```
 """
 function bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -174,23 +148,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -207,21 +177,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -237,23 +203,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -270,21 +232,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -298,25 +256,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -331,25 +283,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -366,23 +312,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -403,23 +345,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -434,23 +372,18 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function im(complex::Value; imaginary::IR.Type, location=Location())
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imaginary) && push!(results, imaginary)
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -468,23 +401,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -501,23 +430,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -530,25 +455,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -563,23 +482,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -595,25 +510,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -629,25 +538,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -662,23 +565,18 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function re(complex::Value; real::IR.Type, location=Location())
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(real) && push!(results, real)
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -693,23 +591,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -725,23 +619,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -757,23 +647,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -788,23 +674,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -819,25 +701,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -853,23 +729,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -885,23 +757,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/Complex.jl
+++ b/src/Dialects/17/Complex.jl
@@ -1,8 +1,8 @@
 module complex
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -15,18 +15,23 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[complex, ]
+function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.abs", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "complex.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -41,19 +46,25 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -68,18 +79,23 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[complex, ]
+function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.angle", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "complex.angle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -95,19 +111,25 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function atan2(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.atan2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.atan2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -122,17 +144,21 @@ end
 ```
 """
 function bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -148,19 +174,23 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.conj", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.conj",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -177,17 +207,21 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex, ]
+    results = IR.Type[complex,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "complex.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "complex.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -203,19 +237,23 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -232,17 +270,21 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex, ]
-    operands = Value[real, imaginary, ]
+    results = IR.Type[complex,]
+    operands = Value[real, imaginary]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -256,19 +298,25 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function div(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -283,19 +331,25 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function eq(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -312,19 +366,23 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -345,19 +403,23 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.expm1", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.expm1",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -372,18 +434,23 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary::IR.Type, location=Location())
-    results = IR.Type[imaginary, ]
-    operands = Value[complex, ]
+function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.im", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(imaginary) && push!(results, imaginary)
+
+    return IR.create_operation(
+        "complex.im",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -401,19 +468,23 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.log1p", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.log1p",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -430,19 +501,23 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -455,19 +530,25 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -482,19 +563,23 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.neg", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.neg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -510,19 +595,25 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function neq(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.neq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.neq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -538,19 +629,25 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -565,18 +662,23 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real::IR.Type, location=Location())
-    results = IR.Type[real, ]
-    operands = Value[complex, ]
+function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "complex.re", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(real) && push!(results, real)
+
+    return IR.create_operation(
+        "complex.re",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -591,19 +693,23 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -619,19 +725,23 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -647,19 +757,23 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -674,19 +788,23 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -701,19 +819,25 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -729,19 +853,23 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -757,19 +885,23 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex, ]
+    operands = Value[complex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "complex.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "complex.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/17/Complex.jl
+++ b/src/Dialects/17/Complex.jl
@@ -1,9 +1,8 @@
 module complex
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -16,23 +15,18 @@ The `abs` op takes a single complex number and computes its absolute value.
 %a = complex.abs %b : complex<f32>
 ```
 """
-function abs(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function abs(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.abs", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -47,25 +41,19 @@ The `add` operation takes two complex numbers and returns their sum.
 %a = complex.add %b, %c : complex<f32>
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,23 +68,18 @@ The `angle` op takes a single complex number and computes its argument value wit
      %a = complex.angle %b : complex<f32>
 ```
 """
-function angle(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function angle(complex::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.angle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.angle", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -112,25 +95,19 @@ atan2(y, x) = -i * log((x + i * y) / sqrt(x**2 + y**2))
 %a = complex.atan2 %b, %c : complex<f32>
 ```
 """
-function atan2(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -145,21 +122,17 @@ end
 ```
 """
 function bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -175,23 +148,19 @@ complex conjugate.
 %a = complex.conj %b: complex<f32>
 ```
 """
-function conj(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function conj(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.conj",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.conj", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -208,21 +177,17 @@ attribute containing the real and imaginary parts.
 ```
 """
 function constant(; complex::IR.Type, value, location=Location())
-    results = IR.Type[complex,]
+    results = IR.Type[complex, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "complex.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "complex.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -238,23 +203,19 @@ it, i.e. `cos(x)`, where `x` is the input value.
 %a = complex.cos %b : complex<f32>
 ```
 """
-function cos(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cos(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -271,21 +232,17 @@ floating-point operands, the real and the imaginary part.
 ```
 """
 function create(real::Value, imaginary::Value; complex::IR.Type, location=Location())
-    results = IR.Type[complex,]
-    operands = Value[real, imaginary]
+    results = IR.Type[complex, ]
+    operands = Value[real, imaginary, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "complex.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -299,25 +256,19 @@ division:
 %a = complex.div %b, %c : complex<f32>
 ```
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -332,25 +283,19 @@ The `eq` op takes two complex numbers and returns whether they are equal.
 %a = complex.eq %b, %c : complex<f32>
 ```
 """
-function eq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function eq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -367,23 +312,19 @@ it, i.e. `exp(x)` or `e^(x)`, where `x` is the input value.
 %a = complex.exp %b : complex<f32>
 ```
 """
-function exp(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function exp(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -404,23 +345,19 @@ complex.expm1(x) := complex.exp(x) - 1
 %a = complex.expm1 %b : complex<f32>
 ```
 """
-function expm1(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function expm1(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -435,23 +372,18 @@ The `im` op takes a single complex number and extracts the imaginary part.
 %a = complex.im %b : complex<f32>
 ```
 """
-function im(complex::Value; imaginary=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function im(complex::Value; imaginary::IR.Type, location=Location())
+    results = IR.Type[imaginary, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imaginary) && push!(results, imaginary)
-
-    return IR.create_operation(
-        "complex.im",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.im", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -469,23 +401,19 @@ approximately equal to 2.718281.
 %a = complex.log1p %b : complex<f32>
 ```
 """
-function log1p(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log1p(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -502,23 +430,19 @@ logarithm of it, i.e. `log(x)` or `log_e(x)`, where `x` is the input value.
 %a = complex.log %b : complex<f32>
 ```
 """
-function log(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function log(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -531,25 +455,19 @@ The `mul` operation takes two complex numbers and returns their product:
 %a = complex.mul %b, %c : complex<f32>
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -564,23 +482,19 @@ The `neg` op takes a single complex number `complex` and returns `-complex`.
 %a = complex.neg %b : complex<f32>
 ```
 """
-function neg(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function neg(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -596,25 +510,19 @@ equal.
 %a = complex.neq %b, %c : complex<f32>
 ```
 """
-function neq(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function neq(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.neq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.neq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -630,25 +538,19 @@ exponent.
 %a = complex.pow %b, %c : complex<f32>
 ```
 """
-function pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -663,23 +565,18 @@ The `re` op takes a single complex number and extracts the real part.
 %a = complex.re %b : complex<f32>
 ```
 """
-function re(complex::Value; real=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[complex,]
+function re(complex::Value; real::IR.Type, location=Location())
+    results = IR.Type[real, ]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(real) && push!(results, real)
-
-    return IR.create_operation(
-        "complex.re",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "complex.re", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -694,23 +591,19 @@ The `rsqrt` operation computes reciprocal of square root.
 %a = complex.rsqrt %b : complex<f32>
 ```
 """
-function rsqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function rsqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -726,23 +619,19 @@ it, i.e. `y = sign(x) = x / |x|` if `x != 0`, otherwise `y = 0`.
 %a = complex.sign %b : complex<f32>
 ```
 """
-function sign(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sign(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -758,23 +647,19 @@ it, i.e. `sin(x)`, where `x` is the input value.
 %a = complex.sin %b : complex<f32>
 ```
 """
-function sin(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sin(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -789,23 +674,19 @@ The `sqrt` operation takes a complex number and returns its square root.
 %a = complex.sqrt %b : complex<f32>
 ```
 """
-function sqrt(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sqrt(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -820,25 +701,19 @@ The `sub` operation takes two complex numbers and returns their difference.
 %a = complex.sub %b, %c : complex<f32>
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -854,23 +729,19 @@ it, i.e. `tan(x)`, where `x` is the input value.
 %a = complex.tan %b : complex<f32>
 ```
 """
-function tan(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tan(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -886,23 +757,19 @@ tangent.
 %a = complex.tanh %b : complex<f32>
 ```
 """
-function tanh(complex::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function tanh(complex::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[complex,]
+    operands = Value[complex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "complex.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "complex.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/ControlFlow.jl
+++ b/src/Dialects/17/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `assert`
@@ -20,16 +20,20 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg), ]
-    
-    IR.create_operation(
-        "cf.assert", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg),]
+
+    return IR.create_operation(
+        "cf.assert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -52,16 +56,20 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands..., ]
+    operands = Value[destOperands...,]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "cf.br", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "cf.br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -93,19 +101,33 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
+function cond_br(
+    condition::Value,
+    trueDestOperands::Vector{Value},
+    falseDestOperands::Vector{Value};
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
+    operands = Value[condition, trueDestOperands..., falseDestOperands...]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
-    
-    IR.create_operation(
-        "cf.cond_br", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
+    )
+
+    return IR.create_operation(
+        "cf.cond_br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -128,20 +150,37 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
+function switch(
+    flag::Value,
+    defaultOperands::Vector{Value},
+    caseOperands::Vector{Value};
+    case_values=nothing,
+    case_operand_segments,
+    defaultDestination::Block,
+    caseDestinations::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands..., ]
+    operands = Value[flag, defaultOperands..., caseOperands...]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations..., ]
-    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
-    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
+    successors = Block[defaultDestination, caseDestinations...]
+    attributes = NamedAttribute[namedattribute(
+        "case_operand_segments", case_operand_segments
+    ),]
+    push!(
+        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
+    )
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    
-    IR.create_operation(
-        "cf.switch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "cf.switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/ControlFlow.jl
+++ b/src/Dialects/17/ControlFlow.jl
@@ -1,9 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assert`
@@ -21,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -57,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -151,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/ControlFlow.jl
+++ b/src/Dialects/17/ControlFlow.jl
@@ -1,8 +1,8 @@
 module cf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assert`
@@ -20,20 +20,16 @@ assert %b, \"Expected ... to be true\"
 """
 function assert(arg::Value; msg, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
-
-    return IR.create_operation(
-        "cf.assert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    
+    IR.create_operation(
+        "cf.assert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -56,20 +52,16 @@ target block.
 """
 function br(destOperands::Vector{Value}; dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "cf.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -101,33 +93,19 @@ func.func @select(%a: i32, %b: i32, %flag: i1) -> i32 {
 }
 ```
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-
-    return IR.create_operation(
-        "cf.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    
+    IR.create_operation(
+        "cf.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -150,37 +128,20 @@ switch %flag : i32, [
 ]
 ```
 """
-function switch(
-    flag::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(flag::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[flag, defaultOperands..., caseOperands...]
+    operands = Value[flag, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-
-    return IR.create_operation(
-        "cf.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "cf.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/EmitC.jl
+++ b/src/Dialects/17/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add`
@@ -24,17 +24,21 @@ float* v6 = v3 + v4;
 ```
 """
 function add(lhs::Value, rhs::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,17 +61,21 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
-    
-    IR.create_operation(
-        "emitc.apply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
+
+    return IR.create_operation(
+        "emitc.apply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -90,20 +98,32 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee,
+    args=nothing,
+    template_args=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    attributes = NamedAttribute[namedattribute("callee", callee),]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
-    
-    IR.create_operation(
-        "emitc.call", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(template_args) &&
+        push!(attributes, namedattribute("template_args", template_args))
+
+    return IR.create_operation(
+        "emitc.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -126,17 +146,21 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -163,17 +187,21 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "emitc.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "emitc.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -197,17 +225,21 @@ float v6 = v3 / v4;
 ```
 """
 function div(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operand_0, operand_1, ]
+    results = IR.Type[result_0,]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -238,14 +270,19 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_), ]
-    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
-    
-    IR.create_operation(
-        "emitc.include", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("include", include_),]
+    !isnothing(is_standard_include) &&
+        push!(attributes, namedattribute("is_standard_include", is_standard_include))
+
+    return IR.create_operation(
+        "emitc.include",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -269,17 +306,21 @@ float v6 = v3 * v4;
 ```
 """
 function mul(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operand_0, operand_1, ]
+    results = IR.Type[result_0,]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -301,17 +342,21 @@ int32_t v5 = v1 % v2;
 ```
 """
 function rem(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operand_0, operand_1, ]
+    results = IR.Type[result_0,]
+    operands = Value[operand_0, operand_1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.rem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.rem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -338,17 +383,21 @@ ptrdiff_t v9 = v5 - v6;
 ```
 """
 function sub(lhs::Value, rhs::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "emitc.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "emitc.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -387,17 +436,21 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "emitc.variable", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "emitc.variable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/EmitC.jl
+++ b/src/Dialects/17/EmitC.jl
@@ -1,8 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -24,21 +24,17 @@ float* v6 = v3 + v4;
 ```
 """
 function add(lhs::Value, rhs::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,21 +57,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,32 +90,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -146,21 +126,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -187,21 +163,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -225,21 +197,17 @@ float v6 = v3 / v4;
 ```
 """
 function div(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[result_0, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -270,19 +238,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -306,21 +269,17 @@ float v6 = v3 * v4;
 ```
 """
 function mul(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[result_0, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -342,21 +301,17 @@ int32_t v5 = v1 % v2;
 ```
 """
 function rem(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[result_0, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.rem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.rem", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -383,21 +338,17 @@ ptrdiff_t v9 = v5 - v6;
 ```
 """
 function sub(lhs::Value, rhs::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,21 +387,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/EmitC.jl
+++ b/src/Dialects/17/EmitC.jl
@@ -1,9 +1,8 @@
 module emitc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -25,21 +24,17 @@ float* v6 = v3 + v4;
 ```
 """
 function add(lhs::Value, rhs::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,21 +57,17 @@ can be applied to a single operand.
 ```
 """
 function apply(operand::Value; result::IR.Type, applicableOperator, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator),]
-
-    return IR.create_operation(
-        "emitc.apply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("applicableOperator", applicableOperator), ]
+    
+    IR.create_operation(
+        "emitc.apply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -99,32 +90,20 @@ specifying order of operands and attributes in the call as follows:
 %0 = \"emitc.call\"() {callee = \"foo\"} : () -> i32
 ```
 """
-function call(
-    operands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee,
-    args=nothing,
-    template_args=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, args=nothing, template_args=nothing, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(args) && push!(attributes, namedattribute("args", args))
-    !isnothing(template_args) &&
-        push!(attributes, namedattribute("template_args", template_args))
-
-    return IR.create_operation(
-        "emitc.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(template_args) && push!(attributes, namedattribute("template_args", template_args))
+    
+    IR.create_operation(
+        "emitc.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -147,21 +126,17 @@ and EmitC types.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,21 +163,17 @@ it should not be used with pointers.
 ```
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -226,21 +197,17 @@ float v6 = v3 / v4;
 ```
 """
 function div(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[result_0, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -271,19 +238,14 @@ function include_(; include_, is_standard_include=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("include", include_),]
-    !isnothing(is_standard_include) &&
-        push!(attributes, namedattribute("is_standard_include", is_standard_include))
-
-    return IR.create_operation(
-        "emitc.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("include", include_), ]
+    !isnothing(is_standard_include) && push!(attributes, namedattribute("is_standard_include", is_standard_include))
+    
+    IR.create_operation(
+        "emitc.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -307,21 +269,17 @@ float v6 = v3 * v4;
 ```
 """
 function mul(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[result_0, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -343,21 +301,17 @@ int32_t v5 = v1 % v2;
 ```
 """
 function rem(operand_0::Value, operand_1::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operand_0, operand_1]
+    results = IR.Type[result_0, ]
+    operands = Value[operand_0, operand_1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.rem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.rem", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -384,21 +338,17 @@ ptrdiff_t v9 = v5 - v6;
 ```
 """
 function sub(lhs::Value, rhs::Value; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "emitc.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "emitc.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,21 +387,17 @@ emitc.call \"write\"(%2, %3) : (!emitc.ptr<i32>, !emitc.ptr<i32>) -> ()
 ```
 """
 function variable(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "emitc.variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "emitc.variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Func.jl
+++ b/src/Dialects/17/Func.jl
@@ -1,9 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `call_indirect`
@@ -22,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -60,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -103,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,36 +140,21 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -210,22 +175,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Func.jl
+++ b/src/Dialects/17/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `call_indirect`
@@ -21,27 +21,18 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(
-    callee::Value,
-    callee_operands::Vector{Value};
-    results::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[callee, callee_operands...]
+function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[callee, callee_operands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.call_indirect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.call_indirect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -59,24 +50,18 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(
-    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
-)
-    results = IR.Type[result_0...,]
-    operands = Value[operands...,]
+function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
-
-    return IR.create_operation(
-        "func.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    
+    IR.create_operation(
+        "func.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,21 +87,17 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "func.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "func.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,36 +140,21 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "func.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -209,22 +175,18 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "func.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "func.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Func.jl
+++ b/src/Dialects/17/Func.jl
@@ -1,8 +1,8 @@
 module func
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `call_indirect`
@@ -21,18 +21,27 @@ Function values can be created with the
 %result = func.call_indirect %func(%0, %1) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
 ```
 """
-function call_indirect(callee::Value, callee_operands::Vector{Value}; results_::Vector{IR.Type}, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[callee, callee_operands..., ]
+function call_indirect(
+    callee::Value,
+    callee_operands::Vector{Value};
+    results::Vector{IR.Type},
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[callee, callee_operands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "func.call_indirect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.call_indirect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -50,18 +59,24 @@ symbol reference attribute named \"callee\".
 %2 = func.call @my_add(%0, %1) : (f32, f32) -> f32
 ```
 """
-function call(operands_::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[operands_..., ]
+function call(
+    operands::Vector{Value}; result_0::Vector{IR.Type}, callee, location=Location()
+)
+    results = IR.Type[result_0...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
-    
-    IR.create_operation(
-        "func.call", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("callee", callee),]
+
+    return IR.create_operation(
+        "func.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -87,17 +102,21 @@ reference a function simplifies this
 ([rationale](../Rationale/Rationale.md#multithreading-the-compiler)).
 """
 function constant(; result_0::IR.Type, value, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "func.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "func.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -140,21 +159,36 @@ func.func @example_fn_result() -> (f64 {dialectName.attrName = 0 : i64})
 func.func @example_fn_attr() attributes {dialectName.attrName = false}
 ```
 """
-function func_(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func_(;
+    sym_name,
+    function_type,
+    sym_visibility=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "func.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -175,18 +209,22 @@ func.func @foo() : (i32, f8) {
 }
 ```
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "func.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "func.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/GPU.jl
+++ b/src/Dialects/17/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `all_reduce`
@@ -29,32 +29,21 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    uniform=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,38 +69,21 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    hostShared=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,16 +112,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -165,25 +133,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -199,25 +161,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -240,31 +196,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %spmat, %token = gpu.create_2to4_spmat async [%dep] %rows, %cols, %mem : memref<?xf64>
 ```
 """
-function create_2to4_spmat(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    memref::Value;
-    spMat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spMat,]
-    operands = Value[asyncDependencies..., rows, cols, memref]
+function create_2to4_spmat(asyncDependencies::Vector{Value}, rows::Value, cols::Value, memref::Value; spMat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spMat, ]
+    operands = Value[asyncDependencies..., rows, cols, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_2to4_spmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_2to4_spmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -290,33 +234,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %values : memref<?xindex>, memref<?xf64>
 ```
 """
-function create_coo_aos(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    nnz::Value,
-    idxs::Value,
-    values::Value;
-    spmat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spmat,]
-    operands = Value[asyncDependencies..., rows, cols, nnz, idxs, values]
+function create_coo_aos(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, idxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spmat, ]
+    operands = Value[asyncDependencies..., rows, cols, nnz, idxs, values, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_coo_aos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_coo_aos", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -340,34 +270,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %colIdx, %values : memref<?xindex>, memref<?xindex>, memref<?xf64>
 ```
 """
-function create_coo(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    nnz::Value,
-    rowIdxs::Value,
-    colIdxs::Value,
-    values::Value;
-    spmat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spmat,]
-    operands = Value[asyncDependencies..., rows, cols, nnz, rowIdxs, colIdxs, values]
+function create_coo(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, rowIdxs::Value, colIdxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spmat, ]
+    operands = Value[asyncDependencies..., rows, cols, nnz, rowIdxs, colIdxs, values, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -391,34 +306,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %colIdx, %values : memref<?xindex>, memref<?xindex>, memref<?xf64>
 ```
 """
-function create_csr(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    nnz::Value,
-    rowPos::Value,
-    colIdxs::Value,
-    values::Value;
-    spmat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spmat,]
-    operands = Value[asyncDependencies..., rows, cols, nnz, rowPos, colIdxs, values]
+function create_csr(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, rowPos::Value, colIdxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spmat, ]
+    operands = Value[asyncDependencies..., rows, cols, nnz, rowPos, colIdxs, values, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_csr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_csr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -440,31 +340,20 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %dmat, %token = gpu.create_dn_tensor async [%dep] %mem, %dims : index, index into memref<?xf64>
 ```
 """
-function create_dn_tensor(
-    asyncDependencies::Vector{Value},
-    memref::Value,
-    dims::Vector{Value};
-    dnTensor::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[dnTensor,]
-    operands = Value[asyncDependencies..., memref, dims...]
+function create_dn_tensor(asyncDependencies::Vector{Value}, memref::Value, dims::Vector{Value}; dnTensor::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[dnTensor, ]
+    operands = Value[asyncDependencies..., memref, dims..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, length(dims)]))
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, length(dims), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_dn_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_dn_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -488,28 +377,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -530,28 +410,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %token = gpu.destroy_dn_tensor async [%dep] %dnTensor
 ```
 """
-function destroy_dn_tensor(
-    asyncDependencies::Vector{Value},
-    dnTensor::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function destroy_dn_tensor(asyncDependencies::Vector{Value}, dnTensor::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dnTensor]
+    operands = Value[asyncDependencies..., dnTensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.destroy_dn_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.destroy_dn_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -572,28 +443,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %token = gpu.destroy_sp_mat async [%dep] %spmat
 ```
 """
-function destroy_sp_mat(
-    asyncDependencies::Vector{Value},
-    spmat::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function destroy_sp_mat(asyncDependencies::Vector{Value}, spmat::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmat]
+    operands = Value[asyncDependencies..., spmat, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.destroy_sp_mat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.destroy_sp_mat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -664,36 +526,22 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    workgroup_attrib_attrs=nothing,
-    private_attrib_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, workgroup_attrib_attrs=nothing, private_attrib_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(workgroup_attrib_attrs) &&
-        push!(attributes, namedattribute("workgroup_attrib_attrs", workgroup_attrib_attrs))
-    !isnothing(private_attrib_attrs) &&
-        push!(attributes, namedattribute("private_attrib_attrs", private_attrib_attrs))
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(workgroup_attrib_attrs) && push!(attributes, namedattribute("workgroup_attrib_attrs", workgroup_attrib_attrs))
+    !isnothing(private_attrib_attrs) && push!(attributes, namedattribute("private_attrib_attrs", private_attrib_attrs))
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -726,19 +574,15 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,25 +599,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -789,25 +627,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -825,20 +657,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -852,20 +680,16 @@ This operation may not be supported in every environment, there is not yet a
 """
 function host_unregister(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_unregister",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_unregister", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -879,23 +703,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -980,59 +800,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    kernelOperands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        kernelOperands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(kernelOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1127,57 +909,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1199,29 +945,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1243,29 +979,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1280,16 +1006,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1304,23 +1026,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1335,20 +1053,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1359,22 +1073,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1400,36 +1110,21 @@ The matrix arguments can also be associated with one of the following
 operators: NON_TRANSPOSE, TRANSPOSE, CONJUGATE_TRANSPOSE. The default value
 is NON_TRANSPOSE.
 """
-function sddmm_buffer_size(
-    asyncDependencies::Vector{Value},
-    dnmatA::Value,
-    dnmatB::Value,
-    spmatC::Value;
-    bufferSz::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
-    results = IR.Type[bufferSz,]
-    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC]
+function sddmm_buffer_size(asyncDependencies::Vector{Value}, dnmatA::Value, dnmatB::Value, spmatC::Value; bufferSz::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
+    results = IR.Type[bufferSz, ]
+    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.sddmm_buffer_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.sddmm_buffer_size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1455,36 +1150,21 @@ The matrix arguments can also be associated with one of the following
 operators: NON_TRANSPOSE, TRANSPOSE, CONJUGATE_TRANSPOSE. The default value
 is NON_TRANSPOSE.
 """
-function sddmm(
-    asyncDependencies::Vector{Value},
-    dnmatA::Value,
-    dnmatB::Value,
-    spmatC::Value,
-    buffer::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
+function sddmm(asyncDependencies::Vector{Value}, dnmatA::Value, dnmatB::Value, spmatC::Value, buffer::Value; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, buffer]
+    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, buffer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.sddmm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.sddmm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1497,20 +1177,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1535,32 +1211,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    shuffleResult=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1586,36 +1250,21 @@ is NON_TRANSPOSE.
 %bufferszs, %token = gpu.spmm_buffer_size async [%dep] %spmatA{TRANSPOSE}, %dnmatB{TRANSPOSE}, %dnmatC : i64 into f32
 ```
 """
-function spmm_buffer_size(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnmatB::Value,
-    dnmatC::Value;
-    bufferSzs::Vector{IR.Type},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
-    results = IR.Type[bufferSzs...,]
-    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC]
+function spmm_buffer_size(asyncDependencies::Vector{Value}, spmatA::Value, dnmatB::Value, dnmatC::Value; bufferSzs::Vector{IR.Type}, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
+    results = IR.Type[bufferSzs..., ]
+    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.spmm_buffer_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmm_buffer_size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1641,40 +1290,22 @@ is NON_TRANSPOSE.
 %token = gpu.spmm async [%dep] %spmatA{TRANSPOSE}, %dnmatB{TRANSPOSE}, %dnmatC, %buffers : type(\$buffers) into f32
 ```
 """
-function spmm(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnmatB::Value,
-    dnmatC::Value,
-    buffers::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
+function spmm(asyncDependencies::Vector{Value}, spmatA::Value, dnmatB::Value, dnmatC::Value, buffers::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, buffers...]
+    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, buffers..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
-    push!(
-        attributes,
-        operandsegmentsizes([length(asyncDependencies), 1, 1, 1, length(buffers)]),
-    )
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, length(buffers), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.spmm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1700,34 +1331,20 @@ is NON_TRANSPOSE.
 %buffersz, %token = gpu.spmv_buffer_size async [%dep] %spmatA{TRANSPOSE}, %dnX, %dnY into f32
 ```
 """
-function spmv_buffer_size(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnX::Value,
-    dnY::Value;
-    bufferSz::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    computeType,
-    location=Location(),
-)
-    results = IR.Type[bufferSz,]
-    operands = Value[asyncDependencies..., spmatA, dnX, dnY]
+function spmv_buffer_size(asyncDependencies::Vector{Value}, spmatA::Value, dnX::Value, dnY::Value; bufferSz::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, computeType, location=Location())
+    results = IR.Type[bufferSz, ]
+    operands = Value[asyncDependencies..., spmatA, dnX, dnY, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
-
-    return IR.create_operation(
-        "gpu.spmv_buffer_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmv_buffer_size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1753,34 +1370,20 @@ is NON_TRANSPOSE.
 %token = gpu.spmv async [%dep] %spmatA{TRANSPOSE}, %dnX, %dnY : memref<?xf64> into bf16
 ```
 """
-function spmv(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnX::Value,
-    dnY::Value,
-    buffer::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    computeType,
-    location=Location(),
-)
+function spmv(asyncDependencies::Vector{Value}, spmatA::Value, dnX::Value, dnY::Value, buffer::Value; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, computeType, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmatA, dnX, dnY, buffer]
+    operands = Value[asyncDependencies..., spmatA, dnX, dnY, buffer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
-
-    return IR.create_operation(
-        "gpu.spmv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1796,23 +1399,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1847,33 +1446,21 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    a_transpose=nothing,
-    b_transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1901,21 +1488,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1939,24 +1522,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, opType, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1988,30 +1565,19 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2038,30 +1604,19 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value,
-    dstMemref::Value,
-    indices::Vector{Value};
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2080,30 +1635,20 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op,
-    uniform=nothing,
-    location=Location(),
-)
+function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op),]
+    attributes = NamedAttribute[namedattribute("op", op), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.subgroup_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2118,23 +1663,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2151,16 +1692,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2176,25 +1713,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2231,27 +1762,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2269,20 +1792,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/GPU.jl
+++ b/src/Dialects/17/GPU.jl
@@ -1,8 +1,8 @@
 module gpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `all_reduce`
@@ -29,21 +29,32 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
+function all_reduce(
+    value::Value;
+    result_0=nothing::Union{Nothing,IR.Type},
+    op=nothing,
+    uniform=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, ]
-    owned_regions = Region[body, ]
+    operands = Value[value,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-    
-    IR.create_operation(
-        "gpu.all_reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.all_reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -69,21 +80,38 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
+function alloc(
+    asyncDependencies::Vector{Value},
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    hostShared=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-    
-    IR.create_operation(
-        "gpu.alloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.alloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -112,12 +140,16 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -133,19 +165,25 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function block_dim(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.block_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.block_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -161,19 +199,25 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function block_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.block_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.block_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -196,19 +240,31 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %spmat, %token = gpu.create_2to4_spmat async [%dep] %rows, %cols, %mem : memref<?xf64>
 ```
 """
-function create_2to4_spmat(asyncDependencies::Vector{Value}, rows::Value, cols::Value, memref::Value; spMat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
-    results = IR.Type[spMat, ]
-    operands = Value[asyncDependencies..., rows, cols, memref, ]
+function create_2to4_spmat(
+    asyncDependencies::Vector{Value},
+    rows::Value,
+    cols::Value,
+    memref::Value;
+    spMat::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[spMat,]
+    operands = Value[asyncDependencies..., rows, cols, memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.create_2to4_spmat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.create_2to4_spmat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -234,19 +290,33 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %values : memref<?xindex>, memref<?xf64>
 ```
 """
-function create_coo_aos(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, idxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
-    results = IR.Type[spmat, ]
-    operands = Value[asyncDependencies..., rows, cols, nnz, idxs, values, ]
+function create_coo_aos(
+    asyncDependencies::Vector{Value},
+    rows::Value,
+    cols::Value,
+    nnz::Value,
+    idxs::Value,
+    values::Value;
+    spmat::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[spmat,]
+    operands = Value[asyncDependencies..., rows, cols, nnz, idxs, values]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.create_coo_aos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.create_coo_aos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -270,19 +340,34 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %colIdx, %values : memref<?xindex>, memref<?xindex>, memref<?xf64>
 ```
 """
-function create_coo(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, rowIdxs::Value, colIdxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
-    results = IR.Type[spmat, ]
-    operands = Value[asyncDependencies..., rows, cols, nnz, rowIdxs, colIdxs, values, ]
+function create_coo(
+    asyncDependencies::Vector{Value},
+    rows::Value,
+    cols::Value,
+    nnz::Value,
+    rowIdxs::Value,
+    colIdxs::Value,
+    values::Value;
+    spmat::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[spmat,]
+    operands = Value[asyncDependencies..., rows, cols, nnz, rowIdxs, colIdxs, values]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.create_coo", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.create_coo",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -306,19 +391,34 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %colIdx, %values : memref<?xindex>, memref<?xindex>, memref<?xf64>
 ```
 """
-function create_csr(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, rowPos::Value, colIdxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
-    results = IR.Type[spmat, ]
-    operands = Value[asyncDependencies..., rows, cols, nnz, rowPos, colIdxs, values, ]
+function create_csr(
+    asyncDependencies::Vector{Value},
+    rows::Value,
+    cols::Value,
+    nnz::Value,
+    rowPos::Value,
+    colIdxs::Value,
+    values::Value;
+    spmat::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[spmat,]
+    operands = Value[asyncDependencies..., rows, cols, nnz, rowPos, colIdxs, values]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.create_csr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.create_csr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -340,20 +440,31 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %dmat, %token = gpu.create_dn_tensor async [%dep] %mem, %dims : index, index into memref<?xf64>
 ```
 """
-function create_dn_tensor(asyncDependencies::Vector{Value}, memref::Value, dims::Vector{Value}; dnTensor::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
-    results = IR.Type[dnTensor, ]
-    operands = Value[asyncDependencies..., memref, dims..., ]
+function create_dn_tensor(
+    asyncDependencies::Vector{Value},
+    memref::Value,
+    dims::Vector{Value};
+    dnTensor::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[dnTensor,]
+    operands = Value[asyncDependencies..., memref, dims...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, length(dims), ]))
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, length(dims)]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.create_dn_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.create_dn_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -377,19 +488,28 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function dealloc(
+    asyncDependencies::Vector{Value},
+    memref::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref, ]
+    operands = Value[asyncDependencies..., memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -410,19 +530,28 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %token = gpu.destroy_dn_tensor async [%dep] %dnTensor
 ```
 """
-function destroy_dn_tensor(asyncDependencies::Vector{Value}, dnTensor::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function destroy_dn_tensor(
+    asyncDependencies::Vector{Value},
+    dnTensor::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dnTensor, ]
+    operands = Value[asyncDependencies..., dnTensor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.destroy_dn_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.destroy_dn_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -443,19 +572,28 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %token = gpu.destroy_sp_mat async [%dep] %spmat
 ```
 """
-function destroy_sp_mat(asyncDependencies::Vector{Value}, spmat::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function destroy_sp_mat(
+    asyncDependencies::Vector{Value},
+    spmat::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmat, ]
+    operands = Value[asyncDependencies..., spmat]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.destroy_sp_mat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.destroy_sp_mat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -526,22 +664,36 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(; function_type, arg_attrs=nothing, res_attrs=nothing, workgroup_attrib_attrs=nothing, private_attrib_attrs=nothing, body::Region, location=Location())
+function func(;
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    workgroup_attrib_attrs=nothing,
+    private_attrib_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type),]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(workgroup_attrib_attrs) && push!(attributes, namedattribute("workgroup_attrib_attrs", workgroup_attrib_attrs))
-    !isnothing(private_attrib_attrs) && push!(attributes, namedattribute("private_attrib_attrs", private_attrib_attrs))
-    
-    IR.create_operation(
-        "gpu.func", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(workgroup_attrib_attrs) &&
+        push!(attributes, namedattribute("workgroup_attrib_attrs", workgroup_attrib_attrs))
+    !isnothing(private_attrib_attrs) &&
+        push!(attributes, namedattribute("private_attrib_attrs", private_attrib_attrs))
+
+    return IR.create_operation(
+        "gpu.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -574,15 +726,19 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.module", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -599,19 +755,25 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function global_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.global_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.global_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -627,19 +789,25 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function grid_dim(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.grid_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.grid_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -657,16 +825,20 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.host_register", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.host_register",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -680,16 +852,20 @@ This operation may not be supported in every environment, there is not yet a
 """
 function host_unregister(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.host_unregister", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.host_unregister",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -703,19 +879,23 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.lane_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.lane_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -800,21 +980,59 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
+function launch_func(
+    asyncDependencies::Vector{Value},
+    gridSizeX::Value,
+    gridSizeY::Value,
+    gridSizeZ::Value,
+    blockSizeX::Value,
+    blockSizeY::Value,
+    blockSizeZ::Value,
+    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
+    kernelOperands::Vector{Value},
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    kernel,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
+    operands = Value[
+        asyncDependencies...,
+        gridSizeX,
+        gridSizeY,
+        gridSizeZ,
+        blockSizeX,
+        blockSizeY,
+        blockSizeZ,
+        kernelOperands...,
+    ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
+    attributes = NamedAttribute[namedattribute("kernel", kernel),]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(kernelOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies),
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.launch_func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.launch_func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -909,21 +1127,57 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
+function launch(
+    asyncDependencies::Vector{Value},
+    gridSizeX::Value,
+    gridSizeY::Value,
+    gridSizeZ::Value,
+    blockSizeX::Value,
+    blockSizeY::Value,
+    blockSizeZ::Value,
+    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
-    owned_regions = Region[body, ]
+    operands = Value[
+        asyncDependencies...,
+        gridSizeX,
+        gridSizeY,
+        gridSizeZ,
+        blockSizeX,
+        blockSizeY,
+        blockSizeZ,
+    ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(asyncDependencies),
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            (dynamicSharedMemorySize == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.launch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.launch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -945,19 +1199,29 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function memcpy(
+    asyncDependencies::Vector{Value},
+    dst::Value,
+    src::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src, ]
+    operands = Value[asyncDependencies..., dst, src]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.memcpy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.memcpy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -979,19 +1243,29 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function memset(
+    asyncDependencies::Vector{Value},
+    dst::Value,
+    value::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value, ]
+    operands = Value[asyncDependencies..., dst, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.memset", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.memset",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1006,12 +1280,16 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.module_end", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.module_end",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1026,19 +1304,23 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.num_subgroups", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.num_subgroups",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1053,16 +1335,20 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format), ]
-    
-    IR.create_operation(
-        "gpu.printf", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("format", format),]
+
+    return IR.create_operation(
+        "gpu.printf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1073,18 +1359,22 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1110,21 +1400,36 @@ The matrix arguments can also be associated with one of the following
 operators: NON_TRANSPOSE, TRANSPOSE, CONJUGATE_TRANSPOSE. The default value
 is NON_TRANSPOSE.
 """
-function sddmm_buffer_size(asyncDependencies::Vector{Value}, dnmatA::Value, dnmatB::Value, spmatC::Value; bufferSz::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
-    results = IR.Type[bufferSz, ]
-    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, ]
+function sddmm_buffer_size(
+    asyncDependencies::Vector{Value},
+    dnmatA::Value,
+    dnmatB::Value,
+    spmatC::Value;
+    bufferSz::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    modeA=nothing,
+    modeB=nothing,
+    computeType,
+    location=Location(),
+)
+    results = IR.Type[bufferSz,]
+    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    attributes = NamedAttribute[namedattribute("computeType", computeType),]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-    
-    IR.create_operation(
-        "gpu.sddmm_buffer_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.sddmm_buffer_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1150,21 +1455,36 @@ The matrix arguments can also be associated with one of the following
 operators: NON_TRANSPOSE, TRANSPOSE, CONJUGATE_TRANSPOSE. The default value
 is NON_TRANSPOSE.
 """
-function sddmm(asyncDependencies::Vector{Value}, dnmatA::Value, dnmatB::Value, spmatC::Value, buffer::Value; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
+function sddmm(
+    asyncDependencies::Vector{Value},
+    dnmatA::Value,
+    dnmatB::Value,
+    spmatC::Value,
+    buffer::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    modeA=nothing,
+    modeB=nothing,
+    computeType,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, buffer, ]
+    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, buffer]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    attributes = NamedAttribute[namedattribute("computeType", computeType),]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-    
-    IR.create_operation(
-        "gpu.sddmm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.sddmm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1177,16 +1497,20 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex, ]
+    operands = Value[devIndex,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.set_default_device", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.set_default_device",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1211,20 +1535,32 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
+function shuffle(
+    value::Value,
+    offset::Value,
+    width::Value;
+    shuffleResult=nothing::Union{Nothing,IR.Type},
+    valid=nothing::Union{Nothing,IR.Type},
+    mode,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, offset, width, ]
+    operands = Value[value, offset, width]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode), ]
+    attributes = NamedAttribute[namedattribute("mode", mode),]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-    
-    IR.create_operation(
-        "gpu.shuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.shuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1250,21 +1586,36 @@ is NON_TRANSPOSE.
 %bufferszs, %token = gpu.spmm_buffer_size async [%dep] %spmatA{TRANSPOSE}, %dnmatB{TRANSPOSE}, %dnmatC : i64 into f32
 ```
 """
-function spmm_buffer_size(asyncDependencies::Vector{Value}, spmatA::Value, dnmatB::Value, dnmatC::Value; bufferSzs::Vector{IR.Type}, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
-    results = IR.Type[bufferSzs..., ]
-    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, ]
+function spmm_buffer_size(
+    asyncDependencies::Vector{Value},
+    spmatA::Value,
+    dnmatB::Value,
+    dnmatC::Value;
+    bufferSzs::Vector{IR.Type},
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    modeA=nothing,
+    modeB=nothing,
+    computeType,
+    location=Location(),
+)
+    results = IR.Type[bufferSzs...,]
+    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    attributes = NamedAttribute[namedattribute("computeType", computeType),]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-    
-    IR.create_operation(
-        "gpu.spmm_buffer_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.spmm_buffer_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1290,22 +1641,40 @@ is NON_TRANSPOSE.
 %token = gpu.spmm async [%dep] %spmatA{TRANSPOSE}, %dnmatB{TRANSPOSE}, %dnmatC, %buffers : type(\$buffers) into f32
 ```
 """
-function spmm(asyncDependencies::Vector{Value}, spmatA::Value, dnmatB::Value, dnmatC::Value, buffers::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
+function spmm(
+    asyncDependencies::Vector{Value},
+    spmatA::Value,
+    dnmatB::Value,
+    dnmatC::Value,
+    buffers::Vector{Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    modeA=nothing,
+    modeB=nothing,
+    computeType,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, buffers..., ]
+    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, buffers...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, length(buffers), ]))
+    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    push!(
+        attributes,
+        operandsegmentsizes([length(asyncDependencies), 1, 1, 1, length(buffers)]),
+    )
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-    
-    IR.create_operation(
-        "gpu.spmm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.spmm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1331,20 +1700,34 @@ is NON_TRANSPOSE.
 %buffersz, %token = gpu.spmv_buffer_size async [%dep] %spmatA{TRANSPOSE}, %dnX, %dnY into f32
 ```
 """
-function spmv_buffer_size(asyncDependencies::Vector{Value}, spmatA::Value, dnX::Value, dnY::Value; bufferSz::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, computeType, location=Location())
-    results = IR.Type[bufferSz, ]
-    operands = Value[asyncDependencies..., spmatA, dnX, dnY, ]
+function spmv_buffer_size(
+    asyncDependencies::Vector{Value},
+    spmatA::Value,
+    dnX::Value,
+    dnY::Value;
+    bufferSz::IR.Type,
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    modeA=nothing,
+    computeType,
+    location=Location(),
+)
+    results = IR.Type[bufferSz,]
+    operands = Value[asyncDependencies..., spmatA, dnX, dnY]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    attributes = NamedAttribute[namedattribute("computeType", computeType),]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
-    
-    IR.create_operation(
-        "gpu.spmv_buffer_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.spmv_buffer_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1370,20 +1753,34 @@ is NON_TRANSPOSE.
 %token = gpu.spmv async [%dep] %spmatA{TRANSPOSE}, %dnX, %dnY : memref<?xf64> into bf16
 ```
 """
-function spmv(asyncDependencies::Vector{Value}, spmatA::Value, dnX::Value, dnY::Value, buffer::Value; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, computeType, location=Location())
+function spmv(
+    asyncDependencies::Vector{Value},
+    spmatA::Value,
+    dnX::Value,
+    dnY::Value,
+    buffer::Value;
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    modeA=nothing,
+    computeType,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmatA, dnX, dnY, buffer, ]
+    operands = Value[asyncDependencies..., spmatA, dnX, dnY, buffer]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    attributes = NamedAttribute[namedattribute("computeType", computeType),]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
-    
-    IR.create_operation(
-        "gpu.spmv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.spmv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1399,19 +1796,23 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.subgroup_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1446,21 +1847,33 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
+function subgroup_mma_compute(
+    opA::Value,
+    opB::Value,
+    opC::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    a_transpose=nothing,
+    b_transpose=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[opA, opB, opC, ]
+    operands = Value[opA, opB, opC]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_compute", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_compute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1488,17 +1901,21 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[value, ]
+    results = IR.Type[res,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1522,18 +1939,24 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[args..., ]
+function subgroup_mma_elementwise(
+    args::Vector{Value}; res::IR.Type, opType, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType), ]
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_elementwise", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType),]
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_elementwise",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1565,19 +1988,30 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[srcMemref, indices..., ]
+function subgroup_mma_load_matrix(
+    srcMemref::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    leadDimension,
+    transpose=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[srcMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_load_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_load_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1604,19 +2038,30 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
+function subgroup_mma_store_matrix(
+    src::Value,
+    dstMemref::Value,
+    indices::Vector{Value};
+    leadDimension,
+    transpose=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices..., ]
+    operands = Value[src, dstMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-    
-    IR.create_operation(
-        "gpu.subgroup_mma_store_matrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_mma_store_matrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1635,20 +2080,30 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
+function subgroup_reduce(
+    value::Value;
+    result_0=nothing::Union{Nothing,IR.Type},
+    op,
+    uniform=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op), ]
+    attributes = NamedAttribute[namedattribute("op", op),]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-    
-    IR.create_operation(
-        "gpu.subgroup_reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1663,19 +2118,23 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "gpu.subgroup_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.subgroup_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1692,12 +2151,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1713,19 +2176,25 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
+function thread_id(;
+    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "gpu.thread_id", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.thread_id",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1762,19 +2231,27 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+function wait(
+    asyncDependencies::Vector{Value};
+    asyncToken=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[asyncDependencies..., ]
+    operands = Value[asyncDependencies...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-    
-    IR.create_operation(
-        "gpu.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1792,16 +2269,20 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values..., ]
+    operands = Value[values...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "gpu.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "gpu.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/GPU.jl
+++ b/src/Dialects/17/GPU.jl
@@ -1,9 +1,8 @@
 module gpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `all_reduce`
@@ -30,32 +29,21 @@ accumulation as code region. The accumulation operation must be one of:
 If `uniform` flag is set either none or all work items of a workgroup
 need to execute this op in convergence.
 """
-function all_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op=nothing,
-    uniform=nothing,
-    body::Region,
-    location=Location(),
-)
+function all_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op=nothing, uniform=nothing, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
-    owned_regions = Region[body,]
+    operands = Value[value, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(op) && push!(attributes, namedattribute("op", op))
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.all_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.all_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -81,38 +69,21 @@ memory accessible both on host and on device.
 %memref, %token = gpu.alloc async [%dep] host_shared (%width) : memref<64x?xf32, 1>
 ```
 """
-function alloc(
-    asyncDependencies::Vector{Value},
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    hostShared=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands...]
+function alloc(asyncDependencies::Vector{Value}, dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, hostShared=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[asyncDependencies..., dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies), length(dynamicSizes), length(symbolOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(hostShared) && push!(attributes, namedattribute("hostShared", hostShared))
-
-    return IR.create_operation(
-        "gpu.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -141,16 +112,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -166,25 +133,19 @@ the x, y, or z `dimension`.
 %bDimX = gpu.block_dim x
 ```
 """
-function block_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -200,25 +161,19 @@ along the x, y, or z `dimension`.
 %bIdY = gpu.block_id y
 ```
 """
-function block_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function block_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.block_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.block_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,31 +196,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %spmat, %token = gpu.create_2to4_spmat async [%dep] %rows, %cols, %mem : memref<?xf64>
 ```
 """
-function create_2to4_spmat(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    memref::Value;
-    spMat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spMat,]
-    operands = Value[asyncDependencies..., rows, cols, memref]
+function create_2to4_spmat(asyncDependencies::Vector{Value}, rows::Value, cols::Value, memref::Value; spMat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spMat, ]
+    operands = Value[asyncDependencies..., rows, cols, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_2to4_spmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_2to4_spmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -291,33 +234,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %values : memref<?xindex>, memref<?xf64>
 ```
 """
-function create_coo_aos(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    nnz::Value,
-    idxs::Value,
-    values::Value;
-    spmat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spmat,]
-    operands = Value[asyncDependencies..., rows, cols, nnz, idxs, values]
+function create_coo_aos(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, idxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spmat, ]
+    operands = Value[asyncDependencies..., rows, cols, nnz, idxs, values, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_coo_aos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_coo_aos", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -341,34 +270,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %colIdx, %values : memref<?xindex>, memref<?xindex>, memref<?xf64>
 ```
 """
-function create_coo(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    nnz::Value,
-    rowIdxs::Value,
-    colIdxs::Value,
-    values::Value;
-    spmat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spmat,]
-    operands = Value[asyncDependencies..., rows, cols, nnz, rowIdxs, colIdxs, values]
+function create_coo(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, rowIdxs::Value, colIdxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spmat, ]
+    operands = Value[asyncDependencies..., rows, cols, nnz, rowIdxs, colIdxs, values, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -392,34 +306,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
     %colIdx, %values : memref<?xindex>, memref<?xindex>, memref<?xf64>
 ```
 """
-function create_csr(
-    asyncDependencies::Vector{Value},
-    rows::Value,
-    cols::Value,
-    nnz::Value,
-    rowPos::Value,
-    colIdxs::Value,
-    values::Value;
-    spmat::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[spmat,]
-    operands = Value[asyncDependencies..., rows, cols, nnz, rowPos, colIdxs, values]
+function create_csr(asyncDependencies::Vector{Value}, rows::Value, cols::Value, nnz::Value, rowPos::Value, colIdxs::Value, values::Value; spmat::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[spmat, ]
+    operands = Value[asyncDependencies..., rows, cols, nnz, rowPos, colIdxs, values, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_csr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_csr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -441,31 +340,20 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %dmat, %token = gpu.create_dn_tensor async [%dep] %mem, %dims : index, index into memref<?xf64>
 ```
 """
-function create_dn_tensor(
-    asyncDependencies::Vector{Value},
-    memref::Value,
-    dims::Vector{Value};
-    dnTensor::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[dnTensor,]
-    operands = Value[asyncDependencies..., memref, dims...]
+function create_dn_tensor(asyncDependencies::Vector{Value}, memref::Value, dims::Vector{Value}; dnTensor::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
+    results = IR.Type[dnTensor, ]
+    operands = Value[asyncDependencies..., memref, dims..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, length(dims)]))
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, length(dims), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.create_dn_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.create_dn_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -489,28 +377,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.dealloc async [%dep] %memref : memref<8x64xf32, 1>
 ```
 """
-function dealloc(
-    asyncDependencies::Vector{Value},
-    memref::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function dealloc(asyncDependencies::Vector{Value}, memref::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., memref]
+    operands = Value[asyncDependencies..., memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -531,28 +410,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %token = gpu.destroy_dn_tensor async [%dep] %dnTensor
 ```
 """
-function destroy_dn_tensor(
-    asyncDependencies::Vector{Value},
-    dnTensor::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function destroy_dn_tensor(asyncDependencies::Vector{Value}, dnTensor::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dnTensor]
+    operands = Value[asyncDependencies..., dnTensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.destroy_dn_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.destroy_dn_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -573,28 +443,19 @@ that case, it returns a !gpu.async.token in addition to the environment.
 %token = gpu.destroy_sp_mat async [%dep] %spmat
 ```
 """
-function destroy_sp_mat(
-    asyncDependencies::Vector{Value},
-    spmat::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function destroy_sp_mat(asyncDependencies::Vector{Value}, spmat::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmat]
+    operands = Value[asyncDependencies..., spmat, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.destroy_sp_mat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.destroy_sp_mat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -665,36 +526,22 @@ The generic form illustrates the concept
 Note the non-default memory spaces used in memref types in memory
 attribution.
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    workgroup_attrib_attrs=nothing,
-    private_attrib_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, workgroup_attrib_attrs=nothing, private_attrib_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type),]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(workgroup_attrib_attrs) &&
-        push!(attributes, namedattribute("workgroup_attrib_attrs", workgroup_attrib_attrs))
-    !isnothing(private_attrib_attrs) &&
-        push!(attributes, namedattribute("private_attrib_attrs", private_attrib_attrs))
-
-    return IR.create_operation(
-        "gpu.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(workgroup_attrib_attrs) && push!(attributes, namedattribute("workgroup_attrib_attrs", workgroup_attrib_attrs))
+    !isnothing(private_attrib_attrs) && push!(attributes, namedattribute("private_attrib_attrs", private_attrib_attrs))
+    
+    IR.create_operation(
+        "gpu.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -727,19 +574,15 @@ or not intended to be run on the separate device.
 function module_(; bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -756,25 +599,19 @@ current workitem/thread within all workgroups / grid along the x, y, or z
 %gidX = gpu.global_id x
 ```
 """
-function global_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function global_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.global_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.global_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -790,25 +627,19 @@ Returns the number of thread blocks in the grid along the x, y, or z
 %gDimZ = gpu.grid_dim z
 ```
 """
-function grid_dim(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function grid_dim(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.grid_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.grid_dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -826,20 +657,16 @@ the host after synchronizing with the device kernel completion.
 """
 function host_register(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_register",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_register", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -853,20 +680,16 @@ This operation may not be supported in every environment, there is not yet a
 """
 function host_unregister(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.host_unregister",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.host_unregister", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -880,23 +703,19 @@ Returns the lane id within the subgroup (warp/wave).
 %laneId = gpu.lane_id
 ```
 """
-function lane_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function lane_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.lane_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.lane_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -981,59 +800,21 @@ module attributes {gpu.container_module} {
 }
 ```
 """
-function launch_func(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    kernelOperands::Vector{Value},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    kernel,
-    location=Location(),
-)
+function launch_func(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; kernelOperands::Vector{Value}, asyncToken=nothing::Union{Nothing, IR.Type}, kernel, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-        kernelOperands...,
-    ]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, kernelOperands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel),]
+    attributes = NamedAttribute[namedattribute("kernel", kernel), ]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1length(kernelOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1length(kernelOperands), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch_func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch_func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1128,57 +909,21 @@ know what value corresponds to threadIdx.x for coalescing). We can recover
 these properties by analyzing the operations producing values, but it is
 easier just to have that information by construction.
 """
-function launch(
-    asyncDependencies::Vector{Value},
-    gridSizeX::Value,
-    gridSizeY::Value,
-    gridSizeZ::Value,
-    blockSizeX::Value,
-    blockSizeY::Value,
-    blockSizeZ::Value,
-    dynamicSharedMemorySize=nothing::Union{Nothing,Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    body::Region,
-    location=Location(),
-)
+function launch(asyncDependencies::Vector{Value}, gridSizeX::Value, gridSizeY::Value, gridSizeZ::Value, blockSizeX::Value, blockSizeY::Value, blockSizeZ::Value, dynamicSharedMemorySize=nothing::Union{Nothing, Value}; asyncToken=nothing::Union{Nothing, IR.Type}, body::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        asyncDependencies...,
-        gridSizeX,
-        gridSizeY,
-        gridSizeZ,
-        blockSizeX,
-        blockSizeY,
-        blockSizeZ,
-    ]
-    owned_regions = Region[body,]
+    operands = Value[asyncDependencies..., gridSizeX, gridSizeY, gridSizeZ, blockSizeX, blockSizeY, blockSizeZ, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicSharedMemorySize) && push!(operands, dynamicSharedMemorySize)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(asyncDependencies),
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            (dynamicSharedMemorySize == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, 1, 1, 1, (dynamicSharedMemorySize==nothing) ? 0 : 1]))
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.launch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.launch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1200,29 +945,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memcpy async [%dep] %dst, %src : memref<?xf32, 1>, memref<?xf32>
 ```
 """
-function memcpy(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    src::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memcpy(asyncDependencies::Vector{Value}, dst::Value, src::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, src]
+    operands = Value[asyncDependencies..., dst, src, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memcpy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memcpy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1244,29 +979,19 @@ that case, it returns a !gpu.async.token.
 %token = gpu.memset async [%dep] %dst, %value : memref<?xf32, 1>, f32
 ```
 """
-function memset(
-    asyncDependencies::Vector{Value},
-    dst::Value,
-    value::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function memset(asyncDependencies::Vector{Value}, dst::Value, value::Value; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dst, value]
+    operands = Value[asyncDependencies..., dst, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.memset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.memset", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1281,16 +1006,12 @@ function module_end(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.module_end",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.module_end", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1305,23 +1026,19 @@ Returns the number of subgroups within a workgroup.
 %numSg = gpu.num_subgroups : index
 ```
 """
-function num_subgroups(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function num_subgroups(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.num_subgroups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.num_subgroups", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1336,20 +1053,16 @@ imposed by one\'s target platform.
 """
 function printf(args::Vector{Value}; format, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("format", format),]
-
-    return IR.create_operation(
-        "gpu.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("format", format), ]
+    
+    IR.create_operation(
+        "gpu.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1360,22 +1073,18 @@ A terminator operation for regions that appear in the body of  `gpu.func`
 functions. The operands to the `gpu.return` are the result values returned
 by an invocation of the `gpu.func`.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1401,36 +1110,21 @@ The matrix arguments can also be associated with one of the following
 operators: NON_TRANSPOSE, TRANSPOSE, CONJUGATE_TRANSPOSE. The default value
 is NON_TRANSPOSE.
 """
-function sddmm_buffer_size(
-    asyncDependencies::Vector{Value},
-    dnmatA::Value,
-    dnmatB::Value,
-    spmatC::Value;
-    bufferSz::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
-    results = IR.Type[bufferSz,]
-    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC]
+function sddmm_buffer_size(asyncDependencies::Vector{Value}, dnmatA::Value, dnmatB::Value, spmatC::Value; bufferSz::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
+    results = IR.Type[bufferSz, ]
+    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.sddmm_buffer_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.sddmm_buffer_size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1456,36 +1150,21 @@ The matrix arguments can also be associated with one of the following
 operators: NON_TRANSPOSE, TRANSPOSE, CONJUGATE_TRANSPOSE. The default value
 is NON_TRANSPOSE.
 """
-function sddmm(
-    asyncDependencies::Vector{Value},
-    dnmatA::Value,
-    dnmatB::Value,
-    spmatC::Value,
-    buffer::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
+function sddmm(asyncDependencies::Vector{Value}, dnmatA::Value, dnmatB::Value, spmatC::Value, buffer::Value; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, buffer]
+    operands = Value[asyncDependencies..., dnmatA, dnmatB, spmatC, buffer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.sddmm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.sddmm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1498,20 +1177,16 @@ thread-local.
 """
 function set_default_device(devIndex::Value; location=Location())
     results = IR.Type[]
-    operands = Value[devIndex,]
+    operands = Value[devIndex, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.set_default_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.set_default_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1536,32 +1211,20 @@ shuffle. The width needs to be the same for all invocations that participate
 in the shuffle. Exactly the first `width` invocations of a subgroup need to
 execute this op in convergence.
 """
-function shuffle(
-    value::Value,
-    offset::Value,
-    width::Value;
-    shuffleResult=nothing::Union{Nothing,IR.Type},
-    valid=nothing::Union{Nothing,IR.Type},
-    mode,
-    location=Location(),
-)
+function shuffle(value::Value, offset::Value, width::Value; shuffleResult=nothing::Union{Nothing, IR.Type}, valid=nothing::Union{Nothing, IR.Type}, mode, location=Location())
     results = IR.Type[]
-    operands = Value[value, offset, width]
+    operands = Value[value, offset, width, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mode", mode),]
+    attributes = NamedAttribute[namedattribute("mode", mode), ]
     !isnothing(shuffleResult) && push!(results, shuffleResult)
     !isnothing(valid) && push!(results, valid)
-
-    return IR.create_operation(
-        "gpu.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1587,36 +1250,21 @@ is NON_TRANSPOSE.
 %bufferszs, %token = gpu.spmm_buffer_size async [%dep] %spmatA{TRANSPOSE}, %dnmatB{TRANSPOSE}, %dnmatC : i64 into f32
 ```
 """
-function spmm_buffer_size(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnmatB::Value,
-    dnmatC::Value;
-    bufferSzs::Vector{IR.Type},
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
-    results = IR.Type[bufferSzs...,]
-    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC]
+function spmm_buffer_size(asyncDependencies::Vector{Value}, spmatA::Value, dnmatB::Value, dnmatC::Value; bufferSzs::Vector{IR.Type}, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
+    results = IR.Type[bufferSzs..., ]
+    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.spmm_buffer_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmm_buffer_size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1642,40 +1290,22 @@ is NON_TRANSPOSE.
 %token = gpu.spmm async [%dep] %spmatA{TRANSPOSE}, %dnmatB{TRANSPOSE}, %dnmatC, %buffers : type(\$buffers) into f32
 ```
 """
-function spmm(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnmatB::Value,
-    dnmatC::Value,
-    buffers::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    modeB=nothing,
-    computeType,
-    location=Location(),
-)
+function spmm(asyncDependencies::Vector{Value}, spmatA::Value, dnmatB::Value, dnmatC::Value, buffers::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, modeB=nothing, computeType, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, buffers...]
+    operands = Value[asyncDependencies..., spmatA, dnmatB, dnmatC, buffers..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
-    push!(
-        attributes,
-        operandsegmentsizes([length(asyncDependencies), 1, 1, 1, length(buffers)]),
-    )
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
+    push!(attributes, operandsegmentsizes([length(asyncDependencies), 1, 1, 1, length(buffers), ]))
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
     !isnothing(modeB) && push!(attributes, namedattribute("modeB", modeB))
-
-    return IR.create_operation(
-        "gpu.spmm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1701,34 +1331,20 @@ is NON_TRANSPOSE.
 %buffersz, %token = gpu.spmv_buffer_size async [%dep] %spmatA{TRANSPOSE}, %dnX, %dnY into f32
 ```
 """
-function spmv_buffer_size(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnX::Value,
-    dnY::Value;
-    bufferSz::IR.Type,
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    computeType,
-    location=Location(),
-)
-    results = IR.Type[bufferSz,]
-    operands = Value[asyncDependencies..., spmatA, dnX, dnY]
+function spmv_buffer_size(asyncDependencies::Vector{Value}, spmatA::Value, dnX::Value, dnY::Value; bufferSz::IR.Type, asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, computeType, location=Location())
+    results = IR.Type[bufferSz, ]
+    operands = Value[asyncDependencies..., spmatA, dnX, dnY, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
-
-    return IR.create_operation(
-        "gpu.spmv_buffer_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmv_buffer_size", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1754,34 +1370,20 @@ is NON_TRANSPOSE.
 %token = gpu.spmv async [%dep] %spmatA{TRANSPOSE}, %dnX, %dnY : memref<?xf64> into bf16
 ```
 """
-function spmv(
-    asyncDependencies::Vector{Value},
-    spmatA::Value,
-    dnX::Value,
-    dnY::Value,
-    buffer::Value;
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    modeA=nothing,
-    computeType,
-    location=Location(),
-)
+function spmv(asyncDependencies::Vector{Value}, spmatA::Value, dnX::Value, dnY::Value, buffer::Value; asyncToken=nothing::Union{Nothing, IR.Type}, modeA=nothing, computeType, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies..., spmatA, dnX, dnY, buffer]
+    operands = Value[asyncDependencies..., spmatA, dnX, dnY, buffer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("computeType", computeType),]
+    attributes = NamedAttribute[namedattribute("computeType", computeType), ]
     !isnothing(asyncToken) && push!(results, asyncToken)
     !isnothing(modeA) && push!(attributes, namedattribute("modeA", modeA))
-
-    return IR.create_operation(
-        "gpu.spmv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.spmv", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1797,23 +1399,19 @@ workgroup.
 %sgId = gpu.subgroup_id : index
 ```
 """
-function subgroup_id(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_id(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1848,33 +1446,21 @@ This op is meant to be used along with `gpu.subgroup_mma_store_matrix` and
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_compute(
-    opA::Value,
-    opB::Value,
-    opC::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    a_transpose=nothing,
-    b_transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_compute(opA::Value, opB::Value, opC::Value; res=nothing::Union{Nothing, IR.Type}, a_transpose=nothing, b_transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[opA, opB, opC]
+    operands = Value[opA, opB, opC, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
     !isnothing(a_transpose) && push!(attributes, namedattribute("a_transpose", a_transpose))
     !isnothing(b_transpose) && push!(attributes, namedattribute("b_transpose", b_transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_compute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_compute", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1902,21 +1488,17 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
 ```
 """
 function subgroup_mma_constant_matrix(value::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[value,]
+    results = IR.Type[res, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_constant_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_constant_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1940,24 +1522,18 @@ This op is meant to be used along with `gpu.subgroup_mma_compute`.
   -> !gpu.mma_matrix<16x16xf16, \"COp\">
 ```
 """
-function subgroup_mma_elementwise(
-    args::Vector{Value}; res::IR.Type, opType, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[args...,]
+function subgroup_mma_elementwise(args::Vector{Value}; res::IR.Type, opType, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("opType", opType),]
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_elementwise",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("opType", opType), ]
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_elementwise", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1989,30 +1565,19 @@ This op is often meant to be used along with `gpu.subgroup_mma_store_matrix` and
       : memref<32x32xf16, 3>, !gpu.mma_matrix<16x16xf16, \"AOp\">
 ```
 """
-function subgroup_mma_load_matrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function subgroup_mma_load_matrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, leadDimension, transpose=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_load_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_load_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2039,30 +1604,19 @@ gpu.subgroup_mma_store_matrix %D, %sg[%i,%j] : { leadDimension = 32 : i32}
                 : !gpu.mma_matrix<16x16xf16, \"COp\">, memref<32x32xf16, 3>
 ```
 """
-function subgroup_mma_store_matrix(
-    src::Value,
-    dstMemref::Value,
-    indices::Vector{Value};
-    leadDimension,
-    transpose=nothing,
-    location=Location(),
-)
+function subgroup_mma_store_matrix(src::Value, dstMemref::Value, indices::Vector{Value}; leadDimension, transpose=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[src, dstMemref, indices...]
+    operands = Value[src, dstMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension),]
+    attributes = NamedAttribute[namedattribute("leadDimension", leadDimension), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "gpu.subgroup_mma_store_matrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_mma_store_matrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2081,30 +1635,20 @@ subgroup. The result is equal for all work items of a subgroup.
 If `uniform` flag is set either none or all work items of a subgroup
 need to execute this op in convergence.
 """
-function subgroup_reduce(
-    value::Value;
-    result_0=nothing::Union{Nothing,IR.Type},
-    op,
-    uniform=nothing,
-    location=Location(),
-)
+function subgroup_reduce(value::Value; result_0=nothing::Union{Nothing, IR.Type}, op, uniform=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op", op),]
+    attributes = NamedAttribute[namedattribute("op", op), ]
     !isnothing(result_0) && push!(results, result_0)
     !isnothing(uniform) && push!(attributes, namedattribute("uniform", uniform))
-
-    return IR.create_operation(
-        "gpu.subgroup_reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2119,23 +1663,19 @@ Returns the number of threads within a subgroup.
 %sgSz = gpu.subgroup_size : index
 ```
 """
-function subgroup_size(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function subgroup_size(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "gpu.subgroup_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.subgroup_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2152,16 +1692,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2177,25 +1713,19 @@ along the x, y, or z `dimension`.
 %tIdX = gpu.thread_id x
 ```
 """
-function thread_id(;
-    result_0=nothing::Union{Nothing,IR.Type}, dimension, location=Location()
-)
+function thread_id(; result_0=nothing::Union{Nothing, IR.Type}, dimension, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "gpu.thread_id",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.thread_id", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2232,27 +1762,19 @@ once this op completes. Example usage:
 gpu.wait [%t0, %t1]
 ```
 """
-function wait(
-    asyncDependencies::Vector{Value};
-    asyncToken=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function wait(asyncDependencies::Vector{Value}; asyncToken=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies...,]
+    operands = Value[asyncDependencies..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncToken) && push!(results, asyncToken)
-
-    return IR.create_operation(
-        "gpu.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2270,20 +1792,16 @@ gpu.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "gpu.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "gpu.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/IRDL.jl
+++ b/src/Dialects/17/IRDL.jl
@@ -1,8 +1,8 @@
 module irdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `all_of`
@@ -33,25 +33,19 @@ The above program defines a type `complex` inside the dialect `cmath` that
 can has one parameter that must be 32-bit long and a float (in other
 words, that must be `f32`).
 """
-function all_of(
-    args::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function all_of(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.all_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.all_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -80,25 +74,19 @@ The above program defines a type `complex` inside the dialect `cmath` that
 can have a single type parameter that can be either `i32`, `i64`, `f32` or
 `f32`.
 """
-function any_of(
-    args::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function any_of(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.any_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.any_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -121,23 +109,19 @@ irdl.dialect @cmath {
 The above program defines a type `complex_flexible` inside the dialect
 `cmath` that has a single parameter that can be any attribute.
 """
-function any(; output=nothing::Union{Nothing,IR.Type}, location=Location())
+function any(; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.any", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -170,24 +154,20 @@ either a `\"foo\"` or a `\"bar\"`.
 function attribute(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`attributes`
+`attributes_`
 
 `irdl.attributes` defines the attributes of the `irdl.operation` parent 
 operation definition.
@@ -212,24 +192,18 @@ irdl.dialect @example {
 The operation will expect an arbitrary attribute \"attr1\" and an
 attribute \"attr2\" with value `i64`.
 """
-function attributes(
-    attributeValues::Vector{Value}; attributeValueNames, location=Location()
-)
+function attributes_(attributeValues::Vector{Value}; attributeValueNames, location=Location())
     results = IR.Type[]
-    operands = Value[attributeValues...,]
+    operands = Value[attributeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-
-    return IR.create_operation(
-        "irdl.attributes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    
+    IR.create_operation(
+        "irdl.attributes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -262,23 +236,19 @@ irdl.type @op_with_attr {
 In this example, @op_with_attr is defined as a type with a single
 parameter, which is an `IntegerAttr`, as constrained by the C++ predicate.
 """
-function c_pred(; output=nothing::Union{Nothing,IR.Type}, pred, location=Location())
+function c_pred(; output=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.c_pred",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.c_pred", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -301,19 +271,15 @@ The above program defines a `cmath` dialect.
 function dialect(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.dialect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.dialect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -337,28 +303,24 @@ irdl.dialect @cmath {
 The above program defines a `complex_i32` type inside the dialect `cmath`
 that can only have a `i32` as its parameter.
 """
-function is(; output=nothing::Union{Nothing,IR.Type}, expected, location=Location())
+function is(; output=nothing::Union{Nothing, IR.Type}, expected, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("expected", expected),]
+    attributes = NamedAttribute[namedattribute("expected", expected), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.is",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.is", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
 """
-`operands`
+`operands_`
 
 `irdl.operands` define the operands of the `irdl.operation` parent operation
 definition.
@@ -395,22 +357,18 @@ When more than one operand is marked as optional or variadic, the operation
 will expect a \'operandSegmentSizes\' attribute that defines the number of
 operands in each segment.
 """
-function operands(args::Vector{Value}; location=Location())
+function operands_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "irdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -447,19 +405,15 @@ returns a single result of the element type of the operand.
 function operation(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -487,20 +441,16 @@ type has a single parameter that should be either `i32` or `i64`.
 """
 function parameters(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "irdl.parameters",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.parameters", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -531,33 +481,24 @@ irdl.dialect @cmath {
 The above program defines an operation `norm` inside the dialect `cmath` that
 for any `T` takes a `cmath.complex` with parameter `T` and returns a `T`.
 """
-function parametric(
-    args::Vector{Value};
-    output=nothing::Union{Nothing,IR.Type},
-    base_type,
-    location=Location(),
-)
+function parametric(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, base_type, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("base_type", base_type),]
+    attributes = NamedAttribute[namedattribute("base_type", base_type), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.parametric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.parametric", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
 """
-`results`
+`results_`
 
 `irdl.results` define the results of the `irdl.operation` parent operation
 definition.
@@ -594,22 +535,18 @@ When more than one result is marked as optional or variadic, the operation
 will expect a \'resultSegmentSizes\' attribute that defines the number of
 results in each segment.
 """
-function results(args::Vector{Value}; location=Location())
+function results_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "irdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,19 +577,15 @@ type has a single parameter that should be either `i32` or `i64`.
 function type(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/IRDL.jl
+++ b/src/Dialects/17/IRDL.jl
@@ -1,9 +1,8 @@
 module irdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `all_of`
@@ -34,25 +33,19 @@ The above program defines a type `complex` inside the dialect `cmath` that
 can has one parameter that must be 32-bit long and a float (in other
 words, that must be `f32`).
 """
-function all_of(
-    args::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function all_of(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.all_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.all_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -81,25 +74,19 @@ The above program defines a type `complex` inside the dialect `cmath` that
 can have a single type parameter that can be either `i32`, `i64`, `f32` or
 `f32`.
 """
-function any_of(
-    args::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function any_of(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.any_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.any_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -122,23 +109,19 @@ irdl.dialect @cmath {
 The above program defines a type `complex_flexible` inside the dialect
 `cmath` that has a single parameter that can be any attribute.
 """
-function any(; output=nothing::Union{Nothing,IR.Type}, location=Location())
+function any(; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.any", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -171,24 +154,20 @@ either a `\"foo\"` or a `\"bar\"`.
 function attribute(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`attributes`
+`attributes_`
 
 `irdl.attributes` defines the attributes of the `irdl.operation` parent 
 operation definition.
@@ -213,24 +192,18 @@ irdl.dialect @example {
 The operation will expect an arbitrary attribute \"attr1\" and an
 attribute \"attr2\" with value `i64`.
 """
-function attributes(
-    attributeValues::Vector{Value}; attributeValueNames, location=Location()
-)
+function attributes_(attributeValues::Vector{Value}; attributeValueNames, location=Location())
     results = IR.Type[]
-    operands = Value[attributeValues...,]
+    operands = Value[attributeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-
-    return IR.create_operation(
-        "irdl.attributes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    
+    IR.create_operation(
+        "irdl.attributes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -263,23 +236,19 @@ irdl.type @op_with_attr {
 In this example, @op_with_attr is defined as a type with a single
 parameter, which is an `IntegerAttr`, as constrained by the C++ predicate.
 """
-function c_pred(; output=nothing::Union{Nothing,IR.Type}, pred, location=Location())
+function c_pred(; output=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.c_pred",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.c_pred", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -302,19 +271,15 @@ The above program defines a `cmath` dialect.
 function dialect(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.dialect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.dialect", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -338,28 +303,24 @@ irdl.dialect @cmath {
 The above program defines a `complex_i32` type inside the dialect `cmath`
 that can only have a `i32` as its parameter.
 """
-function is(; output=nothing::Union{Nothing,IR.Type}, expected, location=Location())
+function is(; output=nothing::Union{Nothing, IR.Type}, expected, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("expected", expected),]
+    attributes = NamedAttribute[namedattribute("expected", expected), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.is",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.is", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
 """
-`operands`
+`operands_`
 
 `irdl.operands` define the operands of the `irdl.operation` parent operation
 definition.
@@ -396,22 +357,18 @@ When more than one operand is marked as optional or variadic, the operation
 will expect a \'operandSegmentSizes\' attribute that defines the number of
 operands in each segment.
 """
-function operands(args::Vector{Value}; location=Location())
+function operands_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "irdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -448,19 +405,15 @@ returns a single result of the element type of the operand.
 function operation(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -488,20 +441,16 @@ type has a single parameter that should be either `i32` or `i64`.
 """
 function parameters(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "irdl.parameters",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.parameters", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -532,33 +481,24 @@ irdl.dialect @cmath {
 The above program defines an operation `norm` inside the dialect `cmath` that
 for any `T` takes a `cmath.complex` with parameter `T` and returns a `T`.
 """
-function parametric(
-    args::Vector{Value};
-    output=nothing::Union{Nothing,IR.Type},
-    base_type,
-    location=Location(),
-)
+function parametric(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, base_type, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("base_type", base_type),]
+    attributes = NamedAttribute[namedattribute("base_type", base_type), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "irdl.parametric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.parametric", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
 """
-`results`
+`results_`
 
 `irdl.results` define the results of the `irdl.operation` parent operation
 definition.
@@ -595,22 +535,18 @@ When more than one result is marked as optional or variadic, the operation
 will expect a \'resultSegmentSizes\' attribute that defines the number of
 results in each segment.
 """
-function results(args::Vector{Value}; location=Location())
+function results_(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "irdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "irdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -641,19 +577,15 @@ type has a single parameter that should be either `i32` or `i64`.
 function type(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "irdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "irdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/IRDL.jl
+++ b/src/Dialects/17/IRDL.jl
@@ -1,8 +1,8 @@
 module irdl
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `all_of`
@@ -33,19 +33,25 @@ The above program defines a type `complex` inside the dialect `cmath` that
 can has one parameter that must be 32-bit long and a float (in other
 words, that must be `f32`).
 """
-function all_of(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, location=Location())
+function all_of(
+    args::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "irdl.all_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.all_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -74,19 +80,25 @@ The above program defines a type `complex` inside the dialect `cmath` that
 can have a single type parameter that can be either `i32`, `i64`, `f32` or
 `f32`.
 """
-function any_of(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, location=Location())
+function any_of(
+    args::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "irdl.any_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.any_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -109,19 +121,23 @@ irdl.dialect @cmath {
 The above program defines a type `complex_flexible` inside the dialect
 `cmath` that has a single parameter that can be any attribute.
 """
-function any(; output=nothing::Union{Nothing, IR.Type}, location=Location())
+function any(; output=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "irdl.any", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -154,20 +170,24 @@ either a `\"foo\"` or a `\"bar\"`.
 function attribute(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "irdl.attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "irdl.attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`attributes_`
+`attributes`
 
 `irdl.attributes` defines the attributes of the `irdl.operation` parent 
 operation definition.
@@ -192,18 +212,24 @@ irdl.dialect @example {
 The operation will expect an arbitrary attribute \"attr1\" and an
 attribute \"attr2\" with value `i64`.
 """
-function attributes_(attributeValues::Vector{Value}; attributeValueNames, location=Location())
+function attributes(
+    attributeValues::Vector{Value}; attributeValueNames, location=Location()
+)
     results = IR.Type[]
-    operands = Value[attributeValues..., ]
+    operands = Value[attributeValues...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
-    
-    IR.create_operation(
-        "irdl.attributes", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
+
+    return IR.create_operation(
+        "irdl.attributes",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -236,19 +262,23 @@ irdl.type @op_with_attr {
 In this example, @op_with_attr is defined as a type with a single
 parameter, which is an `IntegerAttr`, as constrained by the C++ predicate.
 """
-function c_pred(; output=nothing::Union{Nothing, IR.Type}, pred, location=Location())
+function c_pred(; output=nothing::Union{Nothing,IR.Type}, pred, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred), ]
+    attributes = NamedAttribute[namedattribute("pred", pred),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "irdl.c_pred", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.c_pred",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -271,15 +301,19 @@ The above program defines a `cmath` dialect.
 function dialect(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "irdl.dialect", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "irdl.dialect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -303,24 +337,28 @@ irdl.dialect @cmath {
 The above program defines a `complex_i32` type inside the dialect `cmath`
 that can only have a `i32` as its parameter.
 """
-function is(; output=nothing::Union{Nothing, IR.Type}, expected, location=Location())
+function is(; output=nothing::Union{Nothing,IR.Type}, expected, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("expected", expected), ]
+    attributes = NamedAttribute[namedattribute("expected", expected),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "irdl.is", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.is",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
 """
-`operands_`
+`operands`
 
 `irdl.operands` define the operands of the `irdl.operation` parent operation
 definition.
@@ -357,18 +395,22 @@ When more than one operand is marked as optional or variadic, the operation
 will expect a \'operandSegmentSizes\' attribute that defines the number of
 operands in each segment.
 """
-function operands_(args::Vector{Value}; location=Location())
+function operands(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "irdl.operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -405,15 +447,19 @@ returns a single result of the element type of the operand.
 function operation(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "irdl.operation", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "irdl.operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -441,16 +487,20 @@ type has a single parameter that should be either `i32` or `i64`.
 """
 function parameters(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "irdl.parameters", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.parameters",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -481,24 +531,33 @@ irdl.dialect @cmath {
 The above program defines an operation `norm` inside the dialect `cmath` that
 for any `T` takes a `cmath.complex` with parameter `T` and returns a `T`.
 """
-function parametric(args::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, base_type, location=Location())
+function parametric(
+    args::Vector{Value};
+    output=nothing::Union{Nothing,IR.Type},
+    base_type,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("base_type", base_type), ]
+    attributes = NamedAttribute[namedattribute("base_type", base_type),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "irdl.parametric", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.parametric",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
 """
-`results_`
+`results`
 
 `irdl.results` define the results of the `irdl.operation` parent operation
 definition.
@@ -535,18 +594,22 @@ When more than one result is marked as optional or variadic, the operation
 will expect a \'resultSegmentSizes\' attribute that defines the number of
 results in each segment.
 """
-function results_(args::Vector{Value}; location=Location())
+function results(args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "irdl.results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "irdl.results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -577,15 +640,19 @@ type has a single parameter that should be either `i32` or `i64`.
 function type(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "irdl.type", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "irdl.type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Index.jl
+++ b/src/Dialects/17/Index.jl
@@ -1,8 +1,8 @@
 module index
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -16,25 +16,19 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -51,25 +45,19 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -88,23 +76,19 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.bool.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.bool.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -127,21 +111,17 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.casts",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.casts", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,21 +144,17 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.castu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.castu", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -198,25 +174,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -236,25 +206,19 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -291,29 +255,19 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    pred,
-    location=Location(),
-)
+function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.cmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.cmp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -329,23 +283,19 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -365,25 +315,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -403,25 +347,19 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -441,25 +379,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.floordivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.floordivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -476,25 +408,19 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -512,25 +438,19 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -547,25 +467,19 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mins",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mins", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -583,25 +497,19 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.minu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.minu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -617,25 +525,19 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -652,25 +554,19 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -687,25 +583,19 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.rems",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.rems", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -723,25 +613,19 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.remu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.remu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -760,25 +644,19 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -797,25 +675,19 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shrs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shrs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -834,25 +706,19 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shru",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shru", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -869,23 +735,19 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sizeof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sizeof", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -902,25 +764,19 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -937,25 +793,19 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/Index.jl
+++ b/src/Dialects/17/Index.jl
@@ -1,8 +1,8 @@
 module index
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add`
@@ -16,19 +16,25 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -45,19 +51,25 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function and(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -76,19 +88,23 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.bool.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.bool.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -111,17 +127,21 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "index.casts", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.casts",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -144,17 +164,21 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "index.castu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.castu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -174,19 +198,25 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.ceildivs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.ceildivs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -206,19 +236,25 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ceildivu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.ceildivu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.ceildivu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -255,19 +291,29 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
+function cmp(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    pred,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred), ]
+    attributes = NamedAttribute[namedattribute("pred", pred),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.cmp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.cmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -283,19 +329,23 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -315,19 +365,25 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.divs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.divs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -347,19 +403,25 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function divu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.divu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.divu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -379,19 +441,25 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function floordivs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.floordivs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.floordivs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -408,19 +476,25 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.maxs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.maxs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -438,19 +512,25 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function maxu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.maxu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.maxu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -467,19 +547,25 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mins(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.mins", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.mins",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -497,19 +583,25 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function minu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.minu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.minu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -525,19 +617,25 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -554,19 +652,25 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function or(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -583,19 +687,25 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function rems(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.rems", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.rems",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -613,19 +723,25 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function remu(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.remu", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.remu",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -644,19 +760,25 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shl(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.shl", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.shl",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -675,19 +797,25 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shrs(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.shrs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.shrs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -706,19 +834,25 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shru(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.shru", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.shru",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -735,19 +869,23 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.sizeof", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.sizeof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -764,19 +902,25 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -793,19 +937,25 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function xor(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "index.xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "index.xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/17/Index.jl
+++ b/src/Dialects/17/Index.jl
@@ -1,9 +1,8 @@
 module index
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -17,25 +16,19 @@ The `index.add` operation takes two index values and computes their sum.
 %c = index.add %a, %b
 ```
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -52,25 +45,19 @@ and.
 %c = index.and %a, %b
 ```
 """
-function and(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -89,23 +76,19 @@ This operation is used to materialize bool constants that arise when folding
 %0 = index.bool.constant true
 ```
 """
-function bool_constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function bool_constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.bool.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.bool.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -128,21 +111,17 @@ truncated.
 ```
 """
 function casts(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.casts",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.casts", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -165,21 +144,17 @@ truncated.
 ```
 """
 function castu(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "index.castu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.castu", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,25 +174,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.ceildivs %a, %b
 ```
 """
-function ceildivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -237,25 +206,19 @@ Note: division by zero is undefined behaviour.
 %c = index.ceildivu %a, %b
 ```
 """
-function ceildivu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ceildivu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.ceildivu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.ceildivu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -292,29 +255,19 @@ The result is `1` if the comparison is true and `0` otherwise.
 %2 = index.cmp ne(%a, %b)
 ```
 """
-function cmp(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    pred,
-    location=Location(),
-)
+function cmp(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, pred, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pred", pred),]
+    attributes = NamedAttribute[namedattribute("pred", pred), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.cmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.cmp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -330,23 +283,19 @@ some index-typed integer constant.
 %0 = index.constant 42
 ```
 """
-function constant(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function constant(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.constant", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -366,25 +315,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.divs %a, %b
 ```
 """
-function divs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -404,25 +347,19 @@ Note: division by zero is undefined behaviour.
 %c = index.divu %a, %b
 ```
 """
-function divu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function divu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.divu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.divu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -442,25 +379,19 @@ Note: division by zero and signed division overflow are undefined behaviour.
 %c = index.floordivs %a, %b
 ```
 """
-function floordivs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function floordivs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.floordivs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.floordivs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -477,25 +408,19 @@ maximum value. Treats the leading bit as the sign, i.e. `max(-2, 6) = 6`.
 %c = index.maxs %a, %b
 ```
 """
-function maxs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -513,25 +438,19 @@ unsigned maximum value. Treats the leading bit as the most significant, i.e.
 %c = index.maxu %a, %b
 ```
 """
-function maxu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function maxu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.maxu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.maxu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -548,25 +467,19 @@ minimum value. Treats the leading bit as the sign, i.e. `min(-2, 6) = -2`.
 %c = index.mins %a, %b
 ```
 """
-function mins(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mins(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mins",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mins", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -584,25 +497,19 @@ unsigned minimum value. Treats the leading bit as the most significant, i.e.
 %c = index.minu %a, %b
 ```
 """
-function minu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function minu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.minu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.minu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -618,25 +525,19 @@ The `index.mul` operation takes two index values and computes their product.
 %c = index.mul %a, %b
 ```
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -653,25 +554,19 @@ or.
 %c = index.or %a, %b
 ```
 """
-function or(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -688,25 +583,19 @@ remainder. Treats the leading bit as the sign, i.e. `6 % -2 = 0`.
 %c = index.rems %a, %b
 ```
 """
-function rems(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function rems(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.rems",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.rems", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -724,25 +613,19 @@ unsigned remainder. Treats the leading bit as the most significant, i.e.
 %c = index.remu %a, %b
 ```
 """
-function remu(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function remu(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.remu",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.remu", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -761,25 +644,19 @@ index bitwidth, the operation is undefined.
 %c = index.shl %a, %b
 ```
 """
-function shl(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -798,25 +675,19 @@ greater than the index bitwidth, the operation is undefined.
 %c = index.shrs %a, %b
 ```
 """
-function shrs(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shrs(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shrs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shrs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -835,25 +706,19 @@ bitwidth, the operation is undefined.
 %c = index.shru %a, %b
 ```
 """
-function shru(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shru(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.shru",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.shru", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -870,23 +735,19 @@ is `32 : index`, and on 64-bit systems, the result is `64 : index`.
 %0 = index.sizeof
 ```
 """
-function sizeof(; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function sizeof(; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sizeof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sizeof", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -903,25 +764,19 @@ of the first from the second operand.
 %c = index.sub %a, %b
 ```
 """
-function sub(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -938,25 +793,19 @@ xor.
 %c = index.xor %a, %b
 ```
 """
-function xor(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "index.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "index.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/LLVMIR.jl
+++ b/src/Dialects/17/LLVMIR.jl
@@ -1,26 +1,32 @@
 module llvm
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `ashr`
 
 """
-function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function ashr(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.ashr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.ashr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -28,19 +34,25 @@ end
 `add`
 
 """
-function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -49,17 +61,21 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.addrspacecast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.addrspacecast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -93,17 +109,21 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
-    
-    IR.create_operation(
-        "llvm.mlir.addressof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name),]
+
+    return IR.create_operation(
+        "llvm.mlir.addressof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -111,21 +131,32 @@ end
 `alloca`
 
 """
-function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, inalloca=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arraySize, ]
+function alloca(
+    arraySize::Value;
+    res::IR.Type,
+    alignment=nothing,
+    elem_type=nothing,
+    inalloca=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[arraySize,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inalloca) && push!(attributes, namedattribute("inalloca", inalloca))
-    
-    IR.create_operation(
-        "llvm.alloca", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.alloca",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -133,19 +164,25 @@ end
 `and`
 
 """
-function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function and(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -153,26 +190,53 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, syncscope=nothing, alignment=nothing, weak=nothing, volatile_=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[ptr, cmp, val, ]
+function cmpxchg(
+    ptr::Value,
+    cmp::Value,
+    val::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    success_ordering,
+    failure_ordering,
+    syncscope=nothing,
+    alignment=nothing,
+    weak=nothing,
+    volatile_=nothing,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    tbaa=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[ptr, cmp, val]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
+    attributes = NamedAttribute[
+        namedattribute("success_ordering", success_ordering),
+        namedattribute("failure_ordering", failure_ordering),
+    ]
+    !isnothing(res) && push!(results, res)
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(weak) && push!(attributes, namedattribute("weak", weak))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-    
-    IR.create_operation(
-        "llvm.cmpxchg", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+
+    return IR.create_operation(
+        "llvm.cmpxchg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -180,25 +244,49 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, syncscope=nothing, alignment=nothing, volatile_=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[ptr, val, ]
+function atomicrmw(
+    ptr::Value,
+    val::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    bin_op,
+    ordering,
+    syncscope=nothing,
+    alignment=nothing,
+    volatile_=nothing,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    tbaa=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[ptr, val]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
+    attributes = NamedAttribute[
+        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
+    ]
+    !isnothing(res) && push!(results, res)
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-    
-    IR.create_operation(
-        "llvm.atomicrmw", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+
+    return IR.create_operation(
+        "llvm.atomicrmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -207,17 +295,21 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -225,19 +317,26 @@ end
 `br`
 
 """
-function br(destOperands::Vector{Value}; loop_annotation=nothing, dest::Block, location=Location())
+function br(
+    destOperands::Vector{Value}; loop_annotation=nothing, dest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[destOperands..., ]
+    operands = Value[destOperands...,]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    !isnothing(loop_annotation) && push!(attributes, namedattribute("loop_annotation", loop_annotation))
-    
-    IR.create_operation(
-        "llvm.br", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(loop_annotation) &&
+        push!(attributes, namedattribute("loop_annotation", loop_annotation))
+
+    return IR.create_operation(
+        "llvm.br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -270,26 +369,46 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : !llvm.ptr, (f32) -> ()
 ```
 """
-function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+function call(
+    operand_0::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    callee=nothing,
+    fastmathFlags=nothing,
+    branch_weights=nothing,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    tbaa=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_0..., ]
+    operands = Value[operand_0...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-    
-    IR.create_operation(
-        "llvm.call", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.call",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,15 +428,19 @@ llvm.mlir.global internal constant @has_any_comdat(1 : i64) comdat(@__llvm_comda
 function comdat(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "llvm.comdat", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "llvm.comdat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -339,13 +462,19 @@ function comdat_selector(; sym_name, comdat, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("comdat", comdat), ]
-    
-    IR.create_operation(
-        "llvm.comdat_selector", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("comdat", comdat)
+    ]
+
+    return IR.create_operation(
+        "llvm.comdat_selector",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -353,21 +482,39 @@ end
 `cond_br`
 
 """
-function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, loop_annotation=nothing, trueDest::Block, falseDest::Block, location=Location())
+function cond_br(
+    condition::Value,
+    trueDestOperands::Vector{Value},
+    falseDestOperands::Vector{Value};
+    branch_weights=nothing,
+    loop_annotation=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
+    operands = Value[condition, trueDestOperands..., falseDestOperands...]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    !isnothing(loop_annotation) && push!(attributes, namedattribute("loop_annotation", loop_annotation))
-    
-    IR.create_operation(
-        "llvm.cond_br", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
+    )
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+    !isnothing(loop_annotation) &&
+        push!(attributes, namedattribute("loop_annotation", loop_annotation))
+
+    return IR.create_operation(
+        "llvm.cond_br",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -402,17 +549,21 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "llvm.mlir.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "llvm.mlir.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -420,18 +571,25 @@ end
 `extractelement`
 
 """
-function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[vector, position, ]
+function extractelement(
+    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[vector, position]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.extractelement", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(res) && push!(results, res)
+
+    return IR.create_operation(
+        "llvm.extractelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -440,17 +598,21 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[container, ]
+    results = IR.Type[res,]
+    operands = Value[container,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
-    
-    IR.create_operation(
-        "llvm.extractvalue", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("position", position),]
+
+    return IR.create_operation(
+        "llvm.extractvalue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -458,20 +620,31 @@ end
 `fadd`
 
 """
-function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fadd(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fadd", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fadd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -479,19 +652,32 @@ end
 `fcmp`
 
 """
-function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function fcmp(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    predicate,
+    fastmathFlags=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fcmp", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(res) && push!(results, res)
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fcmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -499,20 +685,31 @@ end
 `fdiv`
 
 """
-function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fdiv(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fdiv", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -520,20 +717,31 @@ end
 `fmul`
 
 """
-function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fmul(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fmul", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -541,20 +749,30 @@ end
 `fneg`
 
 """
-function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fneg(
+    operand::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fneg", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fneg",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -563,17 +781,21 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fpext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fpext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -582,17 +804,21 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptosi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptosi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -601,17 +827,21 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptoui", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptoui",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -620,17 +850,21 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.fptrunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fptrunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -638,20 +872,31 @@ end
 `frem`
 
 """
-function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function frem(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.frem", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.frem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -659,20 +904,31 @@ end
 `fsub`
 
 """
-function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function fsub(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.fsub", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.fsub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -685,14 +941,18 @@ function fence(; ordering, syncscope=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ordering", ordering), ]
+    attributes = NamedAttribute[namedattribute("ordering", ordering),]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    
-    IR.create_operation(
-        "llvm.fence", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.fence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -700,19 +960,23 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val, ]
+    operands = Value[val,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.freeze", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.freeze",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -743,20 +1007,32 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[base, dynamicIndices..., ]
+function getelementptr(
+    base::Value,
+    dynamicIndices::Vector{Value};
+    res::IR.Type,
+    rawConstantIndices,
+    elem_type=nothing,
+    inbounds=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[base, dynamicIndices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-    
-    IR.create_operation(
-        "llvm.getelementptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.getelementptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -787,13 +1063,19 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
-    
-    IR.create_operation(
-        "llvm.mlir.global_ctors", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
+    ]
+
+    return IR.create_operation(
+        "llvm.mlir.global_ctors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -821,13 +1103,19 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
-    
-    IR.create_operation(
-        "llvm.mlir.global_dtors", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
+    ]
+
+    return IR.create_operation(
+        "llvm.mlir.global_dtors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -928,28 +1216,54 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, comdat=nothing, visibility_=nothing, initializer::Region, location=Location())
+function mlir_global(;
+    global_type,
+    constant=nothing,
+    sym_name,
+    linkage,
+    dso_local=nothing,
+    thread_local_=nothing,
+    value=nothing,
+    alignment=nothing,
+    addr_space=nothing,
+    unnamed_addr=nothing,
+    section=nothing,
+    comdat=nothing,
+    visibility_=nothing,
+    initializer::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer, ]
+    owned_regions = Region[initializer,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
+    attributes = NamedAttribute[
+        namedattribute("global_type", global_type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("linkage", linkage),
+    ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) &&
+        push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) &&
+        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
     !isnothing(comdat) && push!(attributes, namedattribute("comdat", comdat))
     !isnothing(visibility_) && push!(attributes, namedattribute("visibility_", visibility_))
-    
-    IR.create_operation(
-        "llvm.mlir.global", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -957,18 +1271,29 @@ end
 `icmp`
 
 """
-function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function icmp(
+    lhs::Value,
+    rhs::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    predicate,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "llvm.icmp", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+    !isnothing(res) && push!(results, res)
+
+    return IR.create_operation(
+        "llvm.icmp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -982,23 +1307,42 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
+function inline_asm(
+    operands::Vector{Value};
+    res=nothing::Union{Nothing,IR.Type},
+    asm_string,
+    constraints,
+    has_side_effects=nothing,
+    is_align_stack=nothing,
+    asm_dialect=nothing,
+    operand_attrs=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
+    attributes = NamedAttribute[
+        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
+    ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) &&
+        push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) &&
+        push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
-    
-    IR.create_operation(
-        "llvm.inline_asm", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(operand_attrs) &&
+        push!(attributes, namedattribute("operand_attrs", operand_attrs))
+
+    return IR.create_operation(
+        "llvm.inline_asm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1006,19 +1350,29 @@ end
 `insertelement`
 
 """
-function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function insertelement(
+    vector::Value,
+    value::Value,
+    position::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, value, position, ]
+    operands = Value[vector, value, position]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.insertelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.insertelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1026,19 +1380,29 @@ end
 `insertvalue`
 
 """
-function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function insertvalue(
+    container::Value,
+    value::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    position,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[container, value, ]
+    operands = Value[container, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.insertvalue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.insertvalue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1047,17 +1411,21 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.inttoptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.inttoptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1065,21 +1433,41 @@ end
 `invoke`
 
 """
-function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
+function invoke(
+    callee_operands::Vector{Value},
+    normalDestOperands::Vector{Value},
+    unwindDestOperands::Vector{Value};
+    result_0::Vector{IR.Type},
+    callee=nothing,
+    branch_weights=nothing,
+    normalDest::Block,
+    unwindDest::Block,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest, ]
+    successors = Block[normalDest, unwindDest]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
+        ]),
+    )
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.invoke", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.invoke",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1112,35 +1500,68 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, comdat=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, visibility_=nothing, arm_streaming=nothing, arm_locally_streaming=nothing, section=nothing, unnamed_addr=nothing, alignment=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    linkage=nothing,
+    dso_local=nothing,
+    CConv=nothing,
+    comdat=nothing,
+    personality=nothing,
+    garbageCollector=nothing,
+    passthrough=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    function_entry_count=nothing,
+    memory=nothing,
+    visibility_=nothing,
+    arm_streaming=nothing,
+    arm_locally_streaming=nothing,
+    section=nothing,
+    unnamed_addr=nothing,
+    alignment=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(comdat) && push!(attributes, namedattribute("comdat", comdat))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) &&
+        push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) &&
+        push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
     !isnothing(visibility_) && push!(attributes, namedattribute("visibility_", visibility_))
-    !isnothing(arm_streaming) && push!(attributes, namedattribute("arm_streaming", arm_streaming))
-    !isnothing(arm_locally_streaming) && push!(attributes, namedattribute("arm_locally_streaming", arm_locally_streaming))
+    !isnothing(arm_streaming) &&
+        push!(attributes, namedattribute("arm_streaming", arm_streaming))
+    !isnothing(arm_locally_streaming) &&
+        push!(attributes, namedattribute("arm_locally_streaming", arm_locally_streaming))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) &&
+        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "llvm.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1148,19 +1569,25 @@ end
 `lshr`
 
 """
-function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function lshr(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.lshr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.lshr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1168,19 +1595,25 @@ end
 `landingpad`
 
 """
-function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[operand_0..., ]
+function landingpad(
+    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[operand_0...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-    
-    IR.create_operation(
-        "llvm.landingpad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.landingpad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1210,9 +1643,22 @@ Examples:
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#load-instruction
 """
-function load(addr::Value; res::IR.Type, alignment=nothing, volatile_=nothing, nontemporal=nothing, ordering=nothing, syncscope=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[addr, ]
+function load(
+    addr::Value;
+    res::IR.Type,
+    alignment=nothing,
+    volatile_=nothing,
+    nontemporal=nothing,
+    ordering=nothing,
+    syncscope=nothing,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    tbaa=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[addr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -1221,16 +1667,23 @@ function load(addr::Value; res::IR.Type, alignment=nothing, volatile_=nothing, n
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
     !isnothing(ordering) && push!(attributes, namedattribute("ordering", ordering))
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-    
-    IR.create_operation(
-        "llvm.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1250,15 +1703,19 @@ llvm.metadata @metadata {
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "llvm.metadata", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "llvm.metadata",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1266,19 +1723,25 @@ end
 `mul`
 
 """
-function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1301,17 +1764,21 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.null", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.null",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1319,19 +1786,25 @@ end
 `or`
 
 """
-function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function or(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1352,17 +1825,21 @@ IR dialect type.
 ```
 """
 function mlir_poison(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.poison", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.poison",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1371,17 +1848,21 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.ptrtoint", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.ptrtoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1391,16 +1872,20 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.resume", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.resume",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1408,19 +1893,23 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing, Value}; location=Location())
+function return_(arg=nothing::Union{Nothing,Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-    
-    IR.create_operation(
-        "llvm.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1428,19 +1917,25 @@ end
 `sdiv`
 
 """
-function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function sdiv(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.sdiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sdiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1449,17 +1944,21 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.sext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1468,17 +1967,21 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.sitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1486,19 +1989,25 @@ end
 `srem`
 
 """
-function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function srem(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.srem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.srem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1506,20 +2015,32 @@ end
 `select`
 
 """
-function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
+function select(
+    condition::Value,
+    trueValue::Value,
+    falseValue::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    fastmathFlags=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue, ]
+    operands = Value[condition, trueValue, falseValue]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    
-    IR.create_operation(
-        "llvm.select", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fastmathFlags) &&
+        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+
+    return IR.create_operation(
+        "llvm.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1527,19 +2048,25 @@ end
 `shl`
 
 """
-function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function shl(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.shl", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.shl",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1548,17 +2075,21 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[v1, v2, ]
+    results = IR.Type[res,]
+    operands = Value[v1, v2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask), ]
-    
-    IR.create_operation(
-        "llvm.shufflevector", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask),]
+
+    return IR.create_operation(
+        "llvm.shufflevector",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1588,9 +2119,22 @@ llvm.store %val, %ptr atomic monotonic {alignment = 8 : i64}
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#store-instruction
 """
-function store(value::Value, addr::Value; alignment=nothing, volatile_=nothing, nontemporal=nothing, ordering=nothing, syncscope=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+function store(
+    value::Value,
+    addr::Value;
+    alignment=nothing,
+    volatile_=nothing,
+    nontemporal=nothing,
+    ordering=nothing,
+    syncscope=nothing,
+    access_groups=nothing,
+    alias_scopes=nothing,
+    noalias_scopes=nothing,
+    tbaa=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, addr, ]
+    operands = Value[value, addr]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -1599,16 +2143,23 @@ function store(value::Value, addr::Value; alignment=nothing, volatile_=nothing, 
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
     !isnothing(ordering) && push!(attributes, namedattribute("ordering", ordering))
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) &&
+        push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) &&
+        push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) &&
+        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-    
-    IR.create_operation(
-        "llvm.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1616,19 +2167,25 @@ end
 `sub`
 
 """
-function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function sub(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1636,21 +2193,40 @@ end
 `switch`
 
 """
-function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
+function switch(
+    value::Value,
+    defaultOperands::Vector{Value},
+    caseOperands::Vector{Value};
+    case_values=nothing,
+    case_operand_segments,
+    branch_weights=nothing,
+    defaultDestination::Block,
+    caseDestinations::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands..., ]
+    operands = Value[value, defaultOperands..., caseOperands...]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations..., ]
-    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
-    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
+    successors = Block[defaultDestination, caseDestinations...]
+    attributes = NamedAttribute[namedattribute(
+        "case_operand_segments", case_operand_segments
+    ),]
+    push!(
+        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
+    )
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "llvm.switch", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "llvm.switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1659,17 +2235,21 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.trunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.trunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1677,19 +2257,25 @@ end
 `udiv`
 
 """
-function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function udiv(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.udiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.udiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1698,17 +2284,21 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.uitofp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.uitofp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1716,19 +2306,25 @@ end
 `urem`
 
 """
-function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function urem(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.urem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.urem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1748,17 +2344,21 @@ IR dialect type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
+    results = IR.Type[res,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.mlir.undef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.mlir.undef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1772,12 +2372,16 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.unreachable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.unreachable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1785,19 +2389,25 @@ end
 `xor`
 
 """
-function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function xor(
+    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "llvm.xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1806,17 +2416,21 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "llvm.zext", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "llvm.zext",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/LLVMIR.jl
+++ b/src/Dialects/17/LLVMIR.jl
@@ -1,33 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -35,25 +28,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -62,21 +49,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -110,21 +93,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -132,32 +111,21 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    inalloca=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, inalloca=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inalloca) && push!(attributes, namedattribute("inalloca", inalloca))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -165,25 +133,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -191,53 +153,26 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    success_ordering,
-    failure_ordering,
-    syncscope=nothing,
-    alignment=nothing,
-    weak=nothing,
-    volatile_=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, syncscope=nothing, alignment=nothing, weak=nothing, volatile_=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-    !isnothing(res) && push!(results, res)
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(weak) && push!(attributes, namedattribute("weak", weak))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -245,49 +180,25 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value,
-    val::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    bin_op,
-    ordering,
-    syncscope=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, syncscope=nothing, alignment=nothing, volatile_=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-    !isnothing(res) && push!(results, res)
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -296,21 +207,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -318,26 +225,19 @@ end
 `br`
 
 """
-function br(
-    destOperands::Vector{Value}; loop_annotation=nothing, dest::Block, location=Location()
-)
+function br(destOperands::Vector{Value}; loop_annotation=nothing, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-    !isnothing(loop_annotation) &&
-        push!(attributes, namedattribute("loop_annotation", loop_annotation))
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(loop_annotation) && push!(attributes, namedattribute("loop_annotation", loop_annotation))
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -370,46 +270,26 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : !llvm.ptr, (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    branch_weights=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
+function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_0...,]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -429,19 +309,15 @@ llvm.mlir.global internal constant @has_any_comdat(1 : i64) comdat(@__llvm_comda
 function comdat(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.comdat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.comdat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,19 +339,13 @@ function comdat_selector(; sym_name, comdat, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("comdat", comdat)
-    ]
-
-    return IR.create_operation(
-        "llvm.comdat_selector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("comdat", comdat), ]
+    
+    IR.create_operation(
+        "llvm.comdat_selector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -483,39 +353,21 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    loop_annotation=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, loop_annotation=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-    !isnothing(loop_annotation) &&
-        push!(attributes, namedattribute("loop_annotation", loop_annotation))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    !isnothing(loop_annotation) && push!(attributes, namedattribute("loop_annotation", loop_annotation))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -550,21 +402,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -572,25 +420,18 @@ end
 `extractelement`
 
 """
-function extractelement(
-    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, position]
+function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -599,21 +440,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -621,31 +458,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -653,32 +479,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -686,31 +499,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -718,31 +520,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -750,30 +541,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -782,21 +563,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -805,21 +582,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -828,21 +601,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -851,21 +620,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -873,31 +638,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -905,31 +659,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -942,18 +685,14 @@ function fence(; ordering, syncscope=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ordering", ordering),]
+    attributes = NamedAttribute[namedattribute("ordering", ordering), ]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -961,23 +700,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1008,32 +743,20 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(
-    base::Value,
-    dynamicIndices::Vector{Value};
-    res::IR.Type,
-    rawConstantIndices,
-    elem_type=nothing,
-    inbounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, dynamicIndices...]
+function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, dynamicIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1064,19 +787,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1104,19 +821,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1217,54 +928,28 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    comdat=nothing,
-    visibility_=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, comdat=nothing, visibility_=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
     !isnothing(comdat) && push!(attributes, namedattribute("comdat", comdat))
     !isnothing(visibility_) && push!(attributes, namedattribute("visibility_", visibility_))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1272,29 +957,18 @@ end
 `icmp`
 
 """
-function icmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1308,42 +982,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1351,29 +1006,19 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value,
-    value::Value,
-    position::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, value, position]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1381,29 +1026,19 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value,
-    value::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[container, value]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1412,21 +1047,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1434,41 +1065,21 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    branch_weights=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1501,68 +1112,35 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    comdat=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    function_entry_count=nothing,
-    memory=nothing,
-    visibility_=nothing,
-    arm_streaming=nothing,
-    arm_locally_streaming=nothing,
-    section=nothing,
-    unnamed_addr=nothing,
-    alignment=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, comdat=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, visibility_=nothing, arm_streaming=nothing, arm_locally_streaming=nothing, section=nothing, unnamed_addr=nothing, alignment=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(comdat) && push!(attributes, namedattribute("comdat", comdat))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) &&
-        push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
     !isnothing(visibility_) && push!(attributes, namedattribute("visibility_", visibility_))
-    !isnothing(arm_streaming) &&
-        push!(attributes, namedattribute("arm_streaming", arm_streaming))
-    !isnothing(arm_locally_streaming) &&
-        push!(attributes, namedattribute("arm_locally_streaming", arm_locally_streaming))
+    !isnothing(arm_streaming) && push!(attributes, namedattribute("arm_streaming", arm_streaming))
+    !isnothing(arm_locally_streaming) && push!(attributes, namedattribute("arm_locally_streaming", arm_locally_streaming))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1570,25 +1148,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1596,25 +1168,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1644,22 +1210,9 @@ Examples:
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#load-instruction
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    ordering=nothing,
-    syncscope=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, alignment=nothing, volatile_=nothing, nontemporal=nothing, ordering=nothing, syncscope=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -1668,23 +1221,16 @@ function load(
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
     !isnothing(ordering) && push!(attributes, namedattribute("ordering", ordering))
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1704,19 +1250,15 @@ llvm.metadata @metadata {
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1724,25 +1266,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1765,21 +1301,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1787,25 +1319,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1826,21 +1352,17 @@ IR dialect type.
 ```
 """
 function mlir_poison(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.poison",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.poison", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1849,21 +1371,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1873,20 +1391,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1894,23 +1408,19 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing,Value}; location=Location())
+function return_(arg=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1918,25 +1428,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1945,21 +1449,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1968,21 +1468,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1990,25 +1486,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2016,32 +1506,20 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2049,25 +1527,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2076,21 +1548,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2120,22 +1588,9 @@ llvm.store %val, %ptr atomic monotonic {alignment = 8 : i64}
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#store-instruction
 """
-function store(
-    value::Value,
-    addr::Value;
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    ordering=nothing,
-    syncscope=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; alignment=nothing, volatile_=nothing, nontemporal=nothing, ordering=nothing, syncscope=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -2144,23 +1599,16 @@ function store(
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
     !isnothing(ordering) && push!(attributes, namedattribute("ordering", ordering))
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2168,25 +1616,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2194,40 +1636,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2236,21 +1659,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2258,25 +1677,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2285,21 +1698,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2307,25 +1716,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2345,21 +1748,17 @@ IR dialect type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2373,16 +1772,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2390,25 +1785,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2417,21 +1806,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/LLVMIR.jl
+++ b/src/Dialects/17/LLVMIR.jl
@@ -1,32 +1,26 @@
 module llvm
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `ashr`
 
 """
-function ashr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ashr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.ashr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ashr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -34,25 +28,19 @@ end
 `add`
 
 """
-function add(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -61,21 +49,17 @@ end
 
 """
 function addrspacecast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.addrspacecast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.addrspacecast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -109,21 +93,17 @@ llvm.mlir.global @const(42 : i32) : i32
 ```
 """
 function mlir_addressof(; res::IR.Type, global_name, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global_name", global_name),]
-
-    return IR.create_operation(
-        "llvm.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global_name", global_name), ]
+    
+    IR.create_operation(
+        "llvm.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -131,32 +111,21 @@ end
 `alloca`
 
 """
-function alloca(
-    arraySize::Value;
-    res::IR.Type,
-    alignment=nothing,
-    elem_type=nothing,
-    inalloca=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[arraySize,]
+function alloca(arraySize::Value; res::IR.Type, alignment=nothing, elem_type=nothing, inalloca=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[arraySize, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inalloca) && push!(attributes, namedattribute("inalloca", inalloca))
-
-    return IR.create_operation(
-        "llvm.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,25 +133,19 @@ end
 `and`
 
 """
-function and(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function and(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.and", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -190,53 +153,26 @@ end
 `cmpxchg`
 
 """
-function cmpxchg(
-    ptr::Value,
-    cmp::Value,
-    val::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    success_ordering,
-    failure_ordering,
-    syncscope=nothing,
-    alignment=nothing,
-    weak=nothing,
-    volatile_=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[ptr, cmp, val]
+function cmpxchg(ptr::Value, cmp::Value, val::Value; res::IR.Type, success_ordering, failure_ordering, syncscope=nothing, alignment=nothing, weak=nothing, volatile_=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, cmp, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("success_ordering", success_ordering),
-        namedattribute("failure_ordering", failure_ordering),
-    ]
-    !isnothing(res) && push!(results, res)
+    attributes = NamedAttribute[namedattribute("success_ordering", success_ordering), namedattribute("failure_ordering", failure_ordering), ]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(weak) && push!(attributes, namedattribute("weak", weak))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.cmpxchg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.cmpxchg", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -244,49 +180,25 @@ end
 `atomicrmw`
 
 """
-function atomicrmw(
-    ptr::Value,
-    val::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    bin_op,
-    ordering,
-    syncscope=nothing,
-    alignment=nothing,
-    volatile_=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[ptr, val]
+function atomicrmw(ptr::Value, val::Value; res::IR.Type, bin_op, ordering, syncscope=nothing, alignment=nothing, volatile_=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[ptr, val, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("bin_op", bin_op), namedattribute("ordering", ordering)
-    ]
-    !isnothing(res) && push!(results, res)
+    attributes = NamedAttribute[namedattribute("bin_op", bin_op), namedattribute("ordering", ordering), ]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(volatile_) && push!(attributes, namedattribute("volatile_", volatile_))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.atomicrmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.atomicrmw", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -295,21 +207,17 @@ end
 
 """
 function bitcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -317,26 +225,19 @@ end
 `br`
 
 """
-function br(
-    destOperands::Vector{Value}; loop_annotation=nothing, dest::Block, location=Location()
-)
+function br(destOperands::Vector{Value}; loop_annotation=nothing, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[destOperands...,]
+    operands = Value[destOperands..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-    !isnothing(loop_annotation) &&
-        push!(attributes, namedattribute("loop_annotation", loop_annotation))
-
-    return IR.create_operation(
-        "llvm.br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(loop_annotation) && push!(attributes, namedattribute("loop_annotation", loop_annotation))
+    
+    IR.create_operation(
+        "llvm.br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -369,46 +270,26 @@ llvm.call @bar(%0) : (f32) -> ()
 llvm.call %1(%0) : !llvm.ptr, (f32) -> ()
 ```
 """
-function call(
-    operand_0::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    callee=nothing,
-    fastmathFlags=nothing,
-    branch_weights=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
+function call(operand_0::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, callee=nothing, fastmathFlags=nothing, branch_weights=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_0...,]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.call",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.call", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -428,19 +309,15 @@ llvm.mlir.global internal constant @has_any_comdat(1 : i64) comdat(@__llvm_comda
 function comdat(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.comdat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.comdat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,19 +339,13 @@ function comdat_selector(; sym_name, comdat, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("comdat", comdat)
-    ]
-
-    return IR.create_operation(
-        "llvm.comdat_selector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("comdat", comdat), ]
+    
+    IR.create_operation(
+        "llvm.comdat_selector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -482,39 +353,21 @@ end
 `cond_br`
 
 """
-function cond_br(
-    condition::Value,
-    trueDestOperands::Vector{Value},
-    falseDestOperands::Vector{Value};
-    branch_weights=nothing,
-    loop_annotation=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function cond_br(condition::Value, trueDestOperands::Vector{Value}, falseDestOperands::Vector{Value}; branch_weights=nothing, loop_annotation=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueDestOperands..., falseDestOperands...]
+    operands = Value[condition, trueDestOperands..., falseDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-    !isnothing(loop_annotation) &&
-        push!(attributes, namedattribute("loop_annotation", loop_annotation))
-
-    return IR.create_operation(
-        "llvm.cond_br",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueDestOperands), length(falseDestOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    !isnothing(loop_annotation) && push!(attributes, namedattribute("loop_annotation", loop_annotation))
+    
+    IR.create_operation(
+        "llvm.cond_br", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -549,21 +402,17 @@ Examples:
 ```
 """
 function mlir_constant(; res::IR.Type, value, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "llvm.mlir.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "llvm.mlir.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -571,25 +420,18 @@ end
 `extractelement`
 
 """
-function extractelement(
-    vector::Value, position::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, position]
+function extractelement(vector::Value, position::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[vector, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "llvm.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -598,21 +440,17 @@ end
 
 """
 function extractvalue(container::Value; res::IR.Type, position, location=Location())
-    results = IR.Type[res,]
-    operands = Value[container,]
+    results = IR.Type[res, ]
+    operands = Value[container, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
-
-    return IR.create_operation(
-        "llvm.extractvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("position", position), ]
+    
+    IR.create_operation(
+        "llvm.extractvalue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -620,31 +458,20 @@ end
 `fadd`
 
 """
-function fadd(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fadd(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fadd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fadd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -652,32 +479,19 @@ end
 `fcmp`
 
 """
-function fcmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    fastmathFlags=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function fcmp(lhs::Value, rhs::Value; res::IR.Type, predicate, fastmathFlags=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fcmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fcmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -685,31 +499,20 @@ end
 `fdiv`
 
 """
-function fdiv(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -717,31 +520,20 @@ end
 `fmul`
 
 """
-function fmul(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fmul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fmul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -749,30 +541,20 @@ end
 `fneg`
 
 """
-function fneg(
-    operand::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fneg(operand::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fneg",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fneg", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -781,21 +563,17 @@ end
 
 """
 function fpext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fpext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fpext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -804,21 +582,17 @@ end
 
 """
 function fptosi(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptosi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptosi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -827,21 +601,17 @@ end
 
 """
 function fptoui(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptoui",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptoui", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -850,21 +620,17 @@ end
 
 """
 function fptrunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.fptrunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fptrunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -872,31 +638,20 @@ end
 `frem`
 
 """
-function frem(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function frem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.frem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.frem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -904,31 +659,20 @@ end
 `fsub`
 
 """
-function fsub(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function fsub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.fsub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.fsub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -941,18 +685,14 @@ function fence(; ordering, syncscope=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("ordering", ordering),]
+    attributes = NamedAttribute[namedattribute("ordering", ordering), ]
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-
-    return IR.create_operation(
-        "llvm.fence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.fence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -960,23 +700,19 @@ end
 `freeze`
 
 """
-function freeze(val::Value; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function freeze(val::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[val,]
+    operands = Value[val, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.freeze",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.freeze", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1007,32 +743,20 @@ Examples:
    : (!llvm.ptr<struct(i32, f32)>) -> !llvm.ptr<f32>
 ```
 """
-function getelementptr(
-    base::Value,
-    dynamicIndices::Vector{Value};
-    res::IR.Type,
-    rawConstantIndices,
-    elem_type=nothing,
-    inbounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[base, dynamicIndices...]
+function getelementptr(base::Value, dynamicIndices::Vector{Value}; res::IR.Type, rawConstantIndices, elem_type=nothing, inbounds=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[base, dynamicIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices),]
+    attributes = NamedAttribute[namedattribute("rawConstantIndices", rawConstantIndices), ]
     !isnothing(elem_type) && push!(attributes, namedattribute("elem_type", elem_type))
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "llvm.getelementptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.getelementptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1063,19 +787,13 @@ function mlir_global_ctors(; ctors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("ctors", ctors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_ctors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("ctors", ctors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_ctors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1103,19 +821,13 @@ function mlir_global_dtors(; dtors, priorities, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dtors", dtors), namedattribute("priorities", priorities)
-    ]
-
-    return IR.create_operation(
-        "llvm.mlir.global_dtors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dtors", dtors), namedattribute("priorities", priorities), ]
+    
+    IR.create_operation(
+        "llvm.mlir.global_dtors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1216,54 +928,28 @@ Examples:
 llvm.mlir.global private constant @y(dense<1.0> : tensor<8xf32>) { alignment = 32 : i64 } : !llvm.array<8 x f32>
 ```
 """
-function mlir_global(;
-    global_type,
-    constant=nothing,
-    sym_name,
-    linkage,
-    dso_local=nothing,
-    thread_local_=nothing,
-    value=nothing,
-    alignment=nothing,
-    addr_space=nothing,
-    unnamed_addr=nothing,
-    section=nothing,
-    comdat=nothing,
-    visibility_=nothing,
-    initializer::Region,
-    location=Location(),
-)
+function mlir_global(; global_type, constant=nothing, sym_name, linkage, dso_local=nothing, thread_local_=nothing, value=nothing, alignment=nothing, addr_space=nothing, unnamed_addr=nothing, section=nothing, comdat=nothing, visibility_=nothing, initializer::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializer,]
+    owned_regions = Region[initializer, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("global_type", global_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("linkage", linkage),
-    ]
+    attributes = NamedAttribute[namedattribute("global_type", global_type), namedattribute("sym_name", sym_name), namedattribute("linkage", linkage), ]
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
-    !isnothing(thread_local_) &&
-        push!(attributes, namedattribute("thread_local_", thread_local_))
+    !isnothing(thread_local_) && push!(attributes, namedattribute("thread_local_", thread_local_))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
     !isnothing(addr_space) && push!(attributes, namedattribute("addr_space", addr_space))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
     !isnothing(comdat) && push!(attributes, namedattribute("comdat", comdat))
     !isnothing(visibility_) && push!(attributes, namedattribute("visibility_", visibility_))
-
-    return IR.create_operation(
-        "llvm.mlir.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1271,29 +957,18 @@ end
 `icmp`
 
 """
-function icmp(
-    lhs::Value,
-    rhs::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    predicate,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[lhs, rhs]
+function icmp(lhs::Value, rhs::Value; res::IR.Type, predicate, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-    !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.icmp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "llvm.icmp", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1307,42 +982,23 @@ written, or referenced.
 Attempting to define or reference any symbol or any global behavior is
 considered undefined behavior at this time.
 """
-function inline_asm(
-    operands::Vector{Value};
-    res=nothing::Union{Nothing,IR.Type},
-    asm_string,
-    constraints,
-    has_side_effects=nothing,
-    is_align_stack=nothing,
-    asm_dialect=nothing,
-    operand_attrs=nothing,
-    location=Location(),
-)
+function inline_asm(operands_::Vector{Value}; res=nothing::Union{Nothing, IR.Type}, asm_string, constraints, has_side_effects=nothing, is_align_stack=nothing, asm_dialect=nothing, operand_attrs=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("asm_string", asm_string), namedattribute("constraints", constraints)
-    ]
+    attributes = NamedAttribute[namedattribute("asm_string", asm_string), namedattribute("constraints", constraints), ]
     !isnothing(res) && push!(results, res)
-    !isnothing(has_side_effects) &&
-        push!(attributes, namedattribute("has_side_effects", has_side_effects))
-    !isnothing(is_align_stack) &&
-        push!(attributes, namedattribute("is_align_stack", is_align_stack))
+    !isnothing(has_side_effects) && push!(attributes, namedattribute("has_side_effects", has_side_effects))
+    !isnothing(is_align_stack) && push!(attributes, namedattribute("is_align_stack", is_align_stack))
     !isnothing(asm_dialect) && push!(attributes, namedattribute("asm_dialect", asm_dialect))
-    !isnothing(operand_attrs) &&
-        push!(attributes, namedattribute("operand_attrs", operand_attrs))
-
-    return IR.create_operation(
-        "llvm.inline_asm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(operand_attrs) && push!(attributes, namedattribute("operand_attrs", operand_attrs))
+    
+    IR.create_operation(
+        "llvm.inline_asm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1350,29 +1006,19 @@ end
 `insertelement`
 
 """
-function insertelement(
-    vector::Value,
-    value::Value,
-    position::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(vector::Value, value::Value, position::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, value, position]
+    operands = Value[vector, value, position, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1380,29 +1026,19 @@ end
 `insertvalue`
 
 """
-function insertvalue(
-    container::Value,
-    value::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insertvalue(container::Value, value::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[container, value]
+    operands = Value[container, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.insertvalue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.insertvalue", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1411,21 +1047,17 @@ end
 
 """
 function inttoptr(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.inttoptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.inttoptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1433,41 +1065,21 @@ end
 `invoke`
 
 """
-function invoke(
-    callee_operands::Vector{Value},
-    normalDestOperands::Vector{Value},
-    unwindDestOperands::Vector{Value};
-    result_0::Vector{IR.Type},
-    callee=nothing,
-    branch_weights=nothing,
-    normalDest::Block,
-    unwindDest::Block,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands...]
+function invoke(callee_operands::Vector{Value}, normalDestOperands::Vector{Value}, unwindDestOperands::Vector{Value}; result_0::Vector{IR.Type}, callee=nothing, branch_weights=nothing, normalDest::Block, unwindDest::Block, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[callee_operands..., normalDestOperands..., unwindDestOperands..., ]
     owned_regions = Region[]
-    successors = Block[normalDest, unwindDest]
+    successors = Block[normalDest, unwindDest, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(callee_operands), length(normalDestOperands), length(unwindDestOperands)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(callee_operands), length(normalDestOperands), length(unwindDestOperands), ]))
     !isnothing(callee) && push!(attributes, namedattribute("callee", callee))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.invoke",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.invoke", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1500,68 +1112,35 @@ llvm.func internal @internal_func() {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    linkage=nothing,
-    dso_local=nothing,
-    CConv=nothing,
-    comdat=nothing,
-    personality=nothing,
-    garbageCollector=nothing,
-    passthrough=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    function_entry_count=nothing,
-    memory=nothing,
-    visibility_=nothing,
-    arm_streaming=nothing,
-    arm_locally_streaming=nothing,
-    section=nothing,
-    unnamed_addr=nothing,
-    alignment=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, linkage=nothing, dso_local=nothing, CConv=nothing, comdat=nothing, personality=nothing, garbageCollector=nothing, passthrough=nothing, arg_attrs=nothing, res_attrs=nothing, function_entry_count=nothing, memory=nothing, visibility_=nothing, arm_streaming=nothing, arm_locally_streaming=nothing, section=nothing, unnamed_addr=nothing, alignment=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(linkage) && push!(attributes, namedattribute("linkage", linkage))
     !isnothing(dso_local) && push!(attributes, namedattribute("dso_local", dso_local))
     !isnothing(CConv) && push!(attributes, namedattribute("CConv", CConv))
     !isnothing(comdat) && push!(attributes, namedattribute("comdat", comdat))
     !isnothing(personality) && push!(attributes, namedattribute("personality", personality))
-    !isnothing(garbageCollector) &&
-        push!(attributes, namedattribute("garbageCollector", garbageCollector))
+    !isnothing(garbageCollector) && push!(attributes, namedattribute("garbageCollector", garbageCollector))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(function_entry_count) &&
-        push!(attributes, namedattribute("function_entry_count", function_entry_count))
+    !isnothing(function_entry_count) && push!(attributes, namedattribute("function_entry_count", function_entry_count))
     !isnothing(memory) && push!(attributes, namedattribute("memory", memory))
     !isnothing(visibility_) && push!(attributes, namedattribute("visibility_", visibility_))
-    !isnothing(arm_streaming) &&
-        push!(attributes, namedattribute("arm_streaming", arm_streaming))
-    !isnothing(arm_locally_streaming) &&
-        push!(attributes, namedattribute("arm_locally_streaming", arm_locally_streaming))
+    !isnothing(arm_streaming) && push!(attributes, namedattribute("arm_streaming", arm_streaming))
+    !isnothing(arm_locally_streaming) && push!(attributes, namedattribute("arm_locally_streaming", arm_locally_streaming))
     !isnothing(section) && push!(attributes, namedattribute("section", section))
-    !isnothing(unnamed_addr) &&
-        push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
+    !isnothing(unnamed_addr) && push!(attributes, namedattribute("unnamed_addr", unnamed_addr))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "llvm.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1569,25 +1148,19 @@ end
 `lshr`
 
 """
-function lshr(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function lshr(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.lshr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.lshr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1595,25 +1168,19 @@ end
 `landingpad`
 
 """
-function landingpad(
-    operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[operand_0...,]
+function landingpad(operand_0::Vector{Value}; res::IR.Type, cleanup=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[operand_0..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(cleanup) && push!(attributes, namedattribute("cleanup", cleanup))
-
-    return IR.create_operation(
-        "llvm.landingpad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.landingpad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1643,22 +1210,9 @@ Examples:
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#load-instruction
 """
-function load(
-    addr::Value;
-    res::IR.Type,
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    ordering=nothing,
-    syncscope=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[addr,]
+function load(addr::Value; res::IR.Type, alignment=nothing, volatile_=nothing, nontemporal=nothing, ordering=nothing, syncscope=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -1667,23 +1221,16 @@ function load(
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
     !isnothing(ordering) && push!(attributes, namedattribute("ordering", ordering))
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1703,19 +1250,15 @@ llvm.metadata @metadata {
 function metadata(; sym_name, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "llvm.metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "llvm.metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1723,25 +1266,19 @@ end
 `mul`
 
 """
-function mul(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1764,21 +1301,17 @@ Examples:
 ```
 """
 function mlir_null(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1786,25 +1319,19 @@ end
 `or`
 
 """
-function or(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function or(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.or", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1825,21 +1352,17 @@ IR dialect type.
 ```
 """
 function mlir_poison(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.poison",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.poison", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1848,21 +1371,17 @@ end
 
 """
 function ptrtoint(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.ptrtoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.ptrtoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1872,20 +1391,16 @@ end
 """
 function resume(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.resume",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.resume", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1893,23 +1408,19 @@ end
 `return_`
 
 """
-function return_(arg=nothing::Union{Nothing,Value}; location=Location())
+function return_(arg=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(arg) && push!(operands, arg)
-
-    return IR.create_operation(
-        "llvm.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1917,25 +1428,19 @@ end
 `sdiv`
 
 """
-function sdiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sdiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sdiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sdiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1944,21 +1449,17 @@ end
 
 """
 function sext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1967,21 +1468,17 @@ end
 
 """
 function sitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.sitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1989,25 +1486,19 @@ end
 `srem`
 
 """
-function srem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function srem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.srem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.srem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2015,32 +1506,20 @@ end
 `select`
 
 """
-function select(
-    condition::Value,
-    trueValue::Value,
-    falseValue::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    fastmathFlags=nothing,
-    location=Location(),
-)
+function select(condition::Value, trueValue::Value, falseValue::Value; res=nothing::Union{Nothing, IR.Type}, fastmathFlags=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueValue, falseValue]
+    operands = Value[condition, trueValue, falseValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    !isnothing(fastmathFlags) &&
-        push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
-
-    return IR.create_operation(
-        "llvm.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fastmathFlags) && push!(attributes, namedattribute("fastmathFlags", fastmathFlags))
+    
+    IR.create_operation(
+        "llvm.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2048,25 +1527,19 @@ end
 `shl`
 
 """
-function shl(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shl(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.shl",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.shl", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2075,21 +1548,17 @@ end
 
 """
 function shufflevector(v1::Value, v2::Value; res::IR.Type, mask, location=Location())
-    results = IR.Type[res,]
-    operands = Value[v1, v2]
+    results = IR.Type[res, ]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
-
-    return IR.create_operation(
-        "llvm.shufflevector",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    
+    IR.create_operation(
+        "llvm.shufflevector", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2119,22 +1588,9 @@ llvm.store %val, %ptr atomic monotonic {alignment = 8 : i64}
 See the following link for more details:
 https://llvm.org/docs/LangRef.html#store-instruction
 """
-function store(
-    value::Value,
-    addr::Value;
-    alignment=nothing,
-    volatile_=nothing,
-    nontemporal=nothing,
-    ordering=nothing,
-    syncscope=nothing,
-    access_groups=nothing,
-    alias_scopes=nothing,
-    noalias_scopes=nothing,
-    tbaa=nothing,
-    location=Location(),
-)
+function store(value::Value, addr::Value; alignment=nothing, volatile_=nothing, nontemporal=nothing, ordering=nothing, syncscope=nothing, access_groups=nothing, alias_scopes=nothing, noalias_scopes=nothing, tbaa=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, addr]
+    operands = Value[value, addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -2143,23 +1599,16 @@ function store(
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
     !isnothing(ordering) && push!(attributes, namedattribute("ordering", ordering))
     !isnothing(syncscope) && push!(attributes, namedattribute("syncscope", syncscope))
-    !isnothing(access_groups) &&
-        push!(attributes, namedattribute("access_groups", access_groups))
-    !isnothing(alias_scopes) &&
-        push!(attributes, namedattribute("alias_scopes", alias_scopes))
-    !isnothing(noalias_scopes) &&
-        push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
+    !isnothing(access_groups) && push!(attributes, namedattribute("access_groups", access_groups))
+    !isnothing(alias_scopes) && push!(attributes, namedattribute("alias_scopes", alias_scopes))
+    !isnothing(noalias_scopes) && push!(attributes, namedattribute("noalias_scopes", noalias_scopes))
     !isnothing(tbaa) && push!(attributes, namedattribute("tbaa", tbaa))
-
-    return IR.create_operation(
-        "llvm.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2167,25 +1616,19 @@ end
 `sub`
 
 """
-function sub(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function sub(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.sub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2193,40 +1636,21 @@ end
 `switch`
 
 """
-function switch(
-    value::Value,
-    defaultOperands::Vector{Value},
-    caseOperands::Vector{Value};
-    case_values=nothing,
-    case_operand_segments,
-    branch_weights=nothing,
-    defaultDestination::Block,
-    caseDestinations::Vector{Block},
-    location=Location(),
-)
+function switch(value::Value, defaultOperands::Vector{Value}, caseOperands::Vector{Value}; case_values=nothing, case_operand_segments, branch_weights=nothing, defaultDestination::Block, caseDestinations::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value, defaultOperands..., caseOperands...]
+    operands = Value[value, defaultOperands..., caseOperands..., ]
     owned_regions = Region[]
-    successors = Block[defaultDestination, caseDestinations...]
-    attributes = NamedAttribute[namedattribute(
-        "case_operand_segments", case_operand_segments
-    ),]
-    push!(
-        attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands)])
-    )
+    successors = Block[defaultDestination, caseDestinations..., ]
+    attributes = NamedAttribute[namedattribute("case_operand_segments", case_operand_segments), ]
+    push!(attributes, operandsegmentsizes([1, length(defaultOperands), length(caseOperands), ]))
     !isnothing(case_values) && push!(attributes, namedattribute("case_values", case_values))
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "llvm.switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "llvm.switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2235,21 +1659,17 @@ end
 
 """
 function trunc(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2257,25 +1677,19 @@ end
 `udiv`
 
 """
-function udiv(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function udiv(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.udiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.udiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2284,21 +1698,17 @@ end
 
 """
 function uitofp(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.uitofp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.uitofp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2306,25 +1716,19 @@ end
 `urem`
 
 """
-function urem(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function urem(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.urem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.urem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2344,21 +1748,17 @@ IR dialect type.
 ```
 """
 function mlir_undef(; res::IR.Type, location=Location())
-    results = IR.Type[res,]
+    results = IR.Type[res, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.mlir.undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.mlir.undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2372,16 +1772,12 @@ function unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2389,25 +1785,19 @@ end
 `xor`
 
 """
-function xor(
-    lhs::Value, rhs::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function xor(lhs::Value, rhs::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "llvm.xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.xor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2416,21 +1806,17 @@ end
 
 """
 function zext(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "llvm.zext",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "llvm.zext", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Linalg.jl
+++ b/src/Dialects/17/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `index`
@@ -41,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -81,24 +77,18 @@ of the transformation calling the tiling to ensure that the provided
 sizes for each dimension make sense with respect to the semantic of
 softmax.
 """
-function softmax(
-    input::Value, output::Value; result::Vector{IR.Type}, dimension, location=Location()
-)
-    results = IR.Type[result...,]
-    operands = Value[input, output]
+function softmax(input::Value, output::Value; result::Vector{IR.Type}, dimension, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, output, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "linalg.softmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "linalg.softmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -117,55 +107,41 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
 
 No numeric casting is performed on the input operand.
 """
-function abs(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function abs(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -180,29 +156,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.add` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function add(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function add(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -212,29 +178,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -246,29 +202,19 @@ has its non-batch dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_a(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_a(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_a",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_a", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -280,29 +226,19 @@ has its non-batch dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -312,29 +248,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -346,29 +272,19 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_reduce_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_reduce_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -385,29 +301,18 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    dimensions,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,29 +321,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function ceil(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function ceil(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -452,33 +347,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_ncw_fcw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_ncw_fcw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -488,33 +371,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -524,29 +395,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -560,33 +421,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -600,33 +449,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -640,33 +477,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -680,33 +505,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -721,33 +534,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -757,29 +558,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -789,33 +580,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ncdhw_fcdhw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ncdhw_fcdhw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ncdhw_fcdhw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ncdhw_fcdhw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -825,33 +604,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -862,33 +629,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -898,29 +653,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -930,31 +675,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -965,33 +699,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_ncw_cw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_ncw_cw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_ncw_cw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_ncw_cw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1002,33 +724,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1038,33 +748,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1075,33 +773,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1112,33 +798,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1148,33 +822,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1184,33 +846,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1220,33 +870,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1257,33 +895,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ncdhw_cdhw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ncdhw_cdhw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ncdhw_cdhw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ncdhw_cdhw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1294,33 +920,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1330,33 +944,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1373,29 +975,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function div(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function div(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1412,29 +1004,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function div_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function div_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.div_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.div_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1444,29 +1026,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1476,33 +1048,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1512,33 +1072,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1547,29 +1095,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function exp(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function exp(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1580,29 +1118,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1617,29 +1145,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1648,29 +1166,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function floor(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function floor(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1773,39 +1281,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1814,29 +1304,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function log(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function log(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1867,28 +1347,18 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(
-    inputs::Vector{Value},
-    init::Value;
-    result::Vector{IR.Type},
-    mapper::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[inputs..., init]
-    owned_regions = Region[mapper,]
+function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[inputs..., init, ]
+    owned_regions = Region[mapper, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1898,31 +1368,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1934,31 +1393,20 @@ transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_a(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_a(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_a",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_a", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1970,31 +1418,20 @@ transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2004,29 +1441,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2036,29 +1463,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2073,29 +1490,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2110,29 +1517,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2147,29 +1544,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.mul` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function mul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2178,29 +1565,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function negf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function negf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.negf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2210,33 +1587,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2250,33 +1615,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2286,33 +1639,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2326,33 +1667,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2362,33 +1691,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2398,33 +1715,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2434,33 +1739,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2470,33 +1763,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2506,33 +1787,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2542,33 +1811,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2578,33 +1835,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2618,33 +1863,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2654,33 +1887,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2690,33 +1911,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2726,33 +1935,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2762,33 +1959,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2802,33 +1987,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2840,29 +2013,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2874,29 +2037,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2931,29 +2084,18 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(
-    inputs::Vector{Value},
-    inits::Vector{Value};
-    result_0::Vector{IR.Type},
-    dimensions,
-    combiner::Region,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[inputs..., inits...]
-    owned_regions = Region[combiner,]
+function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[inputs..., inits..., ]
+    owned_regions = Region[combiner, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2968,29 +2110,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.sub` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function sub(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function sub(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3011,29 +2143,18 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    permutation,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "linalg.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "linalg.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3043,29 +2164,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Linalg.jl
+++ b/src/Dialects/17/Linalg.jl
@@ -1,8 +1,8 @@
 module linalg
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `index`
@@ -41,19 +41,23 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim), ]
+    attributes = NamedAttribute[namedattribute("dim", dim),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "linalg.index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -77,18 +81,24 @@ of the transformation calling the tiling to ensure that the provided
 sizes for each dimension make sense with respect to the semantic of
 softmax.
 """
-function softmax(input::Value, output::Value; result::Vector{IR.Type}, dimension, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[input, output, ]
+function softmax(
+    input::Value, output::Value; result::Vector{IR.Type}, dimension, location=Location()
+)
+    results = IR.Type[result...,]
+    operands = Value[input, output]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
-    
-    IR.create_operation(
-        "linalg.softmax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+
+    return IR.create_operation(
+        "linalg.softmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -107,41 +117,55 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values..., ]
+    operands = Value[values...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "linalg.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
 
 No numeric casting is performed on the input operand.
 """
-function abs(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function abs(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.abs", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -156,19 +180,29 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.add` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function add(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function add(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.add", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -178,19 +212,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -202,19 +246,29 @@ has its non-batch dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_a(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matmul_transpose_a(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matmul_transpose_a", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matmul_transpose_a",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -226,19 +280,29 @@ has its non-batch dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matmul_transpose_b(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matmul_transpose_b", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matmul_transpose_b",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -248,19 +312,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_matvec(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_matvec", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_matvec",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -272,19 +346,29 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function batch_reduce_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.batch_reduce_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.batch_reduce_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -301,18 +385,29 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[input, init, ]
-    owned_regions = Region[region, ]
+function broadcast(
+    input::Value,
+    init::Value;
+    result::Vector{IR.Type},
+    dimensions,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[input, init]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
-    
-    IR.create_operation(
-        "linalg.broadcast", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
+
+    return IR.create_operation(
+        "linalg.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -321,19 +416,29 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function ceil(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function ceil(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.ceil", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -347,21 +452,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d_ncw_fcw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_1d_ncw_fcw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_1d_ncw_fcw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -371,21 +488,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d_nwc_wcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_1d_nwc_wcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_1d_nwc_wcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -395,19 +524,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_1d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_1d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_1d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -421,21 +560,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nchw_fchw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nchw_fchw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nchw_fchw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -449,21 +600,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_ngchw_fgchw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -477,21 +640,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_fhwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -505,21 +680,33 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_hwcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -534,21 +721,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d_nhwc_hwcf_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -558,19 +757,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_2d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_2d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -580,21 +789,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ncdhw_fcdhw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d_ncdhw_fcdhw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_3d_ncdhw_fcdhw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_3d_ncdhw_fcdhw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -604,21 +825,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d_ndhwc_dhwcf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -629,21 +862,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d_ndhwc_dhwcf_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -653,19 +898,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function conv_3d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.conv_3d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.conv_3d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -675,20 +930,31 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function copy(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -699,21 +965,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_ncw_cw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_ncw_cw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_ncw_cw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_ncw_cw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -724,21 +1002,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_nwc_wc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -748,21 +1038,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_1d_nwc_wcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -773,21 +1075,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nchw_chw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -798,21 +1112,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -822,21 +1148,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwc_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -846,21 +1184,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -870,21 +1220,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_2d_nhwc_hwcm_q(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -895,21 +1257,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ncdhw_cdhw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ncdhw_cdhw(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ncdhw_cdhw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ncdhw_cdhw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -920,21 +1294,33 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ndhwc_dhwc(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -944,21 +1330,33 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function depthwise_conv_3d_ndhwc_dhwcm(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -975,19 +1373,29 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function div(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function div(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.div", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1004,19 +1412,29 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function div_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function div_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.div_unsigned", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.div_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1026,19 +1444,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function dot(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.dot", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.dot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1048,21 +1476,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function elemwise_binary(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    fun=nothing,
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.elemwise_binary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.elemwise_binary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1072,21 +1512,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function elemwise_unary(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    fun=nothing,
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.elemwise_unary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.elemwise_unary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1095,19 +1547,29 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function exp(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function exp(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.exp", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1118,19 +1580,29 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function fill(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.fill", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.fill",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1145,19 +1617,29 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function fill_rng_2d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.fill_rng_2d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.fill_rng_2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1166,19 +1648,29 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function floor(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function floor(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.floor", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1281,21 +1773,39 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function generic(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    indexing_maps,
+    iterator_types,
+    doc=nothing,
+    library_call=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    attributes = NamedAttribute[
+        namedattribute("indexing_maps", indexing_maps),
+        namedattribute("iterator_types", iterator_types),
+    ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
-    
-    IR.create_operation(
-        "linalg.generic", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(library_call) &&
+        push!(attributes, namedattribute("library_call", library_call))
+
+    return IR.create_operation(
+        "linalg.generic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1304,19 +1814,29 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function log(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function log(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.log", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1347,18 +1867,28 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[inputs..., init, ]
-    owned_regions = Region[mapper, ]
+function map(
+    inputs::Vector{Value},
+    init::Value;
+    result::Vector{IR.Type},
+    mapper::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[inputs..., init]
+    owned_regions = Region[mapper,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "linalg.map", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.map",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1368,20 +1898,31 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.matmul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1393,20 +1934,31 @@ transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_a(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul_transpose_a(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.matmul_transpose_a", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.matmul_transpose_a",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1418,20 +1970,31 @@ transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul_transpose_b(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    cast=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-    
-    IR.create_operation(
-        "linalg.matmul_transpose_b", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.matmul_transpose_b",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1441,19 +2004,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matmul_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.matmul_unsigned", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.matmul_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1463,19 +2036,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function matvec(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.matvec", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.matvec",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1490,19 +2073,29 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.max", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1517,19 +2110,29 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function mmt4d(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.mmt4d", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.mmt4d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1544,19 +2147,29 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.mul` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function mul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function mul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.mul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1565,19 +2178,29 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function negf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function negf(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.negf", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.negf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1587,21 +2210,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nchw_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nchw_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nchw_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1615,21 +2250,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nchw_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nchw_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nchw_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1639,21 +2286,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ncw_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ncw_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ncw_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1667,21 +2326,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ncw_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ncw_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ncw_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1691,21 +2362,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1715,21 +2398,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1739,21 +2434,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_ndhwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_ndhwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_ndhwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1763,21 +2470,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1787,21 +2506,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_max_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1811,21 +2542,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1835,21 +2578,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_min_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1863,21 +2618,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nhwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nhwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nhwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1887,21 +2654,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_max(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1911,21 +2690,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_max_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1935,21 +2726,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_min(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1959,21 +2762,33 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_min_unsigned(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1987,21 +2802,33 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function pooling_nwc_sum(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    strides=nothing,
+    dilations=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-    
-    IR.create_operation(
-        "linalg.pooling_nwc_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "linalg.pooling_nwc_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2013,19 +2840,29 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function quantized_batch_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.quantized_batch_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.quantized_batch_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2037,19 +2874,29 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function quantized_matmul(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.quantized_matmul", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.quantized_matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2084,18 +2931,29 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
-    results = IR.Type[result_0..., ]
-    operands = Value[inputs..., inits..., ]
-    owned_regions = Region[combiner, ]
+function reduce(
+    inputs::Vector{Value},
+    inits::Vector{Value};
+    result_0::Vector{IR.Type},
+    dimensions,
+    combiner::Region,
+    location=Location(),
+)
+    results = IR.Type[result_0...,]
+    operands = Value[inputs..., inits...]
+    owned_regions = Region[combiner,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
-    
-    IR.create_operation(
-        "linalg.reduce", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
+
+    return IR.create_operation(
+        "linalg.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2110,19 +2968,29 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.sub` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function sub(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function sub(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.sub", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2143,18 +3011,29 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[input, init, ]
-    owned_regions = Region[region, ]
+function transpose(
+    input::Value,
+    init::Value;
+    result::Vector{IR.Type},
+    permutation,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[input, init]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
-    
-    IR.create_operation(
-        "linalg.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation),]
+
+    return IR.create_operation(
+        "linalg.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2164,19 +3043,29 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_tensors..., ]
-    operands = Value[inputs..., outputs..., ]
-    owned_regions = Region[region, ]
+function vecmat(
+    inputs::Vector{Value},
+    outputs::Vector{Value};
+    result_tensors::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result_tensors...,]
+    operands = Value[inputs..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
-    
-    IR.create_operation(
-        "linalg.vecmat", location;
-        operands, owned_regions, successors, attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+
+    return IR.create_operation(
+        "linalg.vecmat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Linalg.jl
+++ b/src/Dialects/17/Linalg.jl
@@ -1,9 +1,8 @@
 module linalg
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `index`
@@ -42,23 +41,19 @@ scf.for %i = %c0 to %0 step %c1 {
 }
 ```
 """
-function index(; result=nothing::Union{Nothing,IR.Type}, dim, location=Location())
+function index(; result=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "linalg.index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -82,24 +77,18 @@ of the transformation calling the tiling to ensure that the provided
 sizes for each dimension make sense with respect to the semantic of
 softmax.
 """
-function softmax(
-    input::Value, output::Value; result::Vector{IR.Type}, dimension, location=Location()
-)
-    results = IR.Type[result...,]
-    operands = Value[input, output]
+function softmax(input::Value, output::Value; result::Vector{IR.Type}, dimension, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, output, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "linalg.softmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "linalg.softmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,56 +107,41 @@ linalg.yield %f0, %f1 : f32, f32
 """
 function yield(values::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[values...,]
+    operands = Value[values..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
 
 No numeric casting is performed on the input operand.
 """
-function abs(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function abs(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -182,29 +156,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.add` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function add(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function add(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -214,29 +178,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -248,29 +202,19 @@ has its non-batch dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_a(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_a(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_a",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_a", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -282,29 +226,19 @@ has its non-batch dimensions transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -314,29 +248,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -348,29 +272,19 @@ The partial multiplication results are reduced into a 2D output.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function batch_reduce_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function batch_reduce_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.batch_reduce_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.batch_reduce_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -387,29 +301,18 @@ Broadcast the input into the given shape by adding `dimensions`.
       dimensions = [1]
 ```
 """
-function broadcast(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    dimensions,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function broadcast(input::Value, init::Value; result::Vector{IR.Type}, dimensions, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -418,29 +321,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function ceil(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function ceil(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -454,33 +347,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_ncw_fcw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_ncw_fcw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_ncw_fcw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_ncw_fcw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -490,33 +371,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d_nwc_wcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d_nwc_wcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_1d_nwc_wcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_1d_nwc_wcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -526,29 +395,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_1d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_1d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_1d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_1d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -562,33 +421,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nchw_fchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nchw_fchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nchw_fchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nchw_fchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -602,33 +449,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_ngchw_fgchw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_ngchw_fgchw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_ngchw_fgchw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_ngchw_fgchw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -642,33 +477,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_fhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_fhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_fhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_fhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -682,33 +505,21 @@ Layout:
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d_nhwc_hwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -723,33 +534,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_2d_nhwc_hwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d_nhwc_hwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_2d_nhwc_hwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_2d_nhwc_hwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -759,29 +558,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -791,33 +580,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ncdhw_fcdhw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ncdhw_fcdhw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ncdhw_fcdhw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ncdhw_fcdhw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -827,33 +604,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d_ndhwc_dhwcf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -864,33 +629,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. This includes the zero
 point offsets common to quantized operations.
 """
-function conv_3d_ndhwc_dhwcf_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d_ndhwc_dhwcf_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.conv_3d_ndhwc_dhwcf_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.conv_3d_ndhwc_dhwcf_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -900,29 +653,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function conv_3d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function conv_3d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.conv_3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.conv_3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -932,31 +675,20 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function copy(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function copy(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -967,33 +699,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_ncw_cw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_ncw_cw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_ncw_cw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_ncw_cw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1004,33 +724,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_1d_nwc_wc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1040,33 +748,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_1d_nwc_wcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_1d_nwc_wcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_1d_nwc_wcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_1d_nwc_wcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1077,33 +773,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nchw_chw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nchw_chw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nchw_chw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nchw_chw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1114,33 +798,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_2d_nhwc_hwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1150,33 +822,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwc_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwc_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwc_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwc_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1186,33 +846,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1222,33 +870,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_2d_nhwc_hwcm_q(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_2d_nhwc_hwcm_q(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_2d_nhwc_hwcm_q",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_2d_nhwc_hwcm_q", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1259,33 +895,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ncdhw_cdhw(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ncdhw_cdhw(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ncdhw_cdhw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ncdhw_cdhw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1296,33 +920,21 @@ Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output. Multiplier is set to 1
 which is a special case for most depthwise convolutions.
 """
-function depthwise_conv_3d_ndhwc_dhwc(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwc(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1332,33 +944,21 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function depthwise_conv_3d_ndhwc_dhwcm(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function depthwise_conv_3d_ndhwc_dhwcm(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.depthwise_conv_3d_ndhwc_dhwcm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.depthwise_conv_3d_ndhwc_dhwcm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1375,29 +975,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function div(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function div(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1414,29 +1004,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function div_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function div_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.div_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.div_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1446,29 +1026,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function dot(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function dot(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.dot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1478,33 +1048,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_binary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_binary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1514,33 +1072,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function elemwise_unary(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    fun=nothing,
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function elemwise_unary(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, fun=nothing, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(fun) && push!(attributes, namedattribute("fun", fun))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.elemwise_unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.elemwise_unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1549,29 +1095,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function exp(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function exp(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1582,29 +1118,19 @@ Works for arbitrary ranked output tensors since the operation performs scalar
 accesses only and is thus rank polymorphic. Numeric casting is performed on
 the value operand, promoting it to the same data type as the output.
 """
-function fill(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1619,29 +1145,19 @@ and runs them in parallel. The seed operand and the indices of the data
 element seed the random number generation. The min and max operands limit
 the range of the generated random numbers.
 """
-function fill_rng_2d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function fill_rng_2d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.fill_rng_2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.fill_rng_2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1650,29 +1166,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function floor(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function floor(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1775,39 +1281,21 @@ tensors and buffers operands and tensor results.
   -> (tensor<?x?xf32>)
 ```
 """
-function generic(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    indexing_maps,
-    iterator_types,
-    doc=nothing,
-    library_call=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function generic(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, indexing_maps, iterator_types, doc=nothing, library_call=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(doc) && push!(attributes, namedattribute("doc", doc))
-    !isnothing(library_call) &&
-        push!(attributes, namedattribute("library_call", library_call))
-
-    return IR.create_operation(
-        "linalg.generic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(library_call) && push!(attributes, namedattribute("library_call", library_call))
+    
+    IR.create_operation(
+        "linalg.generic", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1816,29 +1304,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function log(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function log(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1869,28 +1347,18 @@ The example above will be printed as:
       outs(%init: tensor<64xf32>)
 ```
 """
-function map(
-    inputs::Vector{Value},
-    init::Value;
-    result::Vector{IR.Type},
-    mapper::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[inputs..., init]
-    owned_regions = Region[mapper,]
+function map(inputs::Vector{Value}, init::Value; result::Vector{IR.Type}, mapper::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[inputs..., init, ]
+    owned_regions = Region[mapper, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "linalg.map",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.map", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1900,31 +1368,20 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1936,31 +1393,20 @@ transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_a(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_a(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_a",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_a", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1972,31 +1418,20 @@ transposed.
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_transpose_b(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    cast=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_transpose_b(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, cast=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(cast) && push!(attributes, namedattribute("cast", cast))
-
-    return IR.create_operation(
-        "linalg.matmul_transpose_b",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.matmul_transpose_b", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2006,29 +1441,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matmul_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matmul_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matmul_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matmul_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2038,29 +1463,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function matvec(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function matvec(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.matvec",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.matvec", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2075,29 +1490,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.div` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2112,29 +1517,19 @@ Differences from linalg.matmul:
   \'0\' suffixes below, for instance the LHS matrix shape (M, K, M0, K0) reads
   as: MxK tiles, each of shape M0xK0.
 """
-function mmt4d(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mmt4d(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mmt4d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mmt4d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2149,29 +1544,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.mul` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function mul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function mul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2180,29 +1565,19 @@ end
 
 No numeric casting is performed on the input operand.
 """
-function negf(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function negf(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.negf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.negf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2212,33 +1587,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2252,33 +1615,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nchw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nchw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nchw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nchw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2288,33 +1639,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2328,33 +1667,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ncw_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ncw_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ncw_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ncw_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2364,33 +1691,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2400,33 +1715,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2436,33 +1739,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_ndhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_ndhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_ndhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_ndhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2472,33 +1763,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2508,33 +1787,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2544,33 +1811,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2580,33 +1835,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2620,33 +1863,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nhwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nhwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nhwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nhwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2656,33 +1887,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2692,33 +1911,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_max_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_max_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_max_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_max_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2728,33 +1935,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2764,33 +1959,21 @@ end
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_min_unsigned(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_min_unsigned(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_min_unsigned",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_min_unsigned", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2804,33 +1987,21 @@ Layout:
 Numeric casting is performed on the input operand, promoting it to the same
 data type as the accumulator/output.
 """
-function pooling_nwc_sum(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    strides=nothing,
-    dilations=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function pooling_nwc_sum(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, strides=nothing, dilations=nothing, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
     !isnothing(strides) && push!(attributes, namedattribute("strides", strides))
     !isnothing(dilations) && push!(attributes, namedattribute("dilations", dilations))
-
-    return IR.create_operation(
-        "linalg.pooling_nwc_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "linalg.pooling_nwc_sum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2842,29 +2013,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_batch_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_batch_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_batch_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_batch_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2876,29 +2037,19 @@ them to the same data type as the accumulator/output. The quantized variant
 includes zero-point adjustments for the left and right operands of the
 matmul.
 """
-function quantized_matmul(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function quantized_matmul(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.quantized_matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.quantized_matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2933,29 +2084,18 @@ The example above will be printed as:
       dimensions = [1]
 ```
 """
-function reduce(
-    inputs::Vector{Value},
-    inits::Vector{Value};
-    result_0::Vector{IR.Type},
-    dimensions,
-    combiner::Region,
-    location=Location(),
-)
-    results = IR.Type[result_0...,]
-    operands = Value[inputs..., inits...]
-    owned_regions = Region[combiner,]
+function reduce(inputs::Vector{Value}, inits::Vector{Value}; result_0::Vector{IR.Type}, dimensions, combiner::Region, location=Location())
+    results = IR.Type[result_0..., ]
+    operands = Value[inputs..., inits..., ]
+    owned_regions = Region[combiner, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimensions", dimensions),]
-
-    return IR.create_operation(
-        "linalg.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimensions", dimensions), ]
+    
+    IR.create_operation(
+        "linalg.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2970,29 +2110,19 @@ passes can take that into account when lowering this code. For example,
 a `linalg.broadcast` + `linalg.sub` sequence can be lowered to a
 `linalg.generic` with different affine maps for the two operands.
 """
-function sub(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function sub(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3013,29 +2143,18 @@ operation only that produces a transposed \"view\".
       permutation = [1, 0]
 ```
 """
-function transpose(
-    input::Value,
-    init::Value;
-    result::Vector{IR.Type},
-    permutation,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[input, init]
-    owned_regions = Region[region,]
+function transpose(input::Value, init::Value; result::Vector{IR.Type}, permutation, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[input, init, ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "linalg.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "linalg.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3045,29 +2164,19 @@ end
 Numeric casting is performed on the operands to the inner multiply, promoting
 them to the same data type as the accumulator/output.
 """
-function vecmat(
-    inputs::Vector{Value},
-    outputs::Vector{Value};
-    result_tensors::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result_tensors...,]
-    operands = Value[inputs..., outputs...]
-    owned_regions = Region[region,]
+function vecmat(inputs::Vector{Value}, outputs::Vector{Value}; result_tensors::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result_tensors..., ]
+    operands = Value[inputs..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(inputs), length(outputs)]))
-
-    return IR.create_operation(
-        "linalg.vecmat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(inputs), length(outputs), ]))
+    
+    IR.create_operation(
+        "linalg.vecmat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/MLProgram.jl
+++ b/src/Dialects/17/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `func`
@@ -24,36 +24,21 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -72,21 +57,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -110,28 +91,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -156,21 +127,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -204,35 +171,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -256,28 +209,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -303,20 +246,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,22 +268,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -357,22 +292,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -396,36 +327,21 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -436,21 +352,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/MLProgram.jl
+++ b/src/Dialects/17/MLProgram.jl
@@ -1,9 +1,8 @@
 module ml_program
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `func`
@@ -25,36 +24,21 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +57,17 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_const", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,28 +91,18 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(
-    consumeTokens::Vector{Value};
-    result::IR.Type,
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[result, produceToken]
-    operands = Value[consumeTokens...,]
+function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[result, produceToken, ]
+    operands = Value[consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -157,21 +127,17 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -205,35 +171,21 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(;
-    sym_name,
-    type,
-    is_mutable=nothing,
-    value=nothing,
-    sym_visibility=nothing,
-    location=Location(),
-)
+function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -257,28 +209,18 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(
-    value::Value,
-    consumeTokens::Vector{Value};
-    produceToken::IR.Type,
-    global_,
-    location=Location(),
-)
-    results = IR.Type[produceToken,]
-    operands = Value[value, consumeTokens...]
+function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
+    results = IR.Type[produceToken, ]
+    operands = Value[value, consumeTokens..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store_graph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store_graph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -304,20 +246,16 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_),]
-
-    return IR.create_operation(
-        "ml_program.global_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("global", global_), ]
+    
+    IR.create_operation(
+        "ml_program.global_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -330,22 +268,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands::Vector{Value}; location=Location())
+function output(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.output",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.output", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -358,22 +292,18 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -397,36 +327,21 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "ml_program.subgraph",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "ml_program.subgraph", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -437,21 +352,17 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token,]
+    results = IR.Type[token, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "ml_program.token",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ml_program.token", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/MLProgram.jl
+++ b/src/Dialects/17/MLProgram.jl
@@ -1,8 +1,8 @@
 module ml_program
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `func`
@@ -24,21 +24,36 @@ ml_program.func @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_visibility=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.func", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,17 +72,21 @@ such a load can be considered to have no side effects.
 ```
 """
 function global_load_const(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load_const", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load_const",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -91,18 +110,28 @@ without additional consideration to evaluation order constraints.
   ordering (%token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_load_graph(consumeTokens::Vector{Value}; result::IR.Type, produceToken::IR.Type, global_, location=Location())
-    results = IR.Type[result, produceToken, ]
-    operands = Value[consumeTokens..., ]
+function global_load_graph(
+    consumeTokens::Vector{Value};
+    result::IR.Type,
+    produceToken::IR.Type,
+    global_,
+    location=Location(),
+)
+    results = IR.Type[result, produceToken]
+    operands = Value[consumeTokens...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load_graph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load_graph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -127,17 +156,21 @@ without additional consideration to evaluation order constraints. See
 ```
 """
 function global_load(; result::IR.Type, global_, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_load", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -171,21 +204,35 @@ ml_program.global mutable @foobar(#ml_program.extern<tensor<4xi32>>)
 ml_program.global mutable @foobar : tensor<?xi32>
 ```
 """
-function global_(; sym_name, type, is_mutable=nothing, value=nothing, sym_visibility=nothing, location=Location())
+function global_(;
+    sym_name,
+    type,
+    is_mutable=nothing,
+    value=nothing,
+    sym_visibility=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
     !isnothing(is_mutable) && push!(attributes, namedattribute("is_mutable", is_mutable))
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.global", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -209,18 +256,28 @@ without additional consideration to evaluation order constraints.
   ordering (%in_token -> !ml_program.token) : tensor<?xi32>
 ```
 """
-function global_store_graph(value::Value, consumeTokens::Vector{Value}; produceToken::IR.Type, global_, location=Location())
-    results = IR.Type[produceToken, ]
-    operands = Value[value, consumeTokens..., ]
+function global_store_graph(
+    value::Value,
+    consumeTokens::Vector{Value};
+    produceToken::IR.Type,
+    global_,
+    location=Location(),
+)
+    results = IR.Type[produceToken,]
+    operands = Value[value, consumeTokens...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_store_graph", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_store_graph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -246,16 +303,20 @@ ml_program.global_store @foobar = %0 : tensor<?xi32>
 """
 function global_store(value::Value; global_, location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("global", global_), ]
-    
-    IR.create_operation(
-        "ml_program.global_store", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("global", global_),]
+
+    return IR.create_operation(
+        "ml_program.global_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -268,18 +329,22 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function output(operands_::Vector{Value}; location=Location())
+function output(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.output", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.output",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -292,18 +357,22 @@ The operation takes variable number of operands and produces no results.
 The operand number and types must match the signature of the function
 that contains the operation.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,21 +396,36 @@ ml_program.subgraph @compute(%arg0 : i32) -> i32 {
 }
 ```
 """
-function subgraph(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
+function subgraph(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_visibility=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "ml_program.subgraph", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "ml_program.subgraph",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -352,17 +436,21 @@ Token values are used to chain side effecting ops in a graph so as to
 establish an execution order. This op produces a token.
 """
 function token(; token::IR.Type, location=Location())
-    results = IR.Type[token, ]
+    results = IR.Type[token,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "ml_program.token", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ml_program.token",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Math.jl
+++ b/src/Dialects/17/Math.jl
@@ -1,9 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `absf`
@@ -19,29 +18,20 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.absf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -59,23 +49,19 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.absi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -106,30 +92,20 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -153,29 +129,20 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -195,29 +162,20 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cbrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cbrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -241,29 +199,20 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -288,30 +237,20 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -335,29 +274,20 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -374,23 +304,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,23 +333,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -440,23 +362,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -480,29 +398,20 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -526,29 +435,20 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -574,29 +474,20 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -620,29 +511,20 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -678,30 +560,20 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fpowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fpowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -725,29 +597,20 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -776,31 +639,20 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -824,25 +676,50 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ipowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ipowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
+    )
+end
+
+"""
+`log10`
+
+Computes the base-10 logarithm of the given value. It takes one operand of
+floating point type (i.e., scalar, tensor or vector) and returns one result of
+the same type.
+
+# Example
+
+```mlir
+// Scalar log10 operation.
+%y = math.log10 %x : f64
+```
+"""
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+    results = IR.Type[]
+    operands = Value[operand, ]
+    owned_regions = Region[]
+    successors = Block[]
+    attributes = NamedAttribute[]
+    !isnothing(result) && push!(results, result)
+    !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -862,29 +739,20 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -902,69 +770,20 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
-    )
-end
-
-"""
-`log10`
-
-Computes the base-10 logarithm of the given value. It takes one operand of
-floating point type (i.e., scalar, tensor or vector) and returns one result of
-the same type.
-
-# Example
-
-```mlir
-// Scalar log10 operation.
-%y = math.log10 %x : f64
-```
-"""
-function log10(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[]
-    successors = Block[]
-    attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-    !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -982,29 +801,20 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1028,30 +838,20 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1078,29 +878,20 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.roundeven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.roundeven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1127,29 +918,20 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1167,29 +949,20 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1213,29 +986,20 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1253,29 +1017,20 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1293,29 +1048,20 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1333,29 +1079,20 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1381,29 +1118,20 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/Math.jl
+++ b/src/Dialects/17/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `absf`
@@ -18,29 +18,20 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.absf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -58,23 +49,19 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.absi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.absi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -105,30 +92,20 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -152,29 +129,20 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -194,29 +162,20 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cbrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cbrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -240,29 +199,20 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -287,30 +237,20 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.copysign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.copysign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -334,29 +274,20 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -373,23 +304,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctlz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctlz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -406,23 +333,19 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.cttz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.cttz", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -439,23 +362,19 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ctpop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ctpop", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -479,29 +398,20 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -525,29 +435,20 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -573,29 +474,20 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.expm1",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.expm1", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -619,29 +511,20 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -677,30 +560,20 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fpowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fpowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -724,29 +597,20 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -775,31 +639,20 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -823,25 +676,50 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "math.ipowi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.ipowi", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
+    )
+end
+
+"""
+`log10`
+
+Computes the base-10 logarithm of the given value. It takes one operand of
+floating point type (i.e., scalar, tensor or vector) and returns one result of
+the same type.
+
+# Example
+
+```mlir
+// Scalar log10 operation.
+%y = math.log10 %x : f64
+```
+"""
+function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+    results = IR.Type[]
+    operands = Value[operand, ]
+    owned_regions = Region[]
+    successors = Block[]
+    attributes = NamedAttribute[]
+    !isnothing(result) && push!(results, result)
+    !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
+    
+    IR.create_operation(
+        "math.log10", location;
+        operands, owned_regions, successors, attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -861,29 +739,20 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log1p",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log1p", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -901,69 +770,20 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log2",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log2", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
-    )
-end
-
-"""
-`log10`
-
-Computes the base-10 logarithm of the given value. It takes one operand of
-floating point type (i.e., scalar, tensor or vector) and returns one result of
-the same type.
-
-# Example
-
-```mlir
-// Scalar log10 operation.
-%y = math.log10 %x : f64
-```
-"""
-function log10(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[]
-    successors = Block[]
-    attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-    !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log10",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -981,29 +801,20 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1027,30 +838,20 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(
-    lhs::Value,
-    rhs::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.powf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.powf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1077,29 +878,20 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.roundeven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.roundeven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1126,29 +918,20 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1166,29 +949,20 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1212,29 +986,20 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1252,29 +1017,20 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1292,29 +1048,20 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1332,29 +1079,20 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1380,29 +1118,20 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(
-    operand::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    fastmath=nothing,
-    location=Location(),
-)
+function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-
-    return IR.create_operation(
-        "math.trunc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "math.trunc", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 

--- a/src/Dialects/17/Math.jl
+++ b/src/Dialects/17/Math.jl
@@ -1,8 +1,8 @@
 module math
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `absf`
@@ -18,20 +18,29 @@ of the same type.
 %a = math.absf %b : f64
 ```
 """
-function absf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function absf(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.absf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.absf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -49,19 +58,23 @@ same type.
 %a = math.absi %b : i64
 ```
 """
-function absi(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function absi(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.absi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.absi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -92,20 +105,30 @@ See also https://en.wikipedia.org/wiki/Atan2
 %a = math.atan2 %b, %c : f32
 ```
 """
-function atan2(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function atan2(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.atan2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.atan2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -129,20 +152,29 @@ one result of the same type. It has no standard attributes.
 %a = math.atan %b : f64
 ```
 """
-function atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function atan(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.atan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.atan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -162,20 +194,29 @@ of the same type. It has no standard attributes.
 
 Note: This op is not equivalent to powf(..., 1/3.0).
 """
-function cbrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function cbrt(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.cbrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cbrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -199,20 +240,29 @@ result of the same type.  It has no standard attributes.
 %a = math.ceil %b : f64
 ```
 """
-function ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function ceil(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -237,20 +287,30 @@ tensor or vector). It has no standard attributes.
 %a = math.copysign %b, %c : f64
 ```
 """
-function copysign(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function copysign(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.copysign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.copysign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -274,20 +334,29 @@ result of the same type.  It has no standard attributes.
 %a = math.cos %b : f64
 ```
 """
-function cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function cos(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -304,19 +373,23 @@ It operates on scalar, tensor or vector.
 %a = math.ctlz %b : i32
 ```
 """
-function ctlz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ctlz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ctlz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ctlz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -333,19 +406,23 @@ It operates on scalar, tensor or vector.
 %a = math.cttz %b : i32
 ```
 """
-function cttz(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cttz(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.cttz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.cttz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -362,19 +439,23 @@ It operates on scalar, tensor or vector.
 %a = math.ctpop %b : i32
 ```
 """
-function ctpop(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ctpop(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ctpop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ctpop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -398,20 +479,29 @@ the same type. It has no standard attributes.
 %a = math.erf %b : f64
 ```
 """
-function erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function erf(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -435,20 +525,29 @@ attributes.
 %a = math.exp2 %b : f64
 ```
 """
-function exp2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function exp2(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.exp2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.exp2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -474,20 +573,29 @@ standard attributes.
 %a = math.expm1 %b : f64
 ```
 """
-function expm1(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function expm1(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.expm1", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.expm1",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -511,20 +619,29 @@ attributes.
 %a = math.exp %b : f64
 ```
 """
-function exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function exp(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -560,20 +677,30 @@ The result is a vector of:
 %a = math.fpowi %base, %power : f64, i32
 ```
 """
-function fpowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function fpowi(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.fpowi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.fpowi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -597,20 +724,29 @@ result of the same type.  It has no standard attributes.
 %a = math.floor %b : f64
 ```
 """
-function floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function floor(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -639,20 +775,31 @@ The semantics of the operation correspond to those of the `llvm.fma`
 particular case of lowering to LLVM, this is guaranteed to lower
 to the `llvm.fma.*` intrinsic.
 """
-function fma(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function fma(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -676,50 +823,25 @@ must have the same type.
 %a = math.ipowi %b, %c : i32
 ```
 """
-function ipowi(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ipowi(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "math.ipowi", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.ipowi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
-    )
-end
-
-"""
-`log10`
-
-Computes the base-10 logarithm of the given value. It takes one operand of
-floating point type (i.e., scalar, tensor or vector) and returns one result of
-the same type.
-
-# Example
-
-```mlir
-// Scalar log10 operation.
-%y = math.log10 %x : f64
-```
-"""
-function log10(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
-    results = IR.Type[]
-    operands = Value[operand, ]
-    owned_regions = Region[]
-    successors = Block[]
-    attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-    !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log10", location;
-        operands, owned_regions, successors, attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -739,20 +861,29 @@ log1p(x) := log(1 + x)
 %y = math.log1p %x : f64
 ```
 """
-function log1p(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log1p(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log1p", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log1p",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -770,20 +901,69 @@ the same type.
 %y = math.log2 %x : f64
 ```
 """
-function log2(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log2(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log2", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log2",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
+    )
+end
+
+"""
+`log10`
+
+Computes the base-10 logarithm of the given value. It takes one operand of
+floating point type (i.e., scalar, tensor or vector) and returns one result of
+the same type.
+
+# Example
+
+```mlir
+// Scalar log10 operation.
+%y = math.log10 %x : f64
+```
+"""
+function log10(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand,]
+    owned_regions = Region[]
+    successors = Block[]
+    attributes = NamedAttribute[]
+    !isnothing(result) && push!(results, result)
+    !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
+
+    return IR.create_operation(
+        "math.log10",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -801,20 +981,29 @@ the same type.
 %y = math.log %x : f64
 ```
 """
-function log(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function log(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -838,20 +1027,30 @@ must have the same type.
 %a = math.powf %b, %c : f64
 ```
 """
-function powf(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function powf(
+    lhs::Value,
+    rhs::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.powf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.powf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -878,20 +1077,29 @@ rounding direction.
 %a = math.roundeven %b : f64
 ```
 """
-function roundeven(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function roundeven(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.roundeven", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.roundeven",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -918,20 +1126,29 @@ rounding direction.
 %a = math.round %b : f64
 ```
 """
-function round(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function round(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -949,20 +1166,29 @@ one result of the same type. It has no standard attributes.
 %a = math.rsqrt %b : f64
 ```
 """
-function rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function rsqrt(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -986,20 +1212,29 @@ result of the same type.  It has no standard attributes.
 %a = math.sin %b : f64
 ```
 """
-function sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function sin(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1017,20 +1252,29 @@ the same type. It has no standard attributes.
 %a = math.sqrt %b : f64
 ```
 """
-function sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function sqrt(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1048,20 +1292,29 @@ result of the same type. It has no standard attributes.
 %a = math.tan %b : f64
 ```
 """
-function tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function tan(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1079,20 +1332,29 @@ result of the same type. It has no standard attributes.
 %a = math.tanh %b : f64
 ```
 """
-function tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function tanh(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1118,20 +1380,29 @@ than the operand, regardless of the current rounding direction.
 %a = math.trunc %b : f64
 ```
 """
-function trunc(operand::Value; result=nothing::Union{Nothing, IR.Type}, fastmath=nothing, location=Location())
+function trunc(
+    operand::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    fastmath=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(fastmath) && push!(attributes, namedattribute("fastmath", fastmath))
-    
-    IR.create_operation(
-        "math.trunc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "math.trunc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 

--- a/src/Dialects/17/MemRef.jl
+++ b/src/Dialects/17/MemRef.jl
@@ -1,9 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `assume_alignment`
@@ -17,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -51,30 +46,19 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    kind,
-    location=Location(),
-)
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -86,20 +70,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -119,20 +99,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -160,28 +136,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -223,30 +189,19 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[memref, indices...]
+function load(memref::Value, indices::Vector{Value}; result::IR.Type, nontemporal=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -291,30 +246,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -355,30 +300,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,22 +351,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -447,22 +378,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -523,21 +450,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -585,21 +508,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -620,20 +539,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -662,25 +577,19 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -731,22 +640,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -770,24 +675,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -834,21 +733,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -874,25 +769,19 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(
-    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-
-    return IR.create_operation(
-        "memref.extract_aligned_pointer_as_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_aligned_pointer_as_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -940,16 +829,9 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(
-    source::Value;
-    base_buffer=nothing::Union{Nothing,IR.Type},
-    offset=nothing::Union{Nothing,IR.Type},
-    sizes=nothing::Union{Nothing,Vector{IR.Type}},
-    strides=nothing::Union{Nothing,Vector{IR.Type}},
-    location=Location(),
-)
+function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -957,16 +839,12 @@ function extract_strided_metadata(
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-
-    return IR.create_operation(
-        "memref.extract_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -985,21 +863,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1041,38 +915,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1102,21 +960,17 @@ If the source and target address spaces are the same, this operation is a noop.
 ```
 """
 function memory_space_cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.memory_space_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.memory_space_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1138,33 +992,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1180,23 +1019,19 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1258,30 +1093,20 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(
-    source::Value,
-    dynamicResultSize=nothing::Union{Nothing,Value};
-    result_0::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source,]
+function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.realloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.realloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1323,40 +1148,19 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1396,21 +1200,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1444,29 +1244,19 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, memref::Value, indices::Vector{Value}; nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1484,21 +1274,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1540,28 +1326,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1698,40 +1474,19 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1752,20 +1507,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/MemRef.jl
+++ b/src/Dialects/17/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `assume_alignment`
@@ -16,20 +16,16 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment),]
-
-    return IR.create_operation(
-        "memref.assume_alignment",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
+    
+    IR.create_operation(
+        "memref.assume_alignment", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -50,30 +46,19 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    kind,
-    location=Location(),
-)
+function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -85,20 +70,16 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.atomic_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.atomic_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -118,20 +99,16 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target]
+    operands = Value[source, target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -159,28 +136,18 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(
-    memref::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    atomic_body::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[memref, indices...]
-    owned_regions = Region[atomic_body,]
+function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
+    owned_regions = Region[atomic_body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.generic_atomic_rmw",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.generic_atomic_rmw", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,30 +189,19 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(
-    memref::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    nontemporal=nothing,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[memref, indices...]
+function load(memref::Value, indices::Vector{Value}; result::IR.Type, nontemporal=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "memref.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "memref.load", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -290,30 +246,20 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,30 +300,20 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(
-    dynamicSizes::Vector{Value},
-    symbolOperands::Vector{Value};
-    memref::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[memref,]
-    operands = Value[dynamicSizes..., symbolOperands...]
+function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[memref, ]
+    operands = Value[dynamicSizes..., symbolOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.alloca",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -415,22 +351,18 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results...,]
+function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -446,22 +378,18 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results::Vector{Value}; location=Location())
+function alloca_scope_return(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.alloca_scope.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.alloca_scope.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -522,21 +450,17 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -584,21 +508,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,20 +539,16 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dealloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dealloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -661,25 +577,19 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "memref.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -730,22 +640,18 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands::Vector{Value}; location=Location())
+function dma_start(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_start",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_start", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -769,24 +675,18 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(
-    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
-)
+function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements]
+    operands = Value[tagMemRef, tagIndices..., numElements, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.dma_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.dma_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -833,21 +733,17 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "memref.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "memref.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -873,25 +769,19 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(
-    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-
-    return IR.create_operation(
-        "memref.extract_aligned_pointer_as_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_aligned_pointer_as_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -939,16 +829,9 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(
-    source::Value;
-    base_buffer=nothing::Union{Nothing,IR.Type},
-    offset=nothing::Union{Nothing,IR.Type},
-    sizes=nothing::Union{Nothing,Vector{IR.Type}},
-    strides=nothing::Union{Nothing,Vector{IR.Type}},
-    location=Location(),
-)
+function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -956,16 +839,12 @@ function extract_strided_metadata(
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-
-    return IR.create_operation(
-        "memref.extract_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.extract_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -984,21 +863,17 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "memref.get_global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "memref.get_global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1040,38 +915,22 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(;
-    sym_name,
-    sym_visibility=nothing,
-    type,
-    initial_value=nothing,
-    constant=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) &&
-        push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.global",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.global", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1101,21 +960,17 @@ If the source and target address spaces are the same, this operation is a noop.
 ```
 """
 function memory_space_cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.memory_space_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.memory_space_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1137,33 +992,18 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(
-    memref::Value,
-    indices::Vector{Value};
-    isWrite,
-    localityHint,
-    isDataCache,
-    location=Location(),
-)
+function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
     results = IR.Type[]
-    operands = Value[memref, indices...]
+    operands = Value[memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("isWrite", isWrite),
-        namedattribute("localityHint", localityHint),
-        namedattribute("isDataCache", isDataCache),
-    ]
-
-    return IR.create_operation(
-        "memref.prefetch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
+    
+    IR.create_operation(
+        "memref.prefetch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1179,23 +1019,19 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref,]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "memref.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1257,30 +1093,20 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(
-    source::Value,
-    dynamicResultSize=nothing::Union{Nothing,Value};
-    result_0::IR.Type,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source,]
+function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "memref.realloc",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.realloc", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1322,40 +1148,19 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.reinterpret_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.reinterpret_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1395,21 +1200,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1443,29 +1244,19 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function store(
-    value::Value,
-    memref::Value,
-    indices::Vector{Value};
-    nontemporal=nothing,
-    location=Location(),
-)
+function store(value::Value, memref::Value, indices::Vector{Value}; nontemporal=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[value, memref, indices...]
+    operands = Value[value, memref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-
-    return IR.create_operation(
-        "memref.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1483,21 +1274,17 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[in,]
+    results = IR.Type[result_0, ]
+    operands = Value[in, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation),]
-
-    return IR.create_operation(
-        "memref.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
+    
+    IR.create_operation(
+        "memref.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1539,28 +1326,18 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(
-    source::Value,
-    byte_shift::Value,
-    sizes::Vector{Value};
-    result_0::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[source, byte_shift, sizes...]
+function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[source, byte_shift, sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.view",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.view", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1697,40 +1474,19 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "memref.subview",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "memref.subview", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1751,20 +1507,16 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref]
+    operands = Value[tensor, memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "memref.tensor_store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "memref.tensor_store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/MemRef.jl
+++ b/src/Dialects/17/MemRef.jl
@@ -1,8 +1,8 @@
 module memref
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `assume_alignment`
@@ -16,16 +16,20 @@ optimization only, and the optimization is best-effort.
 """
 function assume_alignment(memref::Value; alignment, location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("alignment", alignment), ]
-    
-    IR.create_operation(
-        "memref.assume_alignment", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("alignment", alignment),]
+
+    return IR.create_operation(
+        "memref.assume_alignment",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -46,19 +50,30 @@ result represents the latest value that was stored.
 %x = memref.atomic_rmw \"addf\" %value, %I[%i] : (f32, memref<10xf32>) -> f32
 ```
 """
-function atomic_rmw(value::Value, memref::Value, indices::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, kind, location=Location())
+function atomic_rmw(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    kind,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    attributes = NamedAttribute[namedattribute("kind", kind),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "memref.atomic_rmw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.atomic_rmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -70,16 +85,20 @@ GenericAtomicRMWOp region.
 """
 function atomic_yield(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.atomic_yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.atomic_yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -99,16 +118,20 @@ Otherwise, the result is undefined. They may have different layouts.
 """
 function copy(source::Value, target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, target, ]
+    operands = Value[source, target]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -136,18 +159,28 @@ body of `GenericAtomicRMWOp`.
 }
 ```
 """
-function generic_atomic_rmw(memref::Value, indices::Vector{Value}; result::IR.Type, atomic_body::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
-    owned_regions = Region[atomic_body, ]
+function generic_atomic_rmw(
+    memref::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    atomic_body::Region,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[memref, indices...]
+    owned_regions = Region[atomic_body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.generic_atomic_rmw", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.generic_atomic_rmw",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -189,19 +222,30 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function load(memref::Value, indices::Vector{Value}; result::IR.Type, nontemporal=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, indices..., ]
+function load(
+    memref::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    nontemporal=nothing,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
+    !isnothing(result) && push!(results, result)
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-    
-    IR.create_operation(
-        "memref.load", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+
+    return IR.create_operation(
+        "memref.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -246,20 +290,30 @@ boundary.
   memref<8x64xf32, affine_map<(d0, d1)[s0] -> ((d0 + s0), d1)>, 1>
 ```
 """
-function alloc(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[dynamicSizes..., symbolOperands..., ]
+function alloc(
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.alloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -300,20 +354,30 @@ specified, guarantees alignment at least to that boundary. If not specified,
 an alignment on any convenient boundary compatible with the type will be
 chosen.
 """
-function alloca(dynamicSizes::Vector{Value}, symbolOperands::Vector{Value}; memref::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[memref, ]
-    operands = Value[dynamicSizes..., symbolOperands..., ]
+function alloca(
+    dynamicSizes::Vector{Value},
+    symbolOperands::Vector{Value};
+    memref::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[memref,]
+    operands = Value[dynamicSizes..., symbolOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands), ]))
+    push!(attributes, operandsegmentsizes([length(dynamicSizes), length(symbolOperands)]))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.alloca", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -351,18 +415,22 @@ operation:
 If `memref.alloca_scope` returns no value, the `memref.alloca_scope.return ` can
 be left out, and will be inserted implicitly.
 """
-function alloca_scope(; results_::Vector{IR.Type}, bodyRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
+function alloca_scope(; results::Vector{IR.Type}, bodyRegion::Region, location=Location())
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.alloca_scope", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca_scope",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -378,18 +446,22 @@ to indicate which values are going to be returned. For example:
 memref.alloca_scope.return %value
 ```
 """
-function alloca_scope_return(results_::Vector{Value}; location=Location())
+function alloca_scope_return(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.alloca_scope.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.alloca_scope.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -450,17 +522,21 @@ Erase rank information.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -508,17 +584,21 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "memref.collapse_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "memref.collapse_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -539,16 +619,20 @@ memref.dealloc %0 : memref<8x64xf32,  affine_map<(d0, d1) -> (d0, d1), 1>>
 """
 function dealloc(memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dealloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dealloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -577,19 +661,25 @@ The specified memref type is that of the first operand.
 %y = \"memref.dim\"(%A, %c1) : (memref<4 x ? x f32>, index) -> index
 ```
 """
-function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, index, ]
+    operands = Value[source, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "memref.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -640,18 +730,22 @@ TODO: add additional operands to allow source and destination striding, and
 multiple stride levels.
 TODO: Consider replacing src/dst memref indices with view memrefs.
 """
-function dma_start(operands_::Vector{Value}; location=Location())
+function dma_start(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dma_start", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dma_start",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -675,18 +769,24 @@ number of elements associated with the DMA operation.
  dma_wait %tag[%index], %num_elements : memref<1 x i32, affine_map<(d0) -> (d0)>, 2>
  ```
 """
-function dma_wait(tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location())
+function dma_wait(
+    tagMemRef::Value, tagIndices::Vector{Value}, numElements::Value; location=Location()
+)
     results = IR.Type[]
-    operands = Value[tagMemRef, tagIndices..., numElements, ]
+    operands = Value[tagMemRef, tagIndices..., numElements]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.dma_wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.dma_wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -733,17 +833,21 @@ Note: This op currently assumes that the inner strides are of the
 source/result layout map are the faster-varying ones.
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "memref.expand_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "memref.expand_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -769,19 +873,25 @@ as a pointer is explicitly discouraged.
   call @foo(%2) : (!llvm.ptr<f32>) ->()
 ```
 """
-function extract_aligned_pointer_as_index(source::Value; aligned_pointer=nothing::Union{Nothing, IR.Type}, location=Location())
+function extract_aligned_pointer_as_index(
+    source::Value; aligned_pointer=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(aligned_pointer) && push!(results, aligned_pointer)
-    
-    IR.create_operation(
-        "memref.extract_aligned_pointer_as_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.extract_aligned_pointer_as_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -829,9 +939,16 @@ This makes lowering more progressive and brings the following benefits:
     : memref<f32> to memref<?x?xf32, offset: ?, strides: [?, ?]>
 ```
 """
-function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Nothing, IR.Type}, offset=nothing::Union{Nothing, IR.Type}, sizes=nothing::Union{Nothing, Vector{IR.Type}}, strides=nothing::Union{Nothing, Vector{IR.Type}}, location=Location())
+function extract_strided_metadata(
+    source::Value;
+    base_buffer=nothing::Union{Nothing,IR.Type},
+    offset=nothing::Union{Nothing,IR.Type},
+    sizes=nothing::Union{Nothing,Vector{IR.Type}},
+    strides=nothing::Union{Nothing,Vector{IR.Type}},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -839,12 +956,16 @@ function extract_strided_metadata(source::Value; base_buffer=nothing::Union{Noth
     !isnothing(offset) && push!(results, offset)
     !isnothing(sizes) && push!(results, sizes...)
     !isnothing(strides) && push!(results, strides...)
-    
-    IR.create_operation(
-        "memref.extract_strided_metadata", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.extract_strided_metadata",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -863,17 +984,21 @@ undefined.
 ```
 """
 function get_global(; result::IR.Type, name, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "memref.get_global", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "memref.get_global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -915,22 +1040,38 @@ memref.global @z : memref<3xf16> = uninitialized
 memref.global constant @c : memref<2xi32> = dense<1, 4>
 ```
 """
-function global_(; sym_name, sym_visibility=nothing, type, initial_value=nothing, constant=nothing, alignment=nothing, location=Location())
+function global_(;
+    sym_name,
+    sym_visibility=nothing,
+    type,
+    initial_value=nothing,
+    constant=nothing,
+    alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    !isnothing(initial_value) && push!(attributes, namedattribute("initial_value", initial_value))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    !isnothing(initial_value) &&
+        push!(attributes, namedattribute("initial_value", initial_value))
     !isnothing(constant) && push!(attributes, namedattribute("constant", constant))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.global", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.global",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -960,17 +1101,21 @@ If the source and target address spaces are the same, this operation is a noop.
 ```
 """
 function memory_space_cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.memory_space_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.memory_space_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -992,18 +1137,33 @@ in cache). The cache type specifier is either \'data\' or \'instr\'
 and specifies whether the prefetch is performed on data cache or on
 instruction cache.
 """
-function prefetch(memref::Value, indices::Vector{Value}; isWrite, localityHint, isDataCache, location=Location())
+function prefetch(
+    memref::Value,
+    indices::Vector{Value};
+    isWrite,
+    localityHint,
+    isDataCache,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[memref, indices..., ]
+    operands = Value[memref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("isWrite", isWrite), namedattribute("localityHint", localityHint), namedattribute("isDataCache", isDataCache), ]
-    
-    IR.create_operation(
-        "memref.prefetch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("isWrite", isWrite),
+        namedattribute("localityHint", localityHint),
+        namedattribute("isDataCache", isDataCache),
+    ]
+
+    return IR.create_operation(
+        "memref.prefetch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1019,19 +1179,23 @@ The `memref.rank` operation takes a memref operand and returns its rank.
 %1 = memref.rank %arg1 : memref<?x?xf32>
 ```
 """
-function rank(memref::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(memref::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[memref, ]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "memref.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1093,20 +1257,30 @@ behavior.
 %5 = memref.load %old[%index]   // undefined behavior
 ```
 """
-function realloc(source::Value, dynamicResultSize=nothing::Union{Nothing, Value}; result_0::IR.Type, alignment=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[source, ]
+function realloc(
+    source::Value,
+    dynamicResultSize=nothing::Union{Nothing,Value};
+    result_0::IR.Type,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dynamicResultSize) && push!(operands, dynamicResultSize)
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "memref.realloc", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.realloc",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1148,19 +1322,40 @@ means that `%dst`\'s descriptor will be:
 %dst.strides = %strides
 ```
 """
-function reinterpret_cast(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function reinterpret_cast(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "memref.reinterpret_cast", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "memref.reinterpret_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1200,17 +1395,21 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, shape, ]
+    results = IR.Type[result,]
+    operands = Value[source, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1244,19 +1443,29 @@ techniques. This is possible because of the
 [restrictions on dimensions and symbols](Affine.md/#restrictions-on-dimensions-and-symbols)
 in these contexts.
 """
-function store(value::Value, memref::Value, indices::Vector{Value}; nontemporal=nothing, location=Location())
+function store(
+    value::Value,
+    memref::Value,
+    indices::Vector{Value};
+    nontemporal=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, memref, indices..., ]
+    operands = Value[value, memref, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(nontemporal) && push!(attributes, namedattribute("nontemporal", nontemporal))
-    
-    IR.create_operation(
-        "memref.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1274,17 +1483,21 @@ transformation.
 ```
 """
 function transpose(in::Value; result_0::IR.Type, permutation, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[in, ]
+    results = IR.Type[result_0,]
+    operands = Value[in,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation", permutation), ]
-    
-    IR.create_operation(
-        "memref.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("permutation", permutation),]
+
+    return IR.create_operation(
+        "memref.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1326,18 +1539,28 @@ For now, a \"view\" op:
   memref<2048xi8> to memref<?x4x?xf32>
 ```
 """
-function view(source::Value, byte_shift::Value, sizes::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[source, byte_shift, sizes..., ]
+function view(
+    source::Value,
+    byte_shift::Value,
+    sizes::Vector{Value};
+    result_0::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[source, byte_shift, sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.view", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.view",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1474,19 +1697,40 @@ Example 5:
   memref<8x16x4xf32> to memref<6x3xf32, strided<[4, 1], offset: 210>>
 ```
 """
-function subview(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function subview(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "memref.subview", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "memref.subview",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1507,16 +1751,20 @@ memref.tensor_store %8, %10 : memref<4x?xf32, #layout, memspace0>
 """
 function tensor_store(tensor::Value, memref::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, memref, ]
+    operands = Value[tensor, memref]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "memref.tensor_store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "memref.tensor_store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/NVGPU.jl
+++ b/src/Dialects/17/NVGPU.jl
@@ -1,8 +1,8 @@
 module nvgpu
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `device_async_copy`
@@ -54,21 +54,40 @@ nvgpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}, srcElements=nothing::Union{Nothing, Value}; asyncToken::IR.Type, dstElements, bypassL1=nothing, location=Location())
-    results = IR.Type[asyncToken, ]
-    operands = Value[dst, dstIndices..., src, srcIndices..., ]
+function device_async_copy(
+    dst::Value,
+    dstIndices::Vector{Value},
+    src::Value,
+    srcIndices::Vector{Value},
+    srcElements=nothing::Union{Nothing,Value};
+    asyncToken::IR.Type,
+    dstElements,
+    bypassL1=nothing,
+    location=Location(),
+)
+    results = IR.Type[asyncToken,]
+    operands = Value[dst, dstIndices..., src, srcIndices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dstElements", dstElements), ]
+    attributes = NamedAttribute[namedattribute("dstElements", dstElements),]
     !isnothing(srcElements) && push!(operands, srcElements)
-    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), (srcElements==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            1, length(dstIndices), 1, length(srcIndices), (srcElements == nothing) ? 0 : 1
+        ]),
+    )
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-    
-    IR.create_operation(
-        "nvgpu.device_async_copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -92,18 +111,24 @@ Groups are executed in the order they are created.
 %0 = nvgpu.device_async_create_group
   ```
 """
-function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
-    results = IR.Type[asyncToken, ]
-    operands = Value[inputTokens..., ]
+function device_async_create_group(
+    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
+)
+    results = IR.Type[asyncToken,]
+    operands = Value[inputTokens...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.device_async_create_group", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_create_group",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -127,17 +152,21 @@ nvgpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies, ]
+    operands = Value[asyncDependencies,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-    
-    IR.create_operation(
-        "nvgpu.device_async_wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.device_async_wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -159,18 +188,31 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[srcMemref, indices..., ]
+function ldmatrix(
+    srcMemref::Value,
+    indices::Vector{Value};
+    res::IR.Type,
+    transpose,
+    numTiles,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[srcMemref, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
-    
-    IR.create_operation(
-        "nvgpu.ldmatrix", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
+    ]
+
+    return IR.create_operation(
+        "nvgpu.ldmatrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -193,16 +235,20 @@ The `\$txCount` specifies the number of element to the expect-tx operation.
 """
 function mbarrier_arrive_expect_tx(barrier::Value, txcount::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, txcount, ]
+    operands = Value[barrier, txcount]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.arrive.expect_tx", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.arrive.expect_tx",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -219,18 +265,24 @@ The Op does not cause the `nvgpu.mbarrier` to complete its current phase.
   %token = nvgpu.mbarrier.arrive.noComplete %barrier, %count : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>> -> !nvgpu.mbarrier.token
 ```
 """
-function mbarrier_arrive_nocomplete(barrier::Value, count::Value; token::IR.Type, location=Location())
-    results = IR.Type[token, ]
-    operands = Value[barrier, count, ]
+function mbarrier_arrive_nocomplete(
+    barrier::Value, count::Value; token::IR.Type, location=Location()
+)
+    results = IR.Type[token,]
+    operands = Value[barrier, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.arrive.nocomplete", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.arrive.nocomplete",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -249,17 +301,21 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/#arrive-on-operation-on-m
 ```
 """
 function mbarrier_arrive(barrier::Value; token::IR.Type, location=Location())
-    results = IR.Type[token, ]
-    operands = Value[barrier, ]
+    results = IR.Type[token,]
+    operands = Value[barrier,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.arrive", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.arrive",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -278,17 +334,21 @@ The `mbarrier` object has the following type and alignment requirements:
 ```
 """
 function mbarrier_create(; barrier::IR.Type, location=Location())
-    results = IR.Type[barrier, ]
+    results = IR.Type[barrier,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -306,16 +366,20 @@ The Op initializes the `mbarrier` object with the given number of threads.
 """
 function mbarrier_init(barrier::Value, count::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, count, ]
+    operands = Value[barrier, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.init", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -330,18 +394,24 @@ non-blocking instruction which tests for the completion of the phase.
   %isComplete = nvgpu.mbarrier.test.wait %barrier, %token : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>>, !nvgpu.mbarrier.token
 ```
 """
-function mbarrier_test_wait(barrier::Value, token::Value; waitComplete::IR.Type, location=Location())
-    results = IR.Type[waitComplete, ]
-    operands = Value[barrier, token, ]
+function mbarrier_test_wait(
+    barrier::Value, token::Value; waitComplete::IR.Type, location=Location()
+)
+    results = IR.Type[waitComplete,]
+    operands = Value[barrier, token]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.test.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.test.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -358,18 +428,24 @@ OR before the phase completes following a system-dependent time limit.
   nvgpu.mbarrier.try_wait.parity %barrier, %phase, %ticks : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>>
 ```
 """
-function mbarrier_try_wait_parity(barrier::Value, phase::Value, ticks::Value; location=Location())
+function mbarrier_try_wait_parity(
+    barrier::Value, phase::Value, ticks::Value; location=Location()
+)
     results = IR.Type[]
-    operands = Value[barrier, phase, ticks, ]
+    operands = Value[barrier, phase, ticks]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.mbarrier.try_wait.parity", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mbarrier.try_wait.parity",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -397,20 +473,35 @@ nvgpu.mma.sp.sync (%a, %b, %c) metadata (%meta) {mmaShape = [16, 8, 32]} :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sp_sync(matrixA::Value, matrixB::Value, matrixC::Value, sparseMetadata::Value; res::IR.Type, mmaShape, sparsitySelector=nothing, tf32Enabled=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrixA, matrixB, matrixC, sparseMetadata, ]
+function mma_sp_sync(
+    matrixA::Value,
+    matrixB::Value,
+    matrixC::Value,
+    sparseMetadata::Value;
+    res::IR.Type,
+    mmaShape,
+    sparsitySelector=nothing,
+    tf32Enabled=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[matrixA, matrixB, matrixC, sparseMetadata]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
-    !isnothing(sparsitySelector) && push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+    !isnothing(sparsitySelector) &&
+        push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-    
-    IR.create_operation(
-        "nvgpu.mma.sp.sync", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mma.sp.sync",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -436,19 +527,31 @@ This operation is meant to follow the semantic of described here:
     (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf32>) -> vector<2x2xf32>
 ```
 """
-function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, tf32Enabled=nothing, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrixA, matrixB, matrixC, ]
+function mma_sync(
+    matrixA::Value,
+    matrixB::Value,
+    matrixC::Value;
+    res::IR.Type,
+    mmaShape,
+    tf32Enabled=nothing,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[matrixA, matrixB, matrixC]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-    
-    IR.create_operation(
-        "nvgpu.mma.sync", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.mma.sync",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -463,18 +566,28 @@ tile shape. The descriptor is created by `nvgpu.tma.create.descriptor`
 
 The Op uses `\$barrier` mbarrier based completion mechanism.
 """
-function tma_async_load(dst::Value, barrier::Value, tensorMapDescriptor::Value, coordinates::Vector{Value}; location=Location())
+function tma_async_load(
+    dst::Value,
+    barrier::Value,
+    tensorMapDescriptor::Value,
+    coordinates::Vector{Value};
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[dst, barrier, tensorMapDescriptor, coordinates..., ]
+    operands = Value[dst, barrier, tensorMapDescriptor, coordinates...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.tma.async.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.tma.async.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -492,18 +605,24 @@ The `boxDimensions` is the size of the tiled memory region in each dimension.
 For more information see below:
 https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
 """
-function tma_create_descriptor(tensor::Value, boxDimensions::Vector{Value}; tensorMap::IR.Type, location=Location())
-    results = IR.Type[tensorMap, ]
-    operands = Value[tensor, boxDimensions..., ]
+function tma_create_descriptor(
+    tensor::Value, boxDimensions::Vector{Value}; tensorMap::IR.Type, location=Location()
+)
+    results = IR.Type[tensorMap,]
+    operands = Value[tensor, boxDimensions...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "nvgpu.tma.create.descriptor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "nvgpu.tma.create.descriptor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/NVGPU.jl
+++ b/src/Dialects/17/NVGPU.jl
@@ -1,9 +1,8 @@
 module nvgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `device_async_copy`
@@ -55,40 +54,21 @@ nvgpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(
-    dst::Value,
-    dstIndices::Vector{Value},
-    src::Value,
-    srcIndices::Vector{Value},
-    srcElements=nothing::Union{Nothing,Value};
-    asyncToken::IR.Type,
-    dstElements,
-    bypassL1=nothing,
-    location=Location(),
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[dst, dstIndices..., src, srcIndices...]
+function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}, srcElements=nothing::Union{Nothing, Value}; asyncToken::IR.Type, dstElements, bypassL1=nothing, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[dst, dstIndices..., src, srcIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dstElements", dstElements),]
+    attributes = NamedAttribute[namedattribute("dstElements", dstElements), ]
     !isnothing(srcElements) && push!(operands, srcElements)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1, length(dstIndices), 1, length(srcIndices), (srcElements == nothing) ? 0 : 1
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), (srcElements==nothing) ? 0 : 1]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-
-    return IR.create_operation(
-        "nvgpu.device_async_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,24 +92,18 @@ Groups are executed in the order they are created.
 %0 = nvgpu.device_async_create_group
   ```
 """
-function device_async_create_group(
-    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[inputTokens...,]
+function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[inputTokens..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.device_async_create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_create_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,21 +127,17 @@ nvgpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies,]
+    operands = Value[asyncDependencies, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-
-    return IR.create_operation(
-        "nvgpu.device_async_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -189,31 +159,18 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    transpose,
-    numTiles,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
-    ]
-
-    return IR.create_operation(
-        "nvgpu.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
+    
+    IR.create_operation(
+        "nvgpu.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -236,20 +193,16 @@ The `\$txCount` specifies the number of element to the expect-tx operation.
 """
 function mbarrier_arrive_expect_tx(barrier::Value, txcount::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, txcount]
+    operands = Value[barrier, txcount, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.arrive.expect_tx",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.arrive.expect_tx", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -266,24 +219,18 @@ The Op does not cause the `nvgpu.mbarrier` to complete its current phase.
   %token = nvgpu.mbarrier.arrive.noComplete %barrier, %count : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>> -> !nvgpu.mbarrier.token
 ```
 """
-function mbarrier_arrive_nocomplete(
-    barrier::Value, count::Value; token::IR.Type, location=Location()
-)
-    results = IR.Type[token,]
-    operands = Value[barrier, count]
+function mbarrier_arrive_nocomplete(barrier::Value, count::Value; token::IR.Type, location=Location())
+    results = IR.Type[token, ]
+    operands = Value[barrier, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.arrive.nocomplete",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.arrive.nocomplete", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -302,21 +249,17 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/#arrive-on-operation-on-m
 ```
 """
 function mbarrier_arrive(barrier::Value; token::IR.Type, location=Location())
-    results = IR.Type[token,]
-    operands = Value[barrier,]
+    results = IR.Type[token, ]
+    operands = Value[barrier, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.arrive",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.arrive", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -335,21 +278,17 @@ The `mbarrier` object has the following type and alignment requirements:
 ```
 """
 function mbarrier_create(; barrier::IR.Type, location=Location())
-    results = IR.Type[barrier,]
+    results = IR.Type[barrier, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -367,20 +306,16 @@ The Op initializes the `mbarrier` object with the given number of threads.
 """
 function mbarrier_init(barrier::Value, count::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, count]
+    operands = Value[barrier, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -395,24 +330,18 @@ non-blocking instruction which tests for the completion of the phase.
   %isComplete = nvgpu.mbarrier.test.wait %barrier, %token : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>>, !nvgpu.mbarrier.token
 ```
 """
-function mbarrier_test_wait(
-    barrier::Value, token::Value; waitComplete::IR.Type, location=Location()
-)
-    results = IR.Type[waitComplete,]
-    operands = Value[barrier, token]
+function mbarrier_test_wait(barrier::Value, token::Value; waitComplete::IR.Type, location=Location())
+    results = IR.Type[waitComplete, ]
+    operands = Value[barrier, token, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.test.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.test.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -429,24 +358,18 @@ OR before the phase completes following a system-dependent time limit.
   nvgpu.mbarrier.try_wait.parity %barrier, %phase, %ticks : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>>
 ```
 """
-function mbarrier_try_wait_parity(
-    barrier::Value, phase::Value, ticks::Value; location=Location()
-)
+function mbarrier_try_wait_parity(barrier::Value, phase::Value, ticks::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, phase, ticks]
+    operands = Value[barrier, phase, ticks, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.try_wait.parity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.try_wait.parity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -474,35 +397,20 @@ nvgpu.mma.sp.sync (%a, %b, %c) metadata (%meta) {mmaShape = [16, 8, 32]} :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sp_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value,
-    sparseMetadata::Value;
-    res::IR.Type,
-    mmaShape,
-    sparsitySelector=nothing,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC, sparseMetadata]
+function mma_sp_sync(matrixA::Value, matrixB::Value, matrixC::Value, sparseMetadata::Value; res::IR.Type, mmaShape, sparsitySelector=nothing, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, sparseMetadata, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
-    !isnothing(sparsitySelector) &&
-        push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    !isnothing(sparsitySelector) && push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sp.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sp.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -528,31 +436,19 @@ This operation is meant to follow the semantic of described here:
     (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf32>) -> vector<2x2xf32>
 ```
 """
-function mma_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value;
-    res::IR.Type,
-    mmaShape,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC]
+function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -567,28 +463,18 @@ tile shape. The descriptor is created by `nvgpu.tma.create.descriptor`
 
 The Op uses `\$barrier` mbarrier based completion mechanism.
 """
-function tma_async_load(
-    dst::Value,
-    barrier::Value,
-    tensorMapDescriptor::Value,
-    coordinates::Vector{Value};
-    location=Location(),
-)
+function tma_async_load(dst::Value, barrier::Value, tensorMapDescriptor::Value, coordinates::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dst, barrier, tensorMapDescriptor, coordinates...]
+    operands = Value[dst, barrier, tensorMapDescriptor, coordinates..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.tma.async.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.tma.async.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -606,24 +492,18 @@ The `boxDimensions` is the size of the tiled memory region in each dimension.
 For more information see below:
 https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
 """
-function tma_create_descriptor(
-    tensor::Value, boxDimensions::Vector{Value}; tensorMap::IR.Type, location=Location()
-)
-    results = IR.Type[tensorMap,]
-    operands = Value[tensor, boxDimensions...]
+function tma_create_descriptor(tensor::Value, boxDimensions::Vector{Value}; tensorMap::IR.Type, location=Location())
+    results = IR.Type[tensorMap, ]
+    operands = Value[tensor, boxDimensions..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.tma.create.descriptor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.tma.create.descriptor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/NVGPU.jl
+++ b/src/Dialects/17/NVGPU.jl
@@ -1,8 +1,8 @@
 module nvgpu
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `device_async_copy`
@@ -54,40 +54,21 @@ nvgpu.device_async_wait %token2
   memref<4x5xf32> to memref<2x7x5xf32, 3>
 ```
 """
-function device_async_copy(
-    dst::Value,
-    dstIndices::Vector{Value},
-    src::Value,
-    srcIndices::Vector{Value},
-    srcElements=nothing::Union{Nothing,Value};
-    asyncToken::IR.Type,
-    dstElements,
-    bypassL1=nothing,
-    location=Location(),
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[dst, dstIndices..., src, srcIndices...]
+function device_async_copy(dst::Value, dstIndices::Vector{Value}, src::Value, srcIndices::Vector{Value}, srcElements=nothing::Union{Nothing, Value}; asyncToken::IR.Type, dstElements, bypassL1=nothing, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[dst, dstIndices..., src, srcIndices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dstElements", dstElements),]
+    attributes = NamedAttribute[namedattribute("dstElements", dstElements), ]
     !isnothing(srcElements) && push!(operands, srcElements)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1, length(dstIndices), 1, length(srcIndices), (srcElements == nothing) ? 0 : 1
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([1, length(dstIndices), 1, length(srcIndices), (srcElements==nothing) ? 0 : 1]))
     !isnothing(bypassL1) && push!(attributes, namedattribute("bypassL1", bypassL1))
-
-    return IR.create_operation(
-        "nvgpu.device_async_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,24 +92,18 @@ Groups are executed in the order they are created.
 %0 = nvgpu.device_async_create_group
   ```
 """
-function device_async_create_group(
-    inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location()
-)
-    results = IR.Type[asyncToken,]
-    operands = Value[inputTokens...,]
+function device_async_create_group(inputTokens::Vector{Value}; asyncToken::IR.Type, location=Location())
+    results = IR.Type[asyncToken, ]
+    operands = Value[inputTokens..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.device_async_create_group",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_create_group", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,21 +127,17 @@ nvgpu.device_async_wait %0
 """
 function device_async_wait(asyncDependencies::Value; numGroups=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[asyncDependencies,]
+    operands = Value[asyncDependencies, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(numGroups) && push!(attributes, namedattribute("numGroups", numGroups))
-
-    return IR.create_operation(
-        "nvgpu.device_async_wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.device_async_wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -188,31 +159,18 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-mat
   memref<?x?xf16, 3> -> vector<4x2xf16>
 ```
 """
-function ldmatrix(
-    srcMemref::Value,
-    indices::Vector{Value};
-    res::IR.Type,
-    transpose,
-    numTiles,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[srcMemref, indices...]
+function ldmatrix(srcMemref::Value, indices::Vector{Value}; res::IR.Type, transpose, numTiles, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[srcMemref, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("transpose", transpose), namedattribute("numTiles", numTiles)
-    ]
-
-    return IR.create_operation(
-        "nvgpu.ldmatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transpose", transpose), namedattribute("numTiles", numTiles), ]
+    
+    IR.create_operation(
+        "nvgpu.ldmatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -235,20 +193,16 @@ The `\$txCount` specifies the number of element to the expect-tx operation.
 """
 function mbarrier_arrive_expect_tx(barrier::Value, txcount::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, txcount]
+    operands = Value[barrier, txcount, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.arrive.expect_tx",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.arrive.expect_tx", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -265,24 +219,18 @@ The Op does not cause the `nvgpu.mbarrier` to complete its current phase.
   %token = nvgpu.mbarrier.arrive.noComplete %barrier, %count : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>> -> !nvgpu.mbarrier.token
 ```
 """
-function mbarrier_arrive_nocomplete(
-    barrier::Value, count::Value; token::IR.Type, location=Location()
-)
-    results = IR.Type[token,]
-    operands = Value[barrier, count]
+function mbarrier_arrive_nocomplete(barrier::Value, count::Value; token::IR.Type, location=Location())
+    results = IR.Type[token, ]
+    operands = Value[barrier, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.arrive.nocomplete",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.arrive.nocomplete", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -301,21 +249,17 @@ https://docs.nvidia.com/cuda/parallel-thread-execution/#arrive-on-operation-on-m
 ```
 """
 function mbarrier_arrive(barrier::Value; token::IR.Type, location=Location())
-    results = IR.Type[token,]
-    operands = Value[barrier,]
+    results = IR.Type[token, ]
+    operands = Value[barrier, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.arrive",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.arrive", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,21 +278,17 @@ The `mbarrier` object has the following type and alignment requirements:
 ```
 """
 function mbarrier_create(; barrier::IR.Type, location=Location())
-    results = IR.Type[barrier,]
+    results = IR.Type[barrier, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -366,20 +306,16 @@ The Op initializes the `mbarrier` object with the given number of threads.
 """
 function mbarrier_init(barrier::Value, count::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, count]
+    operands = Value[barrier, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -394,24 +330,18 @@ non-blocking instruction which tests for the completion of the phase.
   %isComplete = nvgpu.mbarrier.test.wait %barrier, %token : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>>, !nvgpu.mbarrier.token
 ```
 """
-function mbarrier_test_wait(
-    barrier::Value, token::Value; waitComplete::IR.Type, location=Location()
-)
-    results = IR.Type[waitComplete,]
-    operands = Value[barrier, token]
+function mbarrier_test_wait(barrier::Value, token::Value; waitComplete::IR.Type, location=Location())
+    results = IR.Type[waitComplete, ]
+    operands = Value[barrier, token, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.test.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.test.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -428,24 +358,18 @@ OR before the phase completes following a system-dependent time limit.
   nvgpu.mbarrier.try_wait.parity %barrier, %phase, %ticks : !nvgpu.mbarrier.barrier<memorySpace = #gpu.address_space<workgroup>>
 ```
 """
-function mbarrier_try_wait_parity(
-    barrier::Value, phase::Value, ticks::Value; location=Location()
-)
+function mbarrier_try_wait_parity(barrier::Value, phase::Value, ticks::Value; location=Location())
     results = IR.Type[]
-    operands = Value[barrier, phase, ticks]
+    operands = Value[barrier, phase, ticks, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.mbarrier.try_wait.parity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mbarrier.try_wait.parity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -473,35 +397,20 @@ nvgpu.mma.sp.sync (%a, %b, %c) metadata (%meta) {mmaShape = [16, 8, 32]} :
   (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf16>) -> vector<2x2xf16>
 ```
 """
-function mma_sp_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value,
-    sparseMetadata::Value;
-    res::IR.Type,
-    mmaShape,
-    sparsitySelector=nothing,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC, sparseMetadata]
+function mma_sp_sync(matrixA::Value, matrixB::Value, matrixC::Value, sparseMetadata::Value; res::IR.Type, mmaShape, sparsitySelector=nothing, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, sparseMetadata, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
-    !isnothing(sparsitySelector) &&
-        push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
+    !isnothing(sparsitySelector) && push!(attributes, namedattribute("sparsitySelector", sparsitySelector))
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sp.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sp.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -527,31 +436,19 @@ This operation is meant to follow the semantic of described here:
     (vector<4x2xf16>, vector<2x2xf16>, vector<2x2xf32>) -> vector<2x2xf32>
 ```
 """
-function mma_sync(
-    matrixA::Value,
-    matrixB::Value,
-    matrixC::Value;
-    res::IR.Type,
-    mmaShape,
-    tf32Enabled=nothing,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[matrixA, matrixB, matrixC]
+function mma_sync(matrixA::Value, matrixB::Value, matrixC::Value; res::IR.Type, mmaShape, tf32Enabled=nothing, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[matrixA, matrixB, matrixC, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape),]
+    attributes = NamedAttribute[namedattribute("mmaShape", mmaShape), ]
     !isnothing(tf32Enabled) && push!(attributes, namedattribute("tf32Enabled", tf32Enabled))
-
-    return IR.create_operation(
-        "nvgpu.mma.sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.mma.sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -566,28 +463,18 @@ tile shape. The descriptor is created by `nvgpu.tma.create.descriptor`
 
 The Op uses `\$barrier` mbarrier based completion mechanism.
 """
-function tma_async_load(
-    dst::Value,
-    barrier::Value,
-    tensorMapDescriptor::Value,
-    coordinates::Vector{Value};
-    location=Location(),
-)
+function tma_async_load(dst::Value, barrier::Value, tensorMapDescriptor::Value, coordinates::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dst, barrier, tensorMapDescriptor, coordinates...]
+    operands = Value[dst, barrier, tensorMapDescriptor, coordinates..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.tma.async.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.tma.async.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -605,24 +492,18 @@ The `boxDimensions` is the size of the tiled memory region in each dimension.
 For more information see below:
 https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
 """
-function tma_create_descriptor(
-    tensor::Value, boxDimensions::Vector{Value}; tensorMap::IR.Type, location=Location()
-)
-    results = IR.Type[tensorMap,]
-    operands = Value[tensor, boxDimensions...]
+function tma_create_descriptor(tensor::Value, boxDimensions::Vector{Value}; tensorMap::IR.Type, location=Location())
+    results = IR.Type[tensorMap, ]
+    operands = Value[tensor, boxDimensions..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "nvgpu.tma.create.descriptor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "nvgpu.tma.create.descriptor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/OpenACC.jl
+++ b/src/Dialects/17/OpenACC.jl
@@ -1,8 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `attach`
@@ -26,40 +26,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function attach(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function attach(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.attach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.attach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -85,40 +69,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function copyin(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function copyin(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.copyin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.copyin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -143,37 +111,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function copyout(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function copyout(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.copyout",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.copyout", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -199,40 +154,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function create(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function create(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -273,17 +212,8 @@ integer :: array(1:10)
 acc.bounds lb(1) ub(9) extent(9) startIdx(1)
 ```
 """
-function bounds(
-    lowerbound=nothing::Union{Nothing,Value};
-    upperbound=nothing::Union{Nothing,Value},
-    extent=nothing::Union{Nothing,Value},
-    stride=nothing::Union{Nothing,Value},
-    startIdx=nothing::Union{Nothing,Value},
-    result::IR.Type,
-    strideInBytes=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
+function bounds(lowerbound=nothing::Union{Nothing, Value}; upperbound=nothing::Union{Nothing, Value}, extent=nothing::Union{Nothing, Value}, stride=nothing::Union{Nothing, Value}, startIdx=nothing::Union{Nothing, Value}, result::IR.Type, strideInBytes=nothing, location=Location())
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
@@ -293,36 +223,14 @@ function bounds(
     !isnothing(extent) && push!(operands, extent)
     !isnothing(stride) && push!(operands, stride)
     !isnothing(startIdx) && push!(operands, startIdx)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (lowerbound == nothing)
-                0
-            elseif 1(upperbound == nothing)
-                0
-            elseif 1(extent == nothing)
-                0
-            elseif 1(stride == nothing)
-                0
-            elseif 1(startIdx == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(strideInBytes) &&
-        push!(attributes, namedattribute("strideInBytes", strideInBytes))
-
-    return IR.create_operation(
-        "acc.bounds",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(lowerbound==nothing) ? 0 : 1(upperbound==nothing) ? 0 : 1(extent==nothing) ? 0 : 1(stride==nothing) ? 0 : 1(startIdx==nothing) ? 0 : 1]))
+    !isnothing(strideInBytes) && push!(attributes, namedattribute("strideInBytes", strideInBytes))
+    
+    IR.create_operation(
+        "acc.bounds", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -344,54 +252,25 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    async=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; async=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands...]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(async) && push!(operands, async)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(async == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(async==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,40 +296,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function declare_device_resident(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function declare_device_resident(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.declare_device_resident",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_device_resident", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,20 +333,16 @@ acc.declare_enter dataOperands(%0 : !llvm.ptr<f32>)
 """
 function declare_enter(dataClauseOperands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands...,]
+    operands = Value[dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.declare_enter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_enter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -504,20 +363,16 @@ acc.delete accPtr(%0 : !llvm.ptr<f32>) {dataClause = #acc<data_clause declare_de
 """
 function declare_exit(dataClauseOperands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands...,]
+    operands = Value[dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.declare_exit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_exit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -543,40 +398,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function declare_link(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function declare_link(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.declare_link",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_link", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -601,37 +440,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function delete(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function delete(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.delete",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.delete", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -656,37 +482,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function detach(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function detach(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.detach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.detach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -712,40 +525,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function deviceptr(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function deviceptr(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.deviceptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.deviceptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -760,51 +557,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands...]
+    operands = Value[waitOperands..., dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -819,53 +589,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands...]
+    operands = Value[waitOperands..., dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -891,40 +633,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function firstprivate(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function firstprivate(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.firstprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.firstprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -972,31 +698,18 @@ acc.parallel firstprivate(@privatization_f32 -> %a : f32) {
 }
 ```
 """
-function firstprivate_recipe(;
-    sym_name,
-    type,
-    initRegion::Region,
-    copyRegion::Region,
-    destroyRegion::Region,
-    location=Location(),
-)
+function firstprivate_recipe(; sym_name, type, initRegion::Region, copyRegion::Region, destroyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, copyRegion, destroyRegion]
+    owned_regions = Region[initRegion, copyRegion, destroyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "acc.firstprivate.recipe",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "acc.firstprivate.recipe", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1028,40 +741,24 @@ that is any of the valid `mlir::acc::DataClause` entries.
     done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
     - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function getdeviceptr(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function getdeviceptr(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.getdeviceptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.getdeviceptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1089,19 +786,15 @@ acc.global_ctor @acc_constructor {
 function global_ctor(; sym_name, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "acc.global_ctor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "acc.global_ctor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1130,19 +823,15 @@ acc.global_dtor @acc_destructor {
 function global_dtor(; sym_name, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "acc.global_dtor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "acc.global_dtor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1160,34 +849,21 @@ acc.host_data dataOperands(%0 : !llvm.ptr<f32>) {
 }
 ```
 """
-function host_data(
-    ifCond=nothing::Union{Nothing,Value};
-    dataClauseOperands::Vector{Value},
-    ifPresent=nothing,
-    region::Region,
-    location=Location(),
-)
+function host_data(ifCond=nothing::Union{Nothing, Value}; dataClauseOperands::Vector{Value}, ifPresent=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands...,]
-    owned_regions = Region[region,]
+    operands = Value[dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([(ifCond == nothing) ? 0 : 1length(dataClauseOperands)]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(dataClauseOperands), ]))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.host_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.host_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1204,42 +880,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1259,25 +914,10 @@ acc.kernels num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function kernels(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs::Vector{Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function kernels(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs::Vector{Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., numGangs..., dataClauseOperands...]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., numGangs..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -1285,38 +925,17 @@ function kernels(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            length(numGangs),
-            if (numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(dataClauseOperands)
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), length(numGangs), (numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.kernels",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.kernels", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1340,31 +959,10 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangDim=nothing::Union{Nothing,Value},
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    hasGang=nothing,
-    hasWorker=nothing,
-    hasVector=nothing,
-    privatizations=nothing,
-    reductionRecipes=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangDim=nothing::Union{Nothing, Value}, gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, hasGang=nothing, hasWorker=nothing, hasVector=nothing, privatizations=nothing, reductionRecipes=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
@@ -1372,26 +970,7 @@ function loop(
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangDim == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangDim==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
@@ -1399,20 +978,14 @@ function loop(
     !isnothing(hasGang) && push!(attributes, namedattribute("hasGang", hasGang))
     !isnothing(hasWorker) && push!(attributes, namedattribute("hasWorker", hasWorker))
     !isnothing(hasVector) && push!(attributes, namedattribute("hasVector", hasVector))
-    !isnothing(privatizations) &&
-        push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(reductionRecipes) &&
-        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1438,40 +1011,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function nocreate(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function nocreate(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.nocreate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.nocreate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1490,38 +1047,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs::Vector{Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionRecipes=nothing,
-    privatizations=nothing,
-    firstprivatizations=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs::Vector{Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionRecipes=nothing, privatizations=nothing, firstprivatizations=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        numGangs...,
-        reductionOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-        dataClauseOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., numGangs..., reductionOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -1529,47 +1058,20 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            length(numGangs),
-            if (numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), length(numGangs), (numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
-    !isnothing(reductionRecipes) &&
-        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    !isnothing(privatizations) &&
-        push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(firstprivatizations) &&
-        push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
+    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(firstprivatizations) && push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1595,40 +1097,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function present(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function present(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.present",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.present", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1654,40 +1140,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function private(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function private(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.private",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.private", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1727,26 +1197,18 @@ acc.parallel private(@privatization_f32 -> %a : f32) {
 }
 ```
 """
-function private_recipe(;
-    sym_name, type, initRegion::Region, destroyRegion::Region, location=Location()
-)
+function private_recipe(; sym_name, type, initRegion::Region, destroyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, destroyRegion]
+    owned_regions = Region[initRegion, destroyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "acc.private.recipe",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "acc.private.recipe", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1772,40 +1234,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function reduction(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function reduction(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1867,33 +1313,18 @@ according to OpenACC 3.3:
 |          |            |  .neqv.  |   .false.   |
 -------------------------------------------------|
 """
-function reduction_recipe(;
-    sym_name,
-    type,
-    reductionOperator,
-    initRegion::Region,
-    combinerRegion::Region,
-    location=Location(),
-)
+function reduction_recipe(; sym_name, type, reductionOperator, initRegion::Region, combinerRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, combinerRegion]
+    owned_regions = Region[initRegion, combinerRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("type", type),
-        namedattribute("reductionOperator", reductionOperator),
-    ]
-
-    return IR.create_operation(
-        "acc.reduction.recipe",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), namedattribute("reductionOperator", reductionOperator), ]
+    
+    IR.create_operation(
+        "acc.reduction.recipe", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1911,75 +1342,29 @@ acc.serial private(%c : memref<10xf32>) {
 }
 ```
 """
-function serial(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionRecipes=nothing,
-    privatizations=nothing,
-    firstprivatizations=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function serial(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionRecipes=nothing, privatizations=nothing, firstprivatizations=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-        dataClauseOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
-    !isnothing(reductionRecipes) &&
-        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    !isnothing(privatizations) &&
-        push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(firstprivatizations) &&
-        push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
+    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(firstprivatizations) && push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.serial",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.serial", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1996,42 +1381,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2049,16 +1413,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2084,40 +1444,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function update_device(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function update_device(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.update_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2142,37 +1486,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function update_host(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function update_host(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.update_host",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update_host", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2190,55 +1521,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., deviceTypeOperands..., dataClauseOperands...]
+    operands = Value[waitOperands..., deviceTypeOperands..., dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(dataClauseOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2264,40 +1565,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function use_device(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function use_device(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.use_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.use_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2314,48 +1599,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2366,22 +1626,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/OpenACC.jl
+++ b/src/Dialects/17/OpenACC.jl
@@ -1,9 +1,8 @@
 module acc
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `attach`
@@ -27,40 +26,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function attach(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function attach(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.attach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.attach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -86,40 +69,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function copyin(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function copyin(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.copyin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.copyin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -144,37 +111,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function copyout(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function copyout(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.copyout",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.copyout", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -200,40 +154,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function create(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function create(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.create",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.create", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -274,17 +212,8 @@ integer :: array(1:10)
 acc.bounds lb(1) ub(9) extent(9) startIdx(1)
 ```
 """
-function bounds(
-    lowerbound=nothing::Union{Nothing,Value};
-    upperbound=nothing::Union{Nothing,Value},
-    extent=nothing::Union{Nothing,Value},
-    stride=nothing::Union{Nothing,Value},
-    startIdx=nothing::Union{Nothing,Value},
-    result::IR.Type,
-    strideInBytes=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
+function bounds(lowerbound=nothing::Union{Nothing, Value}; upperbound=nothing::Union{Nothing, Value}, extent=nothing::Union{Nothing, Value}, stride=nothing::Union{Nothing, Value}, startIdx=nothing::Union{Nothing, Value}, result::IR.Type, strideInBytes=nothing, location=Location())
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
@@ -294,33 +223,14 @@ function bounds(
     !isnothing(extent) && push!(operands, extent)
     !isnothing(stride) && push!(operands, stride)
     !isnothing(startIdx) && push!(operands, startIdx)
-    push!(attributes, operandsegmentsizes([
-        if (lowerbound == nothing)
-            0
-        elseif 1(upperbound == nothing)
-            0
-        elseif 1(extent == nothing)
-            0
-        elseif 1(stride == nothing)
-            0
-        elseif 1(startIdx == nothing)
-            0
-        else
-            1
-        end,
-    ]))
-    !isnothing(strideInBytes) &&
-        push!(attributes, namedattribute("strideInBytes", strideInBytes))
-
-    return IR.create_operation(
-        "acc.bounds",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(lowerbound==nothing) ? 0 : 1(upperbound==nothing) ? 0 : 1(extent==nothing) ? 0 : 1(stride==nothing) ? 0 : 1(startIdx==nothing) ? 0 : 1]))
+    !isnothing(strideInBytes) && push!(attributes, namedattribute("strideInBytes", strideInBytes))
+    
+    IR.create_operation(
+        "acc.bounds", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -342,54 +252,25 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(
-    ifCond=nothing::Union{Nothing,Value};
-    async=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function data(ifCond=nothing::Union{Nothing, Value}; async=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands...]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(async) && push!(operands, async)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(async == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(async==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -415,40 +296,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function declare_device_resident(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function declare_device_resident(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.declare_device_resident",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_device_resident", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -468,20 +333,16 @@ acc.declare_enter dataOperands(%0 : !llvm.ptr<f32>)
 """
 function declare_enter(dataClauseOperands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands...,]
+    operands = Value[dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.declare_enter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_enter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,20 +363,16 @@ acc.delete accPtr(%0 : !llvm.ptr<f32>) {dataClause = #acc<data_clause declare_de
 """
 function declare_exit(dataClauseOperands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands...,]
+    operands = Value[dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.declare_exit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_exit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -541,40 +398,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function declare_link(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function declare_link(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.declare_link",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.declare_link", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -599,37 +440,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function delete(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function delete(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.delete",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.delete", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -654,37 +482,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function detach(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function detach(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.detach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.detach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,40 +525,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function deviceptr(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function deviceptr(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.deviceptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.deviceptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -758,51 +557,24 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    location=Location(),
-)
+function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands...]
+    operands = Value[waitOperands..., dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-
-    return IR.create_operation(
-        "acc.enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -817,53 +589,25 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    finalize=nothing,
-    location=Location(),
-)
+function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands...]
+    operands = Value[waitOperands..., dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-
-    return IR.create_operation(
-        "acc.exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -889,40 +633,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function firstprivate(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function firstprivate(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.firstprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.firstprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -970,31 +698,18 @@ acc.parallel firstprivate(@privatization_f32 -> %a : f32) {
 }
 ```
 """
-function firstprivate_recipe(;
-    sym_name,
-    type,
-    initRegion::Region,
-    copyRegion::Region,
-    destroyRegion::Region,
-    location=Location(),
-)
+function firstprivate_recipe(; sym_name, type, initRegion::Region, copyRegion::Region, destroyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, copyRegion, destroyRegion]
+    owned_regions = Region[initRegion, copyRegion, destroyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "acc.firstprivate.recipe",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "acc.firstprivate.recipe", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1026,40 +741,24 @@ that is any of the valid `mlir::acc::DataClause` entries.
     done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
     - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function getdeviceptr(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function getdeviceptr(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.getdeviceptr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.getdeviceptr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1087,19 +786,15 @@ acc.global_ctor @acc_constructor {
 function global_ctor(; sym_name, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "acc.global_ctor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "acc.global_ctor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1128,19 +823,15 @@ acc.global_dtor @acc_destructor {
 function global_dtor(; sym_name, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
-
-    return IR.create_operation(
-        "acc.global_dtor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    
+    IR.create_operation(
+        "acc.global_dtor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1158,34 +849,21 @@ acc.host_data dataOperands(%0 : !llvm.ptr<f32>) {
 }
 ```
 """
-function host_data(
-    ifCond=nothing::Union{Nothing,Value};
-    dataClauseOperands::Vector{Value},
-    ifPresent=nothing,
-    region::Region,
-    location=Location(),
-)
+function host_data(ifCond=nothing::Union{Nothing, Value}; dataClauseOperands::Vector{Value}, ifPresent=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands...,]
-    owned_regions = Region[region,]
+    operands = Value[dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([(ifCond == nothing) ? 0 : 1length(dataClauseOperands)]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(dataClauseOperands), ]))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.host_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.host_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1202,42 +880,21 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1257,25 +914,10 @@ acc.kernels num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function kernels(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs::Vector{Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function kernels(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs::Vector{Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., numGangs..., dataClauseOperands...]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., numGangs..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -1283,38 +925,17 @@ function kernels(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            length(numGangs),
-            if (numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(dataClauseOperands)
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), length(numGangs), (numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.kernels",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.kernels", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1338,31 +959,10 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(
-    gangNum=nothing::Union{Nothing,Value};
-    gangDim=nothing::Union{Nothing,Value},
-    gangStatic=nothing::Union{Nothing,Value},
-    workerNum=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    tileOperands::Vector{Value},
-    privateOperands::Vector{Value},
-    reductionOperands::Vector{Value},
-    results::Vector{IR.Type},
-    collapse=nothing,
-    seq=nothing,
-    independent=nothing,
-    auto_=nothing,
-    hasGang=nothing,
-    hasWorker=nothing,
-    hasVector=nothing,
-    privatizations=nothing,
-    reductionRecipes=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
-    owned_regions = Region[region,]
+function loop(gangNum=nothing::Union{Nothing, Value}; gangDim=nothing::Union{Nothing, Value}, gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, hasGang=nothing, hasWorker=nothing, hasVector=nothing, privatizations=nothing, reductionRecipes=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
@@ -1370,26 +970,7 @@ function loop(
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (gangNum == nothing)
-                0
-            elseif 1(gangDim == nothing)
-                0
-            elseif 1(gangStatic == nothing)
-                0
-            elseif 1(workerNum == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            else
-                1length(tileOperands)
-            end,
-            length(privateOperands),
-            length(reductionOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangDim==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
@@ -1397,20 +978,14 @@ function loop(
     !isnothing(hasGang) && push!(attributes, namedattribute("hasGang", hasGang))
     !isnothing(hasWorker) && push!(attributes, namedattribute("hasWorker", hasWorker))
     !isnothing(hasVector) && push!(attributes, namedattribute("hasVector", hasVector))
-    !isnothing(privatizations) &&
-        push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(reductionRecipes) &&
-        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-
-    return IR.create_operation(
-        "acc.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    
+    IR.create_operation(
+        "acc.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1436,40 +1011,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function nocreate(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function nocreate(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.nocreate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.nocreate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1488,38 +1047,10 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    numGangs::Vector{Value},
-    numWorkers=nothing::Union{Nothing,Value},
-    vectorLength=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionRecipes=nothing,
-    privatizations=nothing,
-    firstprivatizations=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs::Vector{Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionRecipes=nothing, privatizations=nothing, firstprivatizations=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        numGangs...,
-        reductionOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-        dataClauseOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., numGangs..., reductionOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -1527,47 +1058,20 @@ function parallel(
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            length(numGangs),
-            if (numWorkers == nothing)
-                0
-            elseif 1(vectorLength == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), length(numGangs), (numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
-    !isnothing(reductionRecipes) &&
-        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    !isnothing(privatizations) &&
-        push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(firstprivatizations) &&
-        push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
+    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(firstprivatizations) && push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1593,40 +1097,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function present(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function present(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.present",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.present", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1652,40 +1140,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function private(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function private(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.private",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.private", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1725,26 +1197,18 @@ acc.parallel private(@privatization_f32 -> %a : f32) {
 }
 ```
 """
-function private_recipe(;
-    sym_name, type, initRegion::Region, destroyRegion::Region, location=Location()
-)
+function private_recipe(; sym_name, type, initRegion::Region, destroyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, destroyRegion]
+    owned_regions = Region[initRegion, destroyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "acc.private.recipe",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "acc.private.recipe", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1770,40 +1234,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function reduction(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function reduction(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1865,33 +1313,18 @@ according to OpenACC 3.3:
 |          |            |  .neqv.  |   .false.   |
 -------------------------------------------------|
 """
-function reduction_recipe(;
-    sym_name,
-    type,
-    reductionOperator,
-    initRegion::Region,
-    combinerRegion::Region,
-    location=Location(),
-)
+function reduction_recipe(; sym_name, type, reductionOperator, initRegion::Region, combinerRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, combinerRegion]
+    owned_regions = Region[initRegion, combinerRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name),
-        namedattribute("type", type),
-        namedattribute("reductionOperator", reductionOperator),
-    ]
-
-    return IR.create_operation(
-        "acc.reduction.recipe",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), namedattribute("reductionOperator", reductionOperator), ]
+    
+    IR.create_operation(
+        "acc.reduction.recipe", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1909,75 +1342,29 @@ acc.serial private(%c : memref<10xf32>) {
 }
 ```
 """
-function serial(
-    async=nothing::Union{Nothing,Value};
-    waitOperands::Vector{Value},
-    ifCond=nothing::Union{Nothing,Value},
-    selfCond=nothing::Union{Nothing,Value},
-    reductionOperands::Vector{Value},
-    gangPrivateOperands::Vector{Value},
-    gangFirstPrivateOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    asyncAttr=nothing,
-    waitAttr=nothing,
-    selfAttr=nothing,
-    reductionRecipes=nothing,
-    privatizations=nothing,
-    firstprivatizations=nothing,
-    defaultAttr=nothing,
-    region::Region,
-    location=Location(),
-)
+function serial(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionRecipes=nothing, privatizations=nothing, firstprivatizations=nothing, defaultAttr=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        waitOperands...,
-        reductionOperands...,
-        gangPrivateOperands...,
-        gangFirstPrivateOperands...,
-        dataClauseOperands...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[waitOperands..., reductionOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., dataClauseOperands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            (async == nothing) ? 0 : 1length(waitOperands),
-            if (ifCond == nothing)
-                0
-            elseif 1(selfCond == nothing)
-                0
-            else
-                1length(reductionOperands)
-            end,
-            length(gangPrivateOperands),
-            length(gangFirstPrivateOperands),
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), length(dataClauseOperands), ]))
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
-    !isnothing(reductionRecipes) &&
-        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    !isnothing(privatizations) &&
-        push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(firstprivatizations) &&
-        push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
+    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(firstprivatizations) && push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-
-    return IR.create_operation(
-        "acc.serial",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.serial", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1994,42 +1381,21 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(
-    deviceTypeOperands::Vector{Value},
-    deviceNumOperand=nothing::Union{Nothing,Value};
-    ifCond=nothing::Union{Nothing,Value},
-    location=Location(),
-)
+function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
     results = IR.Type[]
-    operands = Value[deviceTypeOperands...,]
+    operands = Value[deviceTypeOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(deviceTypeOperands),
-            if (deviceNumOperand == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-
-    return IR.create_operation(
-        "acc.shutdown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    
+    IR.create_operation(
+        "acc.shutdown", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2047,16 +1413,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2082,40 +1444,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function update_device(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function update_device(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.update_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2140,37 +1486,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function update_host(
-    accPtr::Value,
-    varPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
+function update_host(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[accPtr, bounds...]
+    operands = Value[accPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
+    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.update_host",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update_host", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2188,55 +1521,25 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(
-    ifCond=nothing::Union{Nothing,Value};
-    asyncOperand=nothing::Union{Nothing,Value},
-    waitDevnum=nothing::Union{Nothing,Value},
-    waitOperands::Vector{Value},
-    deviceTypeOperands::Vector{Value},
-    dataClauseOperands::Vector{Value},
-    async=nothing,
-    wait=nothing,
-    ifPresent=nothing,
-    location=Location(),
-)
+function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands..., deviceTypeOperands..., dataClauseOperands...]
+    operands = Value[waitOperands..., deviceTypeOperands..., dataClauseOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (ifCond == nothing)
-                0
-            elseif 1(asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            else
-                1length(waitOperands)
-            end,
-            length(deviceTypeOperands),
-            length(dataClauseOperands),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(dataClauseOperands), ]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-
-    return IR.create_operation(
-        "acc.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2262,40 +1565,24 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function use_device(
-    varPtr::Value,
-    varPtrPtr=nothing::Union{Nothing,Value};
-    bounds::Vector{Value},
-    accPtr::IR.Type,
-    dataClause=nothing,
-    structured=nothing,
-    implicit=nothing,
-    name=nothing,
-    location=Location(),
-)
-    results = IR.Type[accPtr,]
-    operands = Value[varPtr, bounds...]
+function use_device(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+    results = IR.Type[accPtr, ]
+    operands = Value[varPtr, bounds..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(
-        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
-    )
+    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "acc.use_device",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.use_device", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2312,48 +1599,23 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(
-    waitOperands::Vector{Value},
-    asyncOperand=nothing::Union{Nothing,Value};
-    waitDevnum=nothing::Union{Nothing,Value},
-    ifCond=nothing::Union{Nothing,Value},
-    async=nothing,
-    location=Location(),
-)
+function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[waitOperands...,]
+    operands = Value[waitOperands..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(waitOperands),
-            if (asyncOperand == nothing)
-                0
-            elseif 1(waitDevnum == nothing)
-                0
-            elseif 1(ifCond == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-
-    return IR.create_operation(
-        "acc.wait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.wait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2364,22 +1626,18 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "acc.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "acc.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/OpenACC.jl
+++ b/src/Dialects/17/OpenACC.jl
@@ -1,8 +1,8 @@
 module acc
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `attach`
@@ -26,24 +26,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function attach(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function attach(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.attach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.attach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,24 +85,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function copyin(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function copyin(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.copyin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.copyin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -111,24 +143,37 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function copyout(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+function copyout(
+    accPtr::Value,
+    varPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[accPtr, bounds..., ]
+    operands = Value[accPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.copyout", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.copyout",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -154,24 +199,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function create(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function create(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.create", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.create",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -212,8 +273,17 @@ integer :: array(1:10)
 acc.bounds lb(1) ub(9) extent(9) startIdx(1)
 ```
 """
-function bounds(lowerbound=nothing::Union{Nothing, Value}; upperbound=nothing::Union{Nothing, Value}, extent=nothing::Union{Nothing, Value}, stride=nothing::Union{Nothing, Value}, startIdx=nothing::Union{Nothing, Value}, result::IR.Type, strideInBytes=nothing, location=Location())
-    results = IR.Type[result, ]
+function bounds(
+    lowerbound=nothing::Union{Nothing,Value};
+    upperbound=nothing::Union{Nothing,Value},
+    extent=nothing::Union{Nothing,Value},
+    stride=nothing::Union{Nothing,Value},
+    startIdx=nothing::Union{Nothing,Value},
+    result::IR.Type,
+    strideInBytes=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
@@ -223,14 +293,36 @@ function bounds(lowerbound=nothing::Union{Nothing, Value}; upperbound=nothing::U
     !isnothing(extent) && push!(operands, extent)
     !isnothing(stride) && push!(operands, stride)
     !isnothing(startIdx) && push!(operands, startIdx)
-    push!(attributes, operandsegmentsizes([(lowerbound==nothing) ? 0 : 1(upperbound==nothing) ? 0 : 1(extent==nothing) ? 0 : 1(stride==nothing) ? 0 : 1(startIdx==nothing) ? 0 : 1]))
-    !isnothing(strideInBytes) && push!(attributes, namedattribute("strideInBytes", strideInBytes))
-    
-    IR.create_operation(
-        "acc.bounds", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (lowerbound == nothing)
+                0
+            elseif 1(upperbound == nothing)
+                0
+            elseif 1(extent == nothing)
+                0
+            elseif 1(stride == nothing)
+                0
+            elseif 1(startIdx == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+    !isnothing(strideInBytes) &&
+        push!(attributes, namedattribute("strideInBytes", strideInBytes))
+
+    return IR.create_operation(
+        "acc.bounds",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -252,25 +344,54 @@ acc.data present(%a: memref<10x10xf32>, %b: memref<10x10xf32>,
 }
 ```
 """
-function data(ifCond=nothing::Union{Nothing, Value}; async=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, defaultAttr=nothing, region::Region, location=Location())
+function data(
+    ifCond=nothing::Union{Nothing,Value};
+    async=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    dataClauseOperands::Vector{Value},
+    asyncAttr=nothing,
+    waitAttr=nothing,
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[waitOperands..., dataClauseOperands...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(async) && push!(operands, async)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(async==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(async == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(dataClauseOperands),
+        ]),
+    )
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -296,24 +417,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function declare_device_resident(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function declare_device_resident(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.declare_device_resident", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.declare_device_resident",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -333,16 +470,20 @@ acc.declare_enter dataOperands(%0 : !llvm.ptr<f32>)
 """
 function declare_enter(dataClauseOperands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands..., ]
+    operands = Value[dataClauseOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.declare_enter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.declare_enter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -363,16 +504,20 @@ acc.delete accPtr(%0 : !llvm.ptr<f32>) {dataClause = #acc<data_clause declare_de
 """
 function declare_exit(dataClauseOperands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[dataClauseOperands..., ]
+    operands = Value[dataClauseOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.declare_exit", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.declare_exit",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -398,24 +543,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function declare_link(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function declare_link(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.declare_link", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.declare_link",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -440,24 +601,37 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function delete(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+function delete(
+    accPtr::Value,
+    varPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[accPtr, bounds..., ]
+    operands = Value[accPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.delete", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.delete",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -482,24 +656,37 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function detach(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+function detach(
+    accPtr::Value,
+    varPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[accPtr, bounds..., ]
+    operands = Value[accPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.detach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.detach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -525,24 +712,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function deviceptr(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function deviceptr(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.deviceptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.deviceptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -557,24 +760,51 @@ The \"acc.enter_data\" operation represents the OpenACC enter data directive.
 acc.enter_data create(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function enter_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, location=Location())
+function enter_data(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    dataClauseOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands..., ]
+    operands = Value[waitOperands..., dataClauseOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(dataClauseOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
-    
-    IR.create_operation(
-        "acc.enter_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.enter_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -589,25 +819,53 @@ The \"acc.exit_data\" operation represents the OpenACC exit data directive.
 acc.exit_data delete(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function exit_data(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, finalize=nothing, location=Location())
+function exit_data(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    dataClauseOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    finalize=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., dataClauseOperands..., ]
+    operands = Value[waitOperands..., dataClauseOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(dataClauseOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(finalize) && push!(attributes, namedattribute("finalize", finalize))
-    
-    IR.create_operation(
-        "acc.exit_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.exit_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -633,24 +891,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function firstprivate(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function firstprivate(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.firstprivate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.firstprivate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -698,18 +972,31 @@ acc.parallel firstprivate(@privatization_f32 -> %a : f32) {
 }
 ```
 """
-function firstprivate_recipe(; sym_name, type, initRegion::Region, copyRegion::Region, destroyRegion::Region, location=Location())
+function firstprivate_recipe(;
+    sym_name,
+    type,
+    initRegion::Region,
+    copyRegion::Region,
+    destroyRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, copyRegion, destroyRegion, ]
+    owned_regions = Region[initRegion, copyRegion, destroyRegion]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "acc.firstprivate.recipe", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+
+    return IR.create_operation(
+        "acc.firstprivate.recipe",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -741,24 +1028,40 @@ that is any of the valid `mlir::acc::DataClause` entries.
     done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
     - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function getdeviceptr(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function getdeviceptr(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.getdeviceptr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.getdeviceptr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -786,15 +1089,19 @@ acc.global_ctor @acc_constructor {
 function global_ctor(; sym_name, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "acc.global_ctor", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "acc.global_ctor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -823,15 +1130,19 @@ acc.global_dtor @acc_destructor {
 function global_dtor(; sym_name, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
-    
-    IR.create_operation(
-        "acc.global_dtor", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+
+    return IR.create_operation(
+        "acc.global_dtor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -849,21 +1160,34 @@ acc.host_data dataOperands(%0 : !llvm.ptr<f32>) {
 }
 ```
 """
-function host_data(ifCond=nothing::Union{Nothing, Value}; dataClauseOperands::Vector{Value}, ifPresent=nothing, region::Region, location=Location())
+function host_data(
+    ifCond=nothing::Union{Nothing,Value};
+    dataClauseOperands::Vector{Value},
+    ifPresent=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[dataClauseOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[dataClauseOperands...,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([(ifCond == nothing) ? 0 : 1length(dataClauseOperands)]),
+    )
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-    
-    IR.create_operation(
-        "acc.host_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.host_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -880,21 +1204,42 @@ acc.init
 acc.init device_num(%dev1 : i32)
 ```
 """
-function init(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
+function init(
+    deviceTypeOperands::Vector{Value},
+    deviceNumOperand=nothing::Union{Nothing,Value};
+    ifCond=nothing::Union{Nothing,Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[deviceTypeOperands..., ]
+    operands = Value[deviceTypeOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
-    
-    IR.create_operation(
-        "acc.init", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(deviceTypeOperands),
+            if (deviceNumOperand == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+
+    return IR.create_operation(
+        "acc.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -914,10 +1259,25 @@ acc.kernels num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function kernels(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs::Vector{Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, defaultAttr=nothing, region::Region, location=Location())
+function kernels(
+    async=nothing::Union{Nothing,Value};
+    waitOperands::Vector{Value},
+    numGangs::Vector{Value},
+    numWorkers=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    selfCond=nothing::Union{Nothing,Value},
+    dataClauseOperands::Vector{Value},
+    asyncAttr=nothing,
+    waitAttr=nothing,
+    selfAttr=nothing,
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., numGangs..., dataClauseOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[waitOperands..., numGangs..., dataClauseOperands...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -925,17 +1285,38 @@ function kernels(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Valu
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), length(numGangs), (numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (async == nothing) ? 0 : 1length(waitOperands),
+            length(numGangs),
+            if (numWorkers == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            elseif 1(selfCond == nothing)
+                0
+            else
+                1length(dataClauseOperands)
+            end,
+        ]),
+    )
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.kernels", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.kernels",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -959,10 +1340,31 @@ acc.loop gang vector {
 } attributes { collapse = 3 }
 ```
 """
-function loop(gangNum=nothing::Union{Nothing, Value}; gangDim=nothing::Union{Nothing, Value}, gangStatic=nothing::Union{Nothing, Value}, workerNum=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, tileOperands::Vector{Value}, privateOperands::Vector{Value}, reductionOperands::Vector{Value}, results_::Vector{IR.Type}, collapse=nothing, seq=nothing, independent=nothing, auto_=nothing, hasGang=nothing, hasWorker=nothing, hasVector=nothing, privatizations=nothing, reductionRecipes=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[tileOperands..., privateOperands..., reductionOperands..., ]
-    owned_regions = Region[region, ]
+function loop(
+    gangNum=nothing::Union{Nothing,Value};
+    gangDim=nothing::Union{Nothing,Value},
+    gangStatic=nothing::Union{Nothing,Value},
+    workerNum=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    tileOperands::Vector{Value},
+    privateOperands::Vector{Value},
+    reductionOperands::Vector{Value},
+    results::Vector{IR.Type},
+    collapse=nothing,
+    seq=nothing,
+    independent=nothing,
+    auto_=nothing,
+    hasGang=nothing,
+    hasWorker=nothing,
+    hasVector=nothing,
+    privatizations=nothing,
+    reductionRecipes=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[tileOperands..., privateOperands..., reductionOperands...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(gangNum) && push!(operands, gangNum)
@@ -970,7 +1372,26 @@ function loop(gangNum=nothing::Union{Nothing, Value}; gangDim=nothing::Union{Not
     !isnothing(gangStatic) && push!(operands, gangStatic)
     !isnothing(workerNum) && push!(operands, workerNum)
     !isnothing(vectorLength) && push!(operands, vectorLength)
-    push!(attributes, operandsegmentsizes([(gangNum==nothing) ? 0 : 1(gangDim==nothing) ? 0 : 1(gangStatic==nothing) ? 0 : 1(workerNum==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1length(tileOperands), length(privateOperands), length(reductionOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (gangNum == nothing)
+                0
+            elseif 1(gangDim == nothing)
+                0
+            elseif 1(gangStatic == nothing)
+                0
+            elseif 1(workerNum == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            else
+                1length(tileOperands)
+            end,
+            length(privateOperands),
+            length(reductionOperands),
+        ]),
+    )
     !isnothing(collapse) && push!(attributes, namedattribute("collapse", collapse))
     !isnothing(seq) && push!(attributes, namedattribute("seq", seq))
     !isnothing(independent) && push!(attributes, namedattribute("independent", independent))
@@ -978,14 +1399,20 @@ function loop(gangNum=nothing::Union{Nothing, Value}; gangDim=nothing::Union{Not
     !isnothing(hasGang) && push!(attributes, namedattribute("hasGang", hasGang))
     !isnothing(hasWorker) && push!(attributes, namedattribute("hasWorker", hasWorker))
     !isnothing(hasVector) && push!(attributes, namedattribute("hasVector", hasVector))
-    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    
-    IR.create_operation(
-        "acc.loop", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(privatizations) &&
+        push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(reductionRecipes) &&
+        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+
+    return IR.create_operation(
+        "acc.loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1011,24 +1438,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function nocreate(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function nocreate(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.nocreate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.nocreate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1047,10 +1490,38 @@ acc.parallel num_gangs(%c10) num_workers(%c10)
 }
 ```
 """
-function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, numGangs::Vector{Value}, numWorkers=nothing::Union{Nothing, Value}, vectorLength=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionRecipes=nothing, privatizations=nothing, firstprivatizations=nothing, defaultAttr=nothing, region::Region, location=Location())
+function parallel(
+    async=nothing::Union{Nothing,Value};
+    waitOperands::Vector{Value},
+    numGangs::Vector{Value},
+    numWorkers=nothing::Union{Nothing,Value},
+    vectorLength=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    selfCond=nothing::Union{Nothing,Value},
+    reductionOperands::Vector{Value},
+    gangPrivateOperands::Vector{Value},
+    gangFirstPrivateOperands::Vector{Value},
+    dataClauseOperands::Vector{Value},
+    asyncAttr=nothing,
+    waitAttr=nothing,
+    selfAttr=nothing,
+    reductionRecipes=nothing,
+    privatizations=nothing,
+    firstprivatizations=nothing,
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., numGangs..., reductionOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., dataClauseOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        waitOperands...,
+        numGangs...,
+        reductionOperands...,
+        gangPrivateOperands...,
+        gangFirstPrivateOperands...,
+        dataClauseOperands...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
@@ -1058,20 +1529,47 @@ function parallel(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Val
     !isnothing(vectorLength) && push!(operands, vectorLength)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), length(numGangs), (numWorkers==nothing) ? 0 : 1(vectorLength==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (async == nothing) ? 0 : 1length(waitOperands),
+            length(numGangs),
+            if (numWorkers == nothing)
+                0
+            elseif 1(vectorLength == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            elseif 1(selfCond == nothing)
+                0
+            else
+                1length(reductionOperands)
+            end,
+            length(gangPrivateOperands),
+            length(gangFirstPrivateOperands),
+            length(dataClauseOperands),
+        ]),
+    )
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
-    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(firstprivatizations) && push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
+    !isnothing(reductionRecipes) &&
+        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    !isnothing(privatizations) &&
+        push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(firstprivatizations) &&
+        push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.parallel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1097,24 +1595,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function present(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function present(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.present", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.present",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1140,24 +1654,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function private(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function private(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.private", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.private",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1197,18 +1727,26 @@ acc.parallel private(@privatization_f32 -> %a : f32) {
 }
 ```
 """
-function private_recipe(; sym_name, type, initRegion::Region, destroyRegion::Region, location=Location())
+function private_recipe(;
+    sym_name, type, initRegion::Region, destroyRegion::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, destroyRegion, ]
+    owned_regions = Region[initRegion, destroyRegion]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "acc.private.recipe", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+
+    return IR.create_operation(
+        "acc.private.recipe",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1234,24 +1772,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function reduction(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function reduction(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1313,18 +1867,33 @@ according to OpenACC 3.3:
 |          |            |  .neqv.  |   .false.   |
 -------------------------------------------------|
 """
-function reduction_recipe(; sym_name, type, reductionOperator, initRegion::Region, combinerRegion::Region, location=Location())
+function reduction_recipe(;
+    sym_name,
+    type,
+    reductionOperator,
+    initRegion::Region,
+    combinerRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initRegion, combinerRegion, ]
+    owned_regions = Region[initRegion, combinerRegion]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), namedattribute("reductionOperator", reductionOperator), ]
-    
-    IR.create_operation(
-        "acc.reduction.recipe", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name),
+        namedattribute("type", type),
+        namedattribute("reductionOperator", reductionOperator),
+    ]
+
+    return IR.create_operation(
+        "acc.reduction.recipe",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1342,29 +1911,75 @@ acc.serial private(%c : memref<10xf32>) {
 }
 ```
 """
-function serial(async=nothing::Union{Nothing, Value}; waitOperands::Vector{Value}, ifCond=nothing::Union{Nothing, Value}, selfCond=nothing::Union{Nothing, Value}, reductionOperands::Vector{Value}, gangPrivateOperands::Vector{Value}, gangFirstPrivateOperands::Vector{Value}, dataClauseOperands::Vector{Value}, asyncAttr=nothing, waitAttr=nothing, selfAttr=nothing, reductionRecipes=nothing, privatizations=nothing, firstprivatizations=nothing, defaultAttr=nothing, region::Region, location=Location())
+function serial(
+    async=nothing::Union{Nothing,Value};
+    waitOperands::Vector{Value},
+    ifCond=nothing::Union{Nothing,Value},
+    selfCond=nothing::Union{Nothing,Value},
+    reductionOperands::Vector{Value},
+    gangPrivateOperands::Vector{Value},
+    gangFirstPrivateOperands::Vector{Value},
+    dataClauseOperands::Vector{Value},
+    asyncAttr=nothing,
+    waitAttr=nothing,
+    selfAttr=nothing,
+    reductionRecipes=nothing,
+    privatizations=nothing,
+    firstprivatizations=nothing,
+    defaultAttr=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., reductionOperands..., gangPrivateOperands..., gangFirstPrivateOperands..., dataClauseOperands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        waitOperands...,
+        reductionOperands...,
+        gangPrivateOperands...,
+        gangFirstPrivateOperands...,
+        dataClauseOperands...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(async) && push!(operands, async)
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(selfCond) && push!(operands, selfCond)
-    push!(attributes, operandsegmentsizes([(async==nothing) ? 0 : 1length(waitOperands), (ifCond==nothing) ? 0 : 1(selfCond==nothing) ? 0 : 1length(reductionOperands), length(gangPrivateOperands), length(gangFirstPrivateOperands), length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            (async == nothing) ? 0 : 1length(waitOperands),
+            if (ifCond == nothing)
+                0
+            elseif 1(selfCond == nothing)
+                0
+            else
+                1length(reductionOperands)
+            end,
+            length(gangPrivateOperands),
+            length(gangFirstPrivateOperands),
+            length(dataClauseOperands),
+        ]),
+    )
     !isnothing(asyncAttr) && push!(attributes, namedattribute("asyncAttr", asyncAttr))
     !isnothing(waitAttr) && push!(attributes, namedattribute("waitAttr", waitAttr))
     !isnothing(selfAttr) && push!(attributes, namedattribute("selfAttr", selfAttr))
-    !isnothing(reductionRecipes) && push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
-    !isnothing(privatizations) && push!(attributes, namedattribute("privatizations", privatizations))
-    !isnothing(firstprivatizations) && push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
+    !isnothing(reductionRecipes) &&
+        push!(attributes, namedattribute("reductionRecipes", reductionRecipes))
+    !isnothing(privatizations) &&
+        push!(attributes, namedattribute("privatizations", privatizations))
+    !isnothing(firstprivatizations) &&
+        push!(attributes, namedattribute("firstprivatizations", firstprivatizations))
     !isnothing(defaultAttr) && push!(attributes, namedattribute("defaultAttr", defaultAttr))
-    
-    IR.create_operation(
-        "acc.serial", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.serial",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1381,21 +1996,42 @@ acc.shutdown
 acc.shutdown device_num(%dev1 : i32)
 ```
 """
-function shutdown(deviceTypeOperands::Vector{Value}, deviceNumOperand=nothing::Union{Nothing, Value}; ifCond=nothing::Union{Nothing, Value}, location=Location())
+function shutdown(
+    deviceTypeOperands::Vector{Value},
+    deviceNumOperand=nothing::Union{Nothing,Value};
+    ifCond=nothing::Union{Nothing,Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[deviceTypeOperands..., ]
+    operands = Value[deviceTypeOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(deviceNumOperand) && push!(operands, deviceNumOperand)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(deviceTypeOperands), (deviceNumOperand==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
-    
-    IR.create_operation(
-        "acc.shutdown", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(deviceTypeOperands),
+            if (deviceNumOperand == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+
+    return IR.create_operation(
+        "acc.shutdown",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1413,12 +2049,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1444,24 +2084,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function update_device(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function update_device(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.update_device", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.update_device",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1486,24 +2142,37 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function update_host(accPtr::Value, varPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
+function update_host(
+    accPtr::Value,
+    varPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[accPtr, bounds..., ]
+    operands = Value[accPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtr) && push!(operands, varPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(attributes, operandsegmentsizes([1, (varPtr == nothing) ? 0 : 1length(bounds)]))
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.update_host", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.update_host",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1521,25 +2190,55 @@ add to \$hostOperands.
 acc.update device(%d1 : memref<10xf32>) attributes {async}
 ```
 """
-function update(ifCond=nothing::Union{Nothing, Value}; asyncOperand=nothing::Union{Nothing, Value}, waitDevnum=nothing::Union{Nothing, Value}, waitOperands::Vector{Value}, deviceTypeOperands::Vector{Value}, dataClauseOperands::Vector{Value}, async=nothing, wait=nothing, ifPresent=nothing, location=Location())
+function update(
+    ifCond=nothing::Union{Nothing,Value};
+    asyncOperand=nothing::Union{Nothing,Value},
+    waitDevnum=nothing::Union{Nothing,Value},
+    waitOperands::Vector{Value},
+    deviceTypeOperands::Vector{Value},
+    dataClauseOperands::Vector{Value},
+    async=nothing,
+    wait=nothing,
+    ifPresent=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., deviceTypeOperands..., dataClauseOperands..., ]
+    operands = Value[waitOperands..., deviceTypeOperands..., dataClauseOperands...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ifCond) && push!(operands, ifCond)
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
-    push!(attributes, operandsegmentsizes([(ifCond==nothing) ? 0 : 1(asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1length(waitOperands), length(deviceTypeOperands), length(dataClauseOperands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (ifCond == nothing)
+                0
+            elseif 1(asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            else
+                1length(waitOperands)
+            end,
+            length(deviceTypeOperands),
+            length(dataClauseOperands),
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
     !isnothing(wait) && push!(attributes, namedattribute("wait", wait))
     !isnothing(ifPresent) && push!(attributes, namedattribute("ifPresent", ifPresent))
-    
-    IR.create_operation(
-        "acc.update", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.update",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1565,24 +2264,40 @@ counters (2.6.7).
 done to satisfy \"Variables with Implicitly Determined Data Attributes\" in 2.6.2.
 - `name`: Holds the name of variable as specified in user clause (including bounds).
 """
-function use_device(varPtr::Value, varPtrPtr=nothing::Union{Nothing, Value}; bounds::Vector{Value}, accPtr::IR.Type, dataClause=nothing, structured=nothing, implicit=nothing, name=nothing, location=Location())
-    results = IR.Type[accPtr, ]
-    operands = Value[varPtr, bounds..., ]
+function use_device(
+    varPtr::Value,
+    varPtrPtr=nothing::Union{Nothing,Value};
+    bounds::Vector{Value},
+    accPtr::IR.Type,
+    dataClause=nothing,
+    structured=nothing,
+    implicit=nothing,
+    name=nothing,
+    location=Location(),
+)
+    results = IR.Type[accPtr,]
+    operands = Value[varPtr, bounds...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(varPtrPtr) && push!(operands, varPtrPtr)
-    push!(attributes, operandsegmentsizes([1, (varPtrPtr==nothing) ? 0 : 1length(bounds), ]))
+    push!(
+        attributes, operandsegmentsizes([1, (varPtrPtr == nothing) ? 0 : 1length(bounds)])
+    )
     !isnothing(dataClause) && push!(attributes, namedattribute("dataClause", dataClause))
     !isnothing(structured) && push!(attributes, namedattribute("structured", structured))
     !isnothing(implicit) && push!(attributes, namedattribute("implicit", implicit))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "acc.use_device", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.use_device",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1599,23 +2314,48 @@ acc.wait(%value1: index)
 acc.wait() async(%async1: i32)
 ```
 """
-function wait(waitOperands::Vector{Value}, asyncOperand=nothing::Union{Nothing, Value}; waitDevnum=nothing::Union{Nothing, Value}, ifCond=nothing::Union{Nothing, Value}, async=nothing, location=Location())
+function wait(
+    waitOperands::Vector{Value},
+    asyncOperand=nothing::Union{Nothing,Value};
+    waitDevnum=nothing::Union{Nothing,Value},
+    ifCond=nothing::Union{Nothing,Value},
+    async=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[waitOperands..., ]
+    operands = Value[waitOperands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(asyncOperand) && push!(operands, asyncOperand)
     !isnothing(waitDevnum) && push!(operands, waitDevnum)
     !isnothing(ifCond) && push!(operands, ifCond)
-    push!(attributes, operandsegmentsizes([length(waitOperands), (asyncOperand==nothing) ? 0 : 1(waitDevnum==nothing) ? 0 : 1(ifCond==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(waitOperands),
+            if (asyncOperand == nothing)
+                0
+            elseif 1(waitDevnum == nothing)
+                0
+            elseif 1(ifCond == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(async) && push!(attributes, namedattribute("async", async))
-    
-    IR.create_operation(
-        "acc.wait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.wait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1626,18 +2366,22 @@ end
 acc ops (parallel and loop). It returns values to the immediately enclosing
 acc op.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "acc.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "acc.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/OpenMP.jl
+++ b/src/Dialects/17/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `atomic_capture`
@@ -37,20 +37,27 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
+function atomic_capture(;
+    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.capture", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.capture",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,20 +76,32 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(x::Value, v::Value; element_type, hint_val=nothing, memory_order_val=nothing, location=Location())
+function atomic_read(
+    x::Value,
+    v::Value;
+    element_type,
+    hint_val=nothing,
+    memory_order_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, v, ]
+    operands = Value[x, v]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("element_type", element_type), ]
+    attributes = NamedAttribute[namedattribute("element_type", element_type),]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.read", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.read",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -116,20 +135,31 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
+function atomic_update(
+    x::Value;
+    hint_val=nothing,
+    memory_order_val=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
-    owned_regions = Region[region, ]
+    operands = Value[x,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.update", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.update",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -150,20 +180,31 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
+function atomic_write(
+    address::Value,
+    value::Value;
+    hint_val=nothing,
+    memory_order_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[address, value, ]
+    operands = Value[address, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
-    
-    IR.create_operation(
-        "omp.atomic.write", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_order_val) &&
+        push!(attributes, namedattribute("memory_order_val", memory_order_val))
+
+    return IR.create_operation(
+        "omp.atomic.write",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -179,12 +220,16 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.barrier", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.barrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -194,19 +239,29 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
+function cancel(
+    if_expr=nothing::Union{Nothing,Value};
+    cancellation_construct_type_val,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    attributes = NamedAttribute[namedattribute(
+        "cancellation_construct_type_val", cancellation_construct_type_val
+    ),]
     !isnothing(if_expr) && push!(operands, if_expr)
-    
-    IR.create_operation(
-        "omp.cancel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.cancel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -222,13 +277,19 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
-    
-    IR.create_operation(
-        "omp.cancellationpoint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute(
+        "cancellation_construct_type_val", cancellation_construct_type_val
+    ),]
+
+    return IR.create_operation(
+        "omp.cancellationpoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -244,14 +305,18 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    
-    IR.create_operation(
-        "omp.critical.declare", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.critical.declare",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -264,16 +329,20 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "omp.critical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.critical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -287,16 +356,20 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList..., ]
+    operands = Value[varList...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.flush", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.flush",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,15 +382,19 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.master", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.master",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -339,20 +416,31 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
+function ordered(
+    depend_vec_vars::Vector{Value};
+    depend_type_val=nothing,
+    num_loops_val=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[depend_vec_vars..., ]
+    operands = Value[depend_vec_vars...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
-    
-    IR.create_operation(
-        "omp.ordered", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(depend_type_val) &&
+        push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) &&
+        push!(attributes, namedattribute("num_loops_val", num_loops_val))
+
+    return IR.create_operation(
+        "omp.ordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -370,16 +458,20 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-    
-    IR.create_operation(
-        "omp.ordered_region", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.ordered_region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -415,23 +507,51 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
+function parallel(
+    if_expr_var=nothing::Union{Nothing,Value};
+    num_threads_var=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    reductions=nothing,
+    proc_bind_val=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr_var == nothing)
+                0
+            elseif 1(num_threads_var == nothing)
+                0
+            else
+                1length(allocate_vars)
+            end,
+            length(allocators_vars),
+            length(reduction_vars),
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-    
-    IR.create_operation(
-        "omp.parallel", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(proc_bind_val) &&
+        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+
+    return IR.create_operation(
+        "omp.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -460,18 +580,31 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
+function reduction_declare(;
+    sym_name,
+    type,
+    initializerRegion::Region,
+    reductionRegion::Region,
+    atomicReductionRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "omp.reduction.declare", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("type", type)
+    ]
+
+    return IR.create_operation(
+        "omp.reduction.declare",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -485,16 +618,20 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator, ]
+    operands = Value[operand, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -508,15 +645,19 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.section", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.section",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -547,21 +688,38 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
+function sections(
+    reduction_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    reductions=nothing,
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(reduction_vars), length(allocate_vars), length(allocators_vars)
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.sections", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.sections",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -610,25 +768,55 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
+function simdloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    aligned_vars::Vector{Value},
+    if_expr=nothing::Union{Nothing,Value};
+    nontemporal_vars::Vector{Value},
+    alignment_values=nothing,
+    order_val=nothing,
+    simdlen=nothing,
+    safelen=nothing,
+    inclusive=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), (if_expr==nothing) ? 0 : 1length(nontemporal_vars), ]))
-    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            length(aligned_vars),
+            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
+        ]),
+    )
+    !isnothing(alignment_values) &&
+        push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-    
-    IR.create_operation(
-        "omp.simdloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.simdloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -641,20 +829,30 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
+function single(
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    nowait=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.single", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.single",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -678,24 +876,50 @@ even if the target task is not yet completed.
 
 TODO:  is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types=nothing, region::Region, location=Location())
+function target(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    thread_limit=nothing::Union{Nothing,Value},
+    map_operands::Vector{Value},
+    nowait=nothing,
+    map_types=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[map_operands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[map_operands...,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1length(map_operands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            elseif 1(thread_limit == nothing)
+                0
+            else
+                1length(map_operands)
+            end,
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(map_types) && push!(attributes, namedattribute("map_types", map_types))
-    
-    IR.create_operation(
-        "omp.target", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -730,21 +954,47 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
+function target_data(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    use_device_ptr::Vector{Value},
+    use_device_addr::Vector{Value},
+    map_operands::Vector{Value},
+    map_types,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
-    owned_regions = Region[region, ]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
+    attributes = NamedAttribute[namedattribute("map_types", map_types),]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
-    
-    IR.create_operation(
-        "omp.target_data", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            else
+                1length(use_device_ptr)
+            end,
+            length(use_device_addr),
+            length(map_operands),
+        ]),
+    )
+
+    return IR.create_operation(
+        "omp.target_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -772,22 +1022,44 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
+function target_enter_data(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    map_operands::Vector{Value},
+    nowait=nothing,
+    map_types,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[map_operands..., ]
+    operands = Value[map_operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
+    attributes = NamedAttribute[namedattribute("map_types", map_types),]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            else
+                1length(map_operands)
+            end
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.target_enter_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target_enter_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -815,22 +1087,44 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
+function target_exit_data(
+    if_expr=nothing::Union{Nothing,Value};
+    device=nothing::Union{Nothing,Value},
+    map_operands::Vector{Value},
+    nowait=nothing,
+    map_types,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[map_operands..., ]
+    operands = Value[map_operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
+    attributes = NamedAttribute[namedattribute("map_types", map_types),]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(device == nothing)
+                0
+            else
+                1length(map_operands)
+            end
+        ]),
+    )
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-    
-    IR.create_operation(
-        "omp.target_exit_data", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.target_exit_data",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -858,20 +1152,37 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
+function taskgroup(
+    task_reduction_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value};
+    task_reductions=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
-    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
-    
-    IR.create_operation(
-        "omp.taskgroup", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
+        ]),
+    )
+    !isnothing(task_reductions) &&
+        push!(attributes, namedattribute("task_reductions", task_reductions))
+
+    return IR.create_operation(
+        "omp.taskgroup",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -973,10 +1284,39 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
+function taskloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    if_expr=nothing::Union{Nothing,Value};
+    final_expr=nothing::Union{Nothing,Value},
+    in_reduction_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    priority=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    grain_size=nothing::Union{Nothing,Value},
+    num_tasks=nothing::Union{Nothing,Value},
+    inclusive=nothing,
+    untied=nothing,
+    mergeable=nothing,
+    in_reductions=nothing,
+    reductions=nothing,
+    nogroup=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound...,
+        upperBound...,
+        step...,
+        in_reduction_vars...,
+        reduction_vars...,
+        allocate_vars...,
+        allocators_vars...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -984,19 +1324,48 @@ function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Ve
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            if (if_expr == nothing)
+                0
+            elseif 1(final_expr == nothing)
+                0
+            else
+                1length(in_reduction_vars)
+            end,
+            length(reduction_vars),
+            (priority == nothing) ? 0 : 1length(allocate_vars),
+            length(allocators_vars),
+            if (grain_size == nothing)
+                0
+            elseif 1(num_tasks == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) &&
+        push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-    
-    IR.create_operation(
-        "omp.taskloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1046,26 +1415,61 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, depend_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, depends=nothing, region::Region, location=Location())
+function task(
+    if_expr=nothing::Union{Nothing,Value};
+    final_expr=nothing::Union{Nothing,Value},
+    in_reduction_vars::Vector{Value},
+    priority=nothing::Union{Nothing,Value},
+    depend_vars::Vector{Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    untied=nothing,
+    mergeable=nothing,
+    in_reductions=nothing,
+    depends=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[in_reduction_vars..., depend_vars..., allocate_vars..., allocators_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        in_reduction_vars..., depend_vars..., allocate_vars..., allocators_vars...
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(depend_vars), length(allocate_vars), length(allocators_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (if_expr == nothing)
+                0
+            elseif 1(final_expr == nothing)
+                0
+            else
+                1length(in_reduction_vars)
+            end,
+            (priority == nothing) ? 0 : 1length(depend_vars),
+            length(allocate_vars),
+            length(allocators_vars),
+        ]),
+    )
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) &&
+        push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(depends) && push!(attributes, namedattribute("depends", depends))
-    
-    IR.create_operation(
-        "omp.task", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.task",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1081,12 +1485,16 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.taskwait", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskwait",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1102,12 +1510,16 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.taskyield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.taskyield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1133,24 +1545,56 @@ The \$allocators_vars and \$allocate_vars parameters are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function teams(num_teams_lower=nothing::Union{Nothing, Value}; num_teams_upper=nothing::Union{Nothing, Value}, if_expr=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, region::Region, location=Location())
+function teams(
+    num_teams_lower=nothing::Union{Nothing,Value};
+    num_teams_upper=nothing::Union{Nothing,Value},
+    if_expr=nothing::Union{Nothing,Value},
+    thread_limit=nothing::Union{Nothing,Value},
+    allocate_vars::Vector{Value},
+    allocators_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    reductions=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_teams_lower) && push!(operands, num_teams_lower)
     !isnothing(num_teams_upper) && push!(operands, num_teams_upper)
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([(num_teams_lower==nothing) ? 0 : 1(num_teams_upper==nothing) ? 0 : 1(if_expr==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            if (num_teams_lower == nothing)
+                0
+            elseif 1(num_teams_upper == nothing)
+                0
+            elseif 1(if_expr == nothing)
+                0
+            elseif 1(thread_limit == nothing)
+                0
+            else
+                1length(allocate_vars)
+            end,
+            length(allocators_vars),
+            length(reduction_vars),
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    
-    IR.create_operation(
-        "omp.teams", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.teams",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1168,12 +1612,16 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.terminator", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.terminator",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1196,17 +1644,21 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr, ]
-    operands = Value[sym_addr, ]
+    results = IR.Type[tls_addr,]
+    operands = Value[sym_addr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.threadprivate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.threadprivate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1271,28 +1723,71 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
+function wsloop(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    linear_vars::Vector{Value},
+    linear_step_vars::Vector{Value},
+    reduction_vars::Vector{Value},
+    schedule_chunk_var=nothing::Union{Nothing,Value};
+    reductions=nothing,
+    schedule_val=nothing,
+    schedule_modifier=nothing,
+    simd_modifier=nothing,
+    nowait=nothing,
+    ordered_val=nothing,
+    order_val=nothing,
+    inclusive=nothing,
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
-    owned_regions = Region[region, ]
+    operands = Value[
+        lowerBound...,
+        upperBound...,
+        step...,
+        linear_vars...,
+        linear_step_vars...,
+        reduction_vars...,
+    ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound),
+            length(upperBound),
+            length(step),
+            length(linear_vars),
+            length(linear_step_vars),
+            length(reduction_vars),
+            (schedule_chunk_var == nothing) ? 0 : 1,
+        ]),
+    )
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) &&
+        push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) &&
+        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) &&
+        push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-    
-    IR.create_operation(
-        "omp.wsloop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.wsloop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1303,18 +1798,22 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results_::Vector{Value}; location=Location())
+function yield(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "omp.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "omp.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/OpenMP.jl
+++ b/src/Dialects/17/OpenMP.jl
@@ -1,9 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `atomic_capture`
@@ -38,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -77,32 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value,
-    v::Value;
-    element_type,
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_read(x::Value, v::Value; element_type, hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("element_type", element_type),]
+    attributes = NamedAttribute[namedattribute("element_type", element_type), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -181,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -240,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -278,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -306,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -330,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -357,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -383,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -459,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -508,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -581,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -689,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -769,55 +610,25 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    aligned_vars::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    nontemporal_vars::Vector{Value},
-    alignment_values=nothing,
-    order_val=nothing,
-    simdlen=nothing,
-    safelen=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(aligned_vars),
-            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
-        ]),
-    )
-    !isnothing(alignment_values) &&
-        push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), (if_expr==nothing) ? 0 : 1length(nontemporal_vars), ]))
+    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -830,30 +641,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -877,47 +678,24 @@ even if the target task is not yet completed.
 
 TODO:  is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
-    owned_regions = Region[region,]
+    operands = Value[map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        elseif 1(thread_limit == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(map_types) && push!(attributes, namedattribute("map_types", map_types))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -952,47 +730,21 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    use_device_ptr::Vector{Value},
-    use_device_addr::Vector{Value},
-    map_operands::Vector{Value},
-    map_types,
-    region::Region,
-    location=Location(),
-)
+function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
-    owned_regions = Region[region,]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(use_device_ptr)
-            end,
-            length(use_device_addr),
-            length(map_operands),
-        ]),
-    )
-
-    return IR.create_operation(
-        "omp.target_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
+    
+    IR.create_operation(
+        "omp.target_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1020,41 +772,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1082,41 +815,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(attributes, operandsegmentsizes([
-        if (if_expr == nothing)
-            0
-        elseif 1(device == nothing)
-            0
-        else
-            1length(map_operands)
-        end,
-    ]))
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1144,37 +858,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1276,39 +973,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1316,48 +984,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1407,61 +1046,26 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    depend_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    depends=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, depend_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, depends=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        in_reduction_vars..., depend_vars..., allocate_vars..., allocators_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., depend_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(depend_vars),
-            length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(depend_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(depends) && push!(attributes, namedattribute("depends", depends))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1477,16 +1081,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1502,16 +1102,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1537,56 +1133,24 @@ The \$allocators_vars and \$allocate_vars parameters are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function teams(
-    num_teams_lower=nothing::Union{Nothing,Value};
-    num_teams_upper=nothing::Union{Nothing,Value},
-    if_expr=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function teams(num_teams_lower=nothing::Union{Nothing, Value}; num_teams_upper=nothing::Union{Nothing, Value}, if_expr=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_teams_lower) && push!(operands, num_teams_lower)
     !isnothing(num_teams_upper) && push!(operands, num_teams_upper)
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (num_teams_lower == nothing)
-                0
-            elseif 1(num_teams_upper == nothing)
-                0
-            elseif 1(if_expr == nothing)
-                0
-            elseif 1(thread_limit == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(num_teams_lower==nothing) ? 0 : 1(num_teams_upper==nothing) ? 0 : 1(if_expr==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-
-    return IR.create_operation(
-        "omp.teams",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.teams", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1604,16 +1168,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1636,21 +1196,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1715,71 +1271,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1790,22 +1303,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/OpenMP.jl
+++ b/src/Dialects/17/OpenMP.jl
@@ -1,8 +1,8 @@
 module omp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `atomic_capture`
@@ -37,27 +37,20 @@ The region has the following allowed forms:
   }
 ```
 """
-function atomic_capture(;
-    hint_val=nothing, memory_order_val=nothing, region::Region, location=Location()
-)
+function atomic_capture(; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.capture",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.capture", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -76,32 +69,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `acquire` or `relaxed`.
 """
-function atomic_read(
-    x::Value,
-    v::Value;
-    element_type,
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_read(x::Value, v::Value; element_type, hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[x, v]
+    operands = Value[x, v, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("element_type", element_type),]
+    attributes = NamedAttribute[namedattribute("element_type", element_type), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -135,31 +116,20 @@ the core update operation is directly translated like regular operations by
 the host dialect. The front-end must handle semantic checks for allowed
 operations.
 """
-function atomic_update(
-    x::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function atomic_update(x::Value; hint_val=nothing, memory_order_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.update",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.update", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -180,31 +150,20 @@ optimization.
 `memory_order` indicates the memory ordering behavior of the construct. It
 can be one of `seq_cst`, `release` or `relaxed`.
 """
-function atomic_write(
-    address::Value,
-    value::Value;
-    hint_val=nothing,
-    memory_order_val=nothing,
-    location=Location(),
-)
+function atomic_write(address::Value, value::Value; hint_val=nothing, memory_order_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[address, value]
+    operands = Value[address, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-    !isnothing(memory_order_val) &&
-        push!(attributes, namedattribute("memory_order_val", memory_order_val))
-
-    return IR.create_operation(
-        "omp.atomic.write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_order_val) && push!(attributes, namedattribute("memory_order_val", memory_order_val))
+    
+    IR.create_operation(
+        "omp.atomic.write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -220,16 +179,12 @@ function barrier(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.barrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.barrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -239,29 +194,19 @@ end
 The cancel construct activates cancellation of the innermost enclosing
 region of the type specified.
 """
-function cancel(
-    if_expr=nothing::Union{Nothing,Value};
-    cancellation_construct_type_val,
-    location=Location(),
-)
+function cancel(if_expr=nothing::Union{Nothing, Value}; cancellation_construct_type_val, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
     !isnothing(if_expr) && push!(operands, if_expr)
-
-    return IR.create_operation(
-        "omp.cancel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.cancel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -277,19 +222,13 @@ function cancellationpoint(; cancellation_construct_type_val, location=Location(
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cancellation_construct_type_val", cancellation_construct_type_val
-    ),]
-
-    return IR.create_operation(
-        "omp.cancellationpoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cancellation_construct_type_val", cancellation_construct_type_val), ]
+    
+    IR.create_operation(
+        "omp.cancellationpoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -305,18 +244,14 @@ function critical_declare(; sym_name, hint_val=nothing, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name),]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), ]
     !isnothing(hint_val) && push!(attributes, namedattribute("hint_val", hint_val))
-
-    return IR.create_operation(
-        "omp.critical.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -329,20 +264,16 @@ block (region) to be executed by only a single thread at a time.
 function critical(; name=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "omp.critical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.critical", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -356,20 +287,16 @@ specified or implied.
 """
 function flush(varList::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[varList...,]
+    operands = Value[varList..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.flush",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.flush", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -382,19 +309,15 @@ the master thread of the team.
 function master(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.master",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.master", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,31 +339,20 @@ the index of the element of \"vec\" for the DEPEND(SINK: vec) clause. It
 contains the operands in multiple \"vec\" when multiple DEPEND(SINK: vec)
 clauses exist in one ORDERED directive.
 """
-function ordered(
-    depend_vec_vars::Vector{Value};
-    depend_type_val=nothing,
-    num_loops_val=nothing,
-    location=Location(),
-)
+function ordered(depend_vec_vars::Vector{Value}; depend_type_val=nothing, num_loops_val=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[depend_vec_vars...,]
+    operands = Value[depend_vec_vars..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(depend_type_val) &&
-        push!(attributes, namedattribute("depend_type_val", depend_type_val))
-    !isnothing(num_loops_val) &&
-        push!(attributes, namedattribute("num_loops_val", num_loops_val))
-
-    return IR.create_operation(
-        "omp.ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(depend_type_val) && push!(attributes, namedattribute("depend_type_val", depend_type_val))
+    !isnothing(num_loops_val) && push!(attributes, namedattribute("num_loops_val", num_loops_val))
+    
+    IR.create_operation(
+        "omp.ordered", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -458,20 +370,16 @@ specified.
 function ordered_region(; simd=nothing, region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(simd) && push!(attributes, namedattribute("simd", simd))
-
-    return IR.create_operation(
-        "omp.ordered_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.ordered_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -507,51 +415,23 @@ threads complete.
 The optional \$proc_bind_val attribute controls the thread affinity for the execution
 of the parallel region.
 """
-function parallel(
-    if_expr_var=nothing::Union{Nothing,Value};
-    num_threads_var=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    proc_bind_val=nothing,
-    region::Region,
-    location=Location(),
-)
+function parallel(if_expr_var=nothing::Union{Nothing, Value}; num_threads_var=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, proc_bind_val=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr_var) && push!(operands, if_expr_var)
     !isnothing(num_threads_var) && push!(operands, num_threads_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr_var == nothing)
-                0
-            elseif 1(num_threads_var == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr_var==nothing) ? 0 : 1(num_threads_var==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(proc_bind_val) &&
-        push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
-
-    return IR.create_operation(
-        "omp.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(proc_bind_val) && push!(attributes, namedattribute("proc_bind_val", proc_bind_val))
+    
+    IR.create_operation(
+        "omp.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -580,31 +460,18 @@ element and accumulator types.
 For initializer and reduction regions, the operand to `omp.yield` must
 match the parent operation\'s results.
 """
-function reduction_declare(;
-    sym_name,
-    type,
-    initializerRegion::Region,
-    reductionRegion::Region,
-    atomicReductionRegion::Region,
-    location=Location(),
-)
+function reduction_declare(; sym_name, type, initializerRegion::Region, reductionRegion::Region, atomicReductionRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion]
+    owned_regions = Region[initializerRegion, reductionRegion, atomicReductionRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("type", type)
-    ]
-
-    return IR.create_operation(
-        "omp.reduction.declare",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "omp.reduction.declare", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,20 +485,16 @@ updated immediately.
 """
 function reduction(operand::Value, accumulator::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, accumulator]
+    operands = Value[operand, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,19 +508,15 @@ sections construct. A section op should always be surrounded by an
 function section(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.section",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.section", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -688,38 +547,21 @@ that specify the memory allocator to be used to obtain storage for private value
 The `nowait` attribute, when present, signifies that there should be no
 implicit barrier at the end of the construct.
 """
-function sections(
-    reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    reductions=nothing,
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function sections(reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; reductions=nothing, nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(reduction_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.sections",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.sections", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -768,55 +610,25 @@ for (%i1, %i2) : index = (%c0, %c0) to (%c10, %c10) step (%c1, %c1) {
 }
 ```
 """
-function simdloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    aligned_vars::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    nontemporal_vars::Vector{Value},
-    alignment_values=nothing,
-    order_val=nothing,
-    simdlen=nothing,
-    safelen=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function simdloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, aligned_vars::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; nontemporal_vars::Vector{Value}, alignment_values=nothing, order_val=nothing, simdlen=nothing, safelen=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., aligned_vars..., nontemporal_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(aligned_vars),
-            (if_expr == nothing) ? 0 : 1length(nontemporal_vars),
-        ]),
-    )
-    !isnothing(alignment_values) &&
-        push!(attributes, namedattribute("alignment_values", alignment_values))
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(aligned_vars), (if_expr==nothing) ? 0 : 1length(nontemporal_vars), ]))
+    !isnothing(alignment_values) && push!(attributes, namedattribute("alignment_values", alignment_values))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(simdlen) && push!(attributes, namedattribute("simdlen", simdlen))
     !isnothing(safelen) && push!(attributes, namedattribute("safelen", safelen))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.simdloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.simdloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -829,30 +641,20 @@ master thread), in the context of its implicit task. The other threads
 in the team, which do not execute the block, wait at an implicit barrier
 at the end of the single construct unless a nowait clause is specified.
 """
-function single(
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    nowait=nothing,
-    region::Region,
-    location=Location(),
-)
+function single(allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; nowait=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars)]))
+    push!(attributes, operandsegmentsizes([length(allocate_vars), length(allocators_vars), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.single",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.single", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -876,50 +678,24 @@ even if the target task is not yet completed.
 
 TODO:  is_device_ptr, depend, defaultmap, in_reduction
 """
-function target(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types=nothing,
-    region::Region,
-    location=Location(),
-)
+function target(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
-    owned_regions = Region[region,]
+    operands = Value[map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            elseif 1(thread_limit == nothing)
-                0
-            else
-                1length(map_operands)
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(map_types) && push!(attributes, namedattribute("map_types", map_types))
-
-    return IR.create_operation(
-        "omp.target",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -954,47 +730,21 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    use_device_ptr::Vector{Value},
-    use_device_addr::Vector{Value},
-    map_operands::Vector{Value},
-    map_types,
-    region::Region,
-    location=Location(),
-)
+function target_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, use_device_ptr::Vector{Value}, use_device_addr::Vector{Value}, map_operands::Vector{Value}, map_types, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[use_device_ptr..., use_device_addr..., map_operands...]
-    owned_regions = Region[region,]
+    operands = Value[use_device_ptr..., use_device_addr..., map_operands..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(use_device_ptr)
-            end,
-            length(use_device_addr),
-            length(map_operands),
-        ]),
-    )
-
-    return IR.create_operation(
-        "omp.target_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(use_device_ptr), length(use_device_addr), length(map_operands), ]))
+    
+    IR.create_operation(
+        "omp.target_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1022,44 +772,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_enter_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_enter_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(map_operands)
-            end
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_enter_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_enter_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1087,44 +815,22 @@ The \$map_types specifies the types and modifiers for the map clause.
 
 TODO:  depend clause and map_type_modifier values iterator and mapper.
 """
-function target_exit_data(
-    if_expr=nothing::Union{Nothing,Value};
-    device=nothing::Union{Nothing,Value},
-    map_operands::Vector{Value},
-    nowait=nothing,
-    map_types,
-    location=Location(),
-)
+function target_exit_data(if_expr=nothing::Union{Nothing, Value}; device=nothing::Union{Nothing, Value}, map_operands::Vector{Value}, nowait=nothing, map_types, location=Location())
     results = IR.Type[]
-    operands = Value[map_operands...,]
+    operands = Value[map_operands..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("map_types", map_types),]
+    attributes = NamedAttribute[namedattribute("map_types", map_types), ]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(device) && push!(operands, device)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(device == nothing)
-                0
-            else
-                1length(map_operands)
-            end
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(device==nothing) ? 0 : 1length(map_operands), ]))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
-
-    return IR.create_operation(
-        "omp.target_exit_data",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.target_exit_data", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1152,37 +858,20 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function taskgroup(
-    task_reduction_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value};
-    task_reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskgroup(task_reduction_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}; task_reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars...]
-    owned_regions = Region[region,]
+    operands = Value[task_reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(task_reduction_vars), length(allocate_vars), length(allocators_vars)
-        ]),
-    )
-    !isnothing(task_reductions) &&
-        push!(attributes, namedattribute("task_reductions", task_reductions))
-
-    return IR.create_operation(
-        "omp.taskgroup",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(task_reduction_vars), length(allocate_vars), length(allocators_vars), ]))
+    !isnothing(task_reductions) && push!(attributes, namedattribute("task_reductions", task_reductions))
+    
+    IR.create_operation(
+        "omp.taskgroup", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1284,39 +973,10 @@ construct. Thus, the taskloop construct creates an implicit taskgroup
 region. If the `nogroup` clause is present, no implicit taskgroup region is
 created.
 """
-function taskloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    grain_size=nothing::Union{Nothing,Value},
-    num_tasks=nothing::Union{Nothing,Value},
-    inclusive=nothing,
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    reductions=nothing,
-    nogroup=nothing,
-    region::Region,
-    location=Location(),
-)
+function taskloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, grain_size=nothing::Union{Nothing, Value}, num_tasks=nothing::Union{Nothing, Value}, inclusive=nothing, untied=nothing, mergeable=nothing, in_reductions=nothing, reductions=nothing, nogroup=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        in_reduction_vars...,
-        reduction_vars...,
-        allocate_vars...,
-        allocators_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., in_reduction_vars..., reduction_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
@@ -1324,48 +984,19 @@ function taskloop(
     !isnothing(priority) && push!(operands, priority)
     !isnothing(grain_size) && push!(operands, grain_size)
     !isnothing(num_tasks) && push!(operands, num_tasks)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            length(reduction_vars),
-            (priority == nothing) ? 0 : 1length(allocate_vars),
-            length(allocators_vars),
-            if (grain_size == nothing)
-                0
-            elseif 1(num_tasks == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), (if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), length(reduction_vars), (priority==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), (grain_size==nothing) ? 0 : 1(num_tasks==nothing) ? 0 : 1]))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
     !isnothing(nogroup) && push!(attributes, namedattribute("nogroup", nogroup))
-
-    return IR.create_operation(
-        "omp.taskloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1415,61 +1046,26 @@ The `allocators_vars` and `allocate_vars` arguments are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function task(
-    if_expr=nothing::Union{Nothing,Value};
-    final_expr=nothing::Union{Nothing,Value},
-    in_reduction_vars::Vector{Value},
-    priority=nothing::Union{Nothing,Value},
-    depend_vars::Vector{Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    untied=nothing,
-    mergeable=nothing,
-    in_reductions=nothing,
-    depends=nothing,
-    region::Region,
-    location=Location(),
-)
+function task(if_expr=nothing::Union{Nothing, Value}; final_expr=nothing::Union{Nothing, Value}, in_reduction_vars::Vector{Value}, priority=nothing::Union{Nothing, Value}, depend_vars::Vector{Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, untied=nothing, mergeable=nothing, in_reductions=nothing, depends=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        in_reduction_vars..., depend_vars..., allocate_vars..., allocators_vars...
-    ]
-    owned_regions = Region[region,]
+    operands = Value[in_reduction_vars..., depend_vars..., allocate_vars..., allocators_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(final_expr) && push!(operands, final_expr)
     !isnothing(priority) && push!(operands, priority)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (if_expr == nothing)
-                0
-            elseif 1(final_expr == nothing)
-                0
-            else
-                1length(in_reduction_vars)
-            end,
-            (priority == nothing) ? 0 : 1length(depend_vars),
-            length(allocate_vars),
-            length(allocators_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(if_expr==nothing) ? 0 : 1(final_expr==nothing) ? 0 : 1length(in_reduction_vars), (priority==nothing) ? 0 : 1length(depend_vars), length(allocate_vars), length(allocators_vars), ]))
     !isnothing(untied) && push!(attributes, namedattribute("untied", untied))
     !isnothing(mergeable) && push!(attributes, namedattribute("mergeable", mergeable))
-    !isnothing(in_reductions) &&
-        push!(attributes, namedattribute("in_reductions", in_reductions))
+    !isnothing(in_reductions) && push!(attributes, namedattribute("in_reductions", in_reductions))
     !isnothing(depends) && push!(attributes, namedattribute("depends", depends))
-
-    return IR.create_operation(
-        "omp.task",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.task", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1485,16 +1081,12 @@ function taskwait(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskwait",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskwait", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1510,16 +1102,12 @@ function taskyield(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.taskyield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.taskyield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1545,56 +1133,24 @@ The \$allocators_vars and \$allocate_vars parameters are a variadic list of
 values that specify the memory allocator to be used to obtain storage for
 private values.
 """
-function teams(
-    num_teams_lower=nothing::Union{Nothing,Value};
-    num_teams_upper=nothing::Union{Nothing,Value},
-    if_expr=nothing::Union{Nothing,Value},
-    thread_limit=nothing::Union{Nothing,Value},
-    allocate_vars::Vector{Value},
-    allocators_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    reductions=nothing,
-    region::Region,
-    location=Location(),
-)
+function teams(num_teams_lower=nothing::Union{Nothing, Value}; num_teams_upper=nothing::Union{Nothing, Value}, if_expr=nothing::Union{Nothing, Value}, thread_limit=nothing::Union{Nothing, Value}, allocate_vars::Vector{Value}, allocators_vars::Vector{Value}, reduction_vars::Vector{Value}, reductions=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[allocate_vars..., allocators_vars..., reduction_vars...]
-    owned_regions = Region[region,]
+    operands = Value[allocate_vars..., allocators_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_teams_lower) && push!(operands, num_teams_lower)
     !isnothing(num_teams_upper) && push!(operands, num_teams_upper)
     !isnothing(if_expr) && push!(operands, if_expr)
     !isnothing(thread_limit) && push!(operands, thread_limit)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            if (num_teams_lower == nothing)
-                0
-            elseif 1(num_teams_upper == nothing)
-                0
-            elseif 1(if_expr == nothing)
-                0
-            elseif 1(thread_limit == nothing)
-                0
-            else
-                1length(allocate_vars)
-            end,
-            length(allocators_vars),
-            length(reduction_vars),
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([(num_teams_lower==nothing) ? 0 : 1(num_teams_upper==nothing) ? 0 : 1(if_expr==nothing) ? 0 : 1(thread_limit==nothing) ? 0 : 1length(allocate_vars), length(allocators_vars), length(reduction_vars), ]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-
-    return IR.create_operation(
-        "omp.teams",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.teams", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1612,16 +1168,12 @@ function terminator(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.terminator",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.terminator", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1644,21 +1196,17 @@ The `sym_addr` refers to the address of the symbol, which is a pointer to
 the original variable.
 """
 function threadprivate(sym_addr::Value; tls_addr::IR.Type, location=Location())
-    results = IR.Type[tls_addr,]
-    operands = Value[sym_addr,]
+    results = IR.Type[tls_addr, ]
+    operands = Value[sym_addr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.threadprivate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.threadprivate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1723,71 +1271,28 @@ The optional `order` attribute specifies which order the iterations of the
 associate loops are executed in. Currently the only option for this
 attribute is \"concurrent\".
 """
-function wsloop(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    linear_vars::Vector{Value},
-    linear_step_vars::Vector{Value},
-    reduction_vars::Vector{Value},
-    schedule_chunk_var=nothing::Union{Nothing,Value};
-    reductions=nothing,
-    schedule_val=nothing,
-    schedule_modifier=nothing,
-    simd_modifier=nothing,
-    nowait=nothing,
-    ordered_val=nothing,
-    order_val=nothing,
-    inclusive=nothing,
-    region::Region,
-    location=Location(),
-)
+function wsloop(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, linear_vars::Vector{Value}, linear_step_vars::Vector{Value}, reduction_vars::Vector{Value}, schedule_chunk_var=nothing::Union{Nothing, Value}; reductions=nothing, schedule_val=nothing, schedule_modifier=nothing, simd_modifier=nothing, nowait=nothing, ordered_val=nothing, order_val=nothing, inclusive=nothing, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[
-        lowerBound...,
-        upperBound...,
-        step...,
-        linear_vars...,
-        linear_step_vars...,
-        reduction_vars...,
-    ]
-    owned_regions = Region[region,]
+    operands = Value[lowerBound..., upperBound..., step..., linear_vars..., linear_step_vars..., reduction_vars..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(schedule_chunk_var) && push!(operands, schedule_chunk_var)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound),
-            length(upperBound),
-            length(step),
-            length(linear_vars),
-            length(linear_step_vars),
-            length(reduction_vars),
-            (schedule_chunk_var == nothing) ? 0 : 1,
-        ]),
-    )
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(linear_vars), length(linear_step_vars), length(reduction_vars), (schedule_chunk_var==nothing) ? 0 : 1]))
     !isnothing(reductions) && push!(attributes, namedattribute("reductions", reductions))
-    !isnothing(schedule_val) &&
-        push!(attributes, namedattribute("schedule_val", schedule_val))
-    !isnothing(schedule_modifier) &&
-        push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
-    !isnothing(simd_modifier) &&
-        push!(attributes, namedattribute("simd_modifier", simd_modifier))
+    !isnothing(schedule_val) && push!(attributes, namedattribute("schedule_val", schedule_val))
+    !isnothing(schedule_modifier) && push!(attributes, namedattribute("schedule_modifier", schedule_modifier))
+    !isnothing(simd_modifier) && push!(attributes, namedattribute("simd_modifier", simd_modifier))
     !isnothing(nowait) && push!(attributes, namedattribute("nowait", nowait))
     !isnothing(ordered_val) && push!(attributes, namedattribute("ordered_val", ordered_val))
     !isnothing(order_val) && push!(attributes, namedattribute("order_val", order_val))
     !isnothing(inclusive) && push!(attributes, namedattribute("inclusive", inclusive))
-
-    return IR.create_operation(
-        "omp.wsloop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.wsloop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1798,22 +1303,18 @@ end
 terminates the region. The semantics of how the values are yielded is
 defined by the parent operation.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "omp.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "omp.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/PDL.jl
+++ b/src/Dialects/17/PDL.jl
@@ -1,9 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_native_constraint`
@@ -21,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -66,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -112,29 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    valueType=nothing::Union{Nothing,Value};
-    attr::IR.Type,
-    value=nothing,
-    location=Location(),
-)
-    results = IR.Type[attr,]
+function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,20 +133,16 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue,]
+    operands = Value[opValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -191,30 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -234,25 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -353,37 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operandValues::Vector{Value},
-    attributeValues::Vector{Value},
-    typeValues::Vector{Value};
-    op::IR.Type,
-    opName=nothing,
-    attributeValueNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operandValues..., attributeValues..., typeValues...]
+function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operandValues..., attributeValues..., typeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(operandValues), length(attributeValues), length(typeValues)
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -414,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -459,21 +402,17 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -502,32 +441,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    opValue::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[opValue, replValues...]
+    operands = Value[opValue, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,26 +481,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -601,23 +524,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -660,31 +579,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    bodyRegion::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[bodyRegion,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -707,23 +616,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) &&
-        push!(attributes, namedattribute("constantType", constantType))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -746,23 +650,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) &&
-        push!(attributes, namedattribute("constantTypes", constantTypes))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/PDL.jl
+++ b/src/Dialects/17/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_native_constraint`
@@ -20,20 +20,16 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -65,24 +61,18 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl.apply_native_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl.apply_native_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -111,29 +101,20 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(
-    valueType=nothing::Union{Nothing,Value};
-    attr::IR.Type,
-    value=nothing,
-    location=Location(),
-)
-    results = IR.Type[attr,]
+function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
+    results = IR.Type[attr, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "pdl.attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,20 +133,16 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue,]
+    operands = Value[opValue, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -190,30 +167,24 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`operands`
+`operands_`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -233,25 +204,19 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands(
-    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
-)
-    results = IR.Type[value,]
+function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
+    results = IR.Type[value, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-
-    return IR.create_operation(
-        "pdl.operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -352,37 +317,20 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(
-    operandValues::Vector{Value},
-    attributeValues::Vector{Value},
-    typeValues::Vector{Value};
-    op::IR.Type,
-    opName=nothing,
-    attributeValueNames,
-    location=Location(),
-)
-    results = IR.Type[op,]
-    operands = Value[operandValues..., attributeValues..., typeValues...]
+function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
+    results = IR.Type[op, ]
+    operands = Value[operandValues..., attributeValues..., typeValues..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(operandValues), length(attributeValues), length(typeValues)
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
+    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-
-    return IR.create_operation(
-        "pdl.operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -413,20 +361,16 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion,]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit),]
+    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "pdl.pattern",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.pattern", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -458,21 +402,17 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl.range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -501,32 +441,20 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(
-    opValue::Value,
-    replOperation=nothing::Union{Nothing,Value};
-    replValues::Vector{Value},
-    location=Location(),
-)
+function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
     results = IR.Type[]
-    operands = Value[opValue, replValues...]
+    operands = Value[opValue, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(
-        attributes,
-        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
-    )
-
-    return IR.create_operation(
-        "pdl.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
+    
+    IR.create_operation(
+        "pdl.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -553,26 +481,22 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
 """
-`results`
+`results_`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -600,23 +524,19 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val,]
-    operands = Value[parent,]
+function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val, ]
+    operands = Value[parent, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl.results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -659,31 +579,21 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(
-    root=nothing::Union{Nothing,Value};
-    externalArgs::Vector{Value},
-    name=nothing,
-    bodyRegion::Region,
-    location=Location(),
-)
+function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
-    operands = Value[externalArgs...,]
-    owned_regions = Region[bodyRegion,]
+    operands = Value[externalArgs..., ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "pdl.rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl.rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -706,23 +616,18 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) &&
-        push!(attributes, namedattribute("constantType", constantType))
-
-    return IR.create_operation(
-        "pdl.type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
+    
+    IR.create_operation(
+        "pdl.type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -745,23 +650,18 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) &&
-        push!(attributes, namedattribute("constantTypes", constantTypes))
-
-    return IR.create_operation(
-        "pdl.types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
+    
+    IR.create_operation(
+        "pdl.types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/PDL.jl
+++ b/src/Dialects/17/PDL.jl
@@ -1,8 +1,8 @@
 module pdl
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_native_constraint`
@@ -20,16 +20,20 @@ pdl.apply_native_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !p
 """
 function apply_native_constraint(args::Vector{Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl.apply_native_constraint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl.apply_native_constraint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -61,18 +65,24 @@ void registerNativeRewrite(PDLPatternModule &pdlModule) {
 }
 ```
 """
-function apply_native_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[args..., ]
+function apply_native_rewrite(
+    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl.apply_native_rewrite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl.apply_native_rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -101,20 +111,29 @@ defined within a `pdl.rewrite` region, the constant value must be specified.
 %attr = pdl.attribute = \"hello\"
 ```
 """
-function attribute(valueType=nothing::Union{Nothing, Value}; attr::IR.Type, value=nothing, location=Location())
-    results = IR.Type[attr, ]
+function attribute(
+    valueType=nothing::Union{Nothing,Value};
+    attr::IR.Type,
+    value=nothing,
+    location=Location(),
+)
+    results = IR.Type[attr,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    
-    IR.create_operation(
-        "pdl.attribute", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -133,16 +152,20 @@ pdl.erase %root
 """
 function erase(opValue::Value; location=Location())
     results = IR.Type[]
-    operands = Value[opValue, ]
+    operands = Value[opValue,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl.erase", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.erase",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -167,24 +190,30 @@ may partially constrain an operand by specifying an expected value type
 %operand = pdl.operand : %type
 ```
 """
-function operand(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
+function operand(
+    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
+)
+    results = IR.Type[value,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-    
-    IR.create_operation(
-        "pdl.operand", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`operands_`
+`operands`
 
 `pdl.operands` operations capture external operand range edges into an
 operation node that originate from operations or block arguments not
@@ -204,19 +233,25 @@ operands by specifying expected value types (via `pdl.types` operations).
 %typed_operands = pdl.operands : %types
 ```
 """
-function operands_(valueType=nothing::Union{Nothing, Value}; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
+function operands(
+    valueType=nothing::Union{Nothing,Value}; value::IR.Type, location=Location()
+)
+    results = IR.Type[value,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(valueType) && push!(operands, valueType)
-    
-    IR.create_operation(
-        "pdl.operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -317,20 +352,37 @@ def MyOp {
 %op = pdl.operation \"foo.op\" -> (%result, %otherResults : !pdl.type, !pdl.range<type>)
 ```
 """
-function operation(operandValues::Vector{Value}, attributeValues::Vector{Value}, typeValues::Vector{Value}; op::IR.Type, opName=nothing, attributeValueNames, location=Location())
-    results = IR.Type[op, ]
-    operands = Value[operandValues..., attributeValues..., typeValues..., ]
+function operation(
+    operandValues::Vector{Value},
+    attributeValues::Vector{Value},
+    typeValues::Vector{Value};
+    op::IR.Type,
+    opName=nothing,
+    attributeValueNames,
+    location=Location(),
+)
+    results = IR.Type[op,]
+    operands = Value[operandValues..., attributeValues..., typeValues...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames), ]
-    push!(attributes, operandsegmentsizes([length(operandValues), length(attributeValues), length(typeValues), ]))
+    attributes = NamedAttribute[namedattribute("attributeValueNames", attributeValueNames),]
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(operandValues), length(attributeValues), length(typeValues)
+        ]),
+    )
     !isnothing(opName) && push!(attributes, namedattribute("opName", opName))
-    
-    IR.create_operation(
-        "pdl.operation", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -361,16 +413,20 @@ pdl.pattern : benefit(1) {
 function pattern(; benefit, sym_name=nothing, bodyRegion::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[bodyRegion, ]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("benefit", benefit), ]
+    attributes = NamedAttribute[namedattribute("benefit", benefit),]
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    
-    IR.create_operation(
-        "pdl.pattern", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.pattern",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -402,17 +458,21 @@ there are multiple sub ranges used for construction, we won\'t be able
 to determine their sizes during constraint time.
 """
 function range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arguments..., ]
+    results = IR.Type[result,]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl.range", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.range",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -441,20 +501,32 @@ pdl.replace %root with (%vals : !pdl.range<value>)
 pdl.replace %root with %otherOp
 ```
 """
-function replace(opValue::Value, replOperation=nothing::Union{Nothing, Value}; replValues::Vector{Value}, location=Location())
+function replace(
+    opValue::Value,
+    replOperation=nothing::Union{Nothing,Value};
+    replValues::Vector{Value},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[opValue, replValues..., ]
+    operands = Value[opValue, replValues...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(replOperation) && push!(operands, replOperation)
-    push!(attributes, operandsegmentsizes([1, (replOperation==nothing) ? 0 : 1length(replValues), ]))
-    
-    IR.create_operation(
-        "pdl.replace", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, (replOperation == nothing) ? 0 : 1length(replValues)]),
+    )
+
+    return IR.create_operation(
+        "pdl.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -481,22 +553,26 @@ as defined by the ODS definition of the operation.
 ```
 """
 function result(parent::Value; val::IR.Type, index, location=Location())
-    results = IR.Type[val, ]
-    operands = Value[parent, ]
+    results = IR.Type[val,]
+    operands = Value[parent,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl.result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl.result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
 """
-`results_`
+`results`
 
 `pdl.results` operations extract a result group from an operation within a
 pattern or rewrite region. If an index is provided, this operation extracts
@@ -524,19 +600,23 @@ operation.
 %results = pdl.results 1 of %operation -> !pdl.value
 ```
 """
-function results_(parent::Value; val::IR.Type, index=nothing, location=Location())
-    results = IR.Type[val, ]
-    operands = Value[parent, ]
+function results(parent::Value; val::IR.Type, index=nothing, location=Location())
+    results = IR.Type[val,]
+    operands = Value[parent,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl.results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -579,21 +659,31 @@ pdl.rewrite {
 }
 ```
 """
-function rewrite(root=nothing::Union{Nothing, Value}; externalArgs::Vector{Value}, name=nothing, bodyRegion::Region, location=Location())
+function rewrite(
+    root=nothing::Union{Nothing,Value};
+    externalArgs::Vector{Value},
+    name=nothing,
+    bodyRegion::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[externalArgs..., ]
-    owned_regions = Region[bodyRegion, ]
+    operands = Value[externalArgs...,]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(externalArgs), ]))
+    push!(attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(externalArgs)]))
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "pdl.rewrite", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl.rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -616,18 +706,23 @@ partially constrain the result by specifying a constant `Type`.
 ```
 """
 function type(; result::IR.Type, constantType=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantType) && push!(attributes, namedattribute("constantType", constantType))
-    
-    IR.create_operation(
-        "pdl.type", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constantType) &&
+        push!(attributes, namedattribute("constantType", constantType))
+
+    return IR.create_operation(
+        "pdl.type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -650,18 +745,23 @@ an array of `Type`s.
 ```
 """
 function types(; result::IR.Type, constantTypes=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(constantTypes) && push!(attributes, namedattribute("constantTypes", constantTypes))
-    
-    IR.create_operation(
-        "pdl.types", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constantTypes) &&
+        push!(attributes, namedattribute("constantTypes", constantTypes))
+
+    return IR.create_operation(
+        "pdl.types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/PDLInterp.jl
+++ b/src/Dialects/17/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_constraint`
@@ -20,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -135,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -163,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -203,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -244,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -284,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -325,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -359,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -399,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -425,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -462,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -523,21 +423,17 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.create_range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.create_range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -554,21 +450,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -585,21 +477,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -618,20 +506,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -649,21 +533,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -685,16 +565,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -719,20 +595,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -754,33 +626,20 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -798,21 +657,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -829,21 +684,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -862,21 +713,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -894,21 +741,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -936,22 +779,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -969,21 +808,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1011,22 +846,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,21 +879,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1083,21 +910,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1117,20 +940,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1149,37 +968,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1200,20 +1003,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1231,28 +1030,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1270,28 +1059,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1309,28 +1088,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1117,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1387,24 +1146,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1422,24 +1175,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/PDLInterp.jl
+++ b/src/Dialects/17/PDLInterp.jl
@@ -1,8 +1,8 @@
 module pdl_interp
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_constraint`
@@ -20,18 +20,24 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
+function apply_constraint(
+    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[args..., ]
+    operands = Value[args...,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.apply_constraint", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.apply_constraint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,18 +63,24 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[args..., ]
+function apply_rewrite(
+    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[args...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.apply_rewrite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.apply_rewrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -85,18 +97,24 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
+function are_equal(
+    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.are_equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.are_equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -117,14 +135,18 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest, ]
+    successors = Block[dest,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.branch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -141,18 +163,24 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
+function check_attribute(
+    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[attribute, ]
+    operands = Value[attribute,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_attribute", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
+
+    return IR.create_operation(
+        "pdl_interp.check_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -175,19 +203,31 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
+function check_operand_count(
+    inputOp::Value;
+    count,
+    compareAtLeast=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-    
-    IR.create_operation(
-        "pdl_interp.check_operand_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("count", count),]
+    !isnothing(compareAtLeast) &&
+        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+
+    return IR.create_operation(
+        "pdl_interp.check_operand_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -204,18 +244,24 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
+function check_operation_name(
+    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_operation_name", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.check_operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -238,19 +284,31 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
+function check_result_count(
+    inputOp::Value;
+    count,
+    compareAtLeast=nothing,
+    trueDest::Block,
+    falseDest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("count", count), ]
-    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-    
-    IR.create_operation(
-        "pdl_interp.check_result_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("count", count),]
+    !isnothing(compareAtLeast) &&
+        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+
+    return IR.create_operation(
+        "pdl_interp.check_result_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -267,18 +325,24 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
+function check_type(
+    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("type", type), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_type", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("type", type),]
+
+    return IR.create_operation(
+        "pdl_interp.check_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -295,18 +359,24 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
+function check_types(
+    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
-    attributes = NamedAttribute[namedattribute("types", types), ]
-    
-    IR.create_operation(
-        "pdl_interp.check_types", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[trueDest, falseDest]
+    attributes = NamedAttribute[namedattribute("types", types),]
+
+    return IR.create_operation(
+        "pdl_interp.check_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -329,12 +399,16 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.continue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.continue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -351,17 +425,21 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute, ]
+    results = IR.Type[attribute,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -384,20 +462,42 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
-    results = IR.Type[resultOp, ]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
+function create_operation(
+    inputOperands::Vector{Value},
+    inputAttributes::Vector{Value},
+    inputResultTypes::Vector{Value};
+    resultOp::IR.Type,
+    name,
+    inputAttributeNames,
+    inferredResultTypes=nothing,
+    location=Location(),
+)
+    results = IR.Type[resultOp,]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
-    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
-    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-    
-    IR.create_operation(
-        "pdl_interp.create_operation", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("name", name),
+        namedattribute("inputAttributeNames", inputAttributeNames),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(inputOperands), length(inputAttributes), length(inputResultTypes)
+        ]),
+    )
+    !isnothing(inferredResultTypes) &&
+        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+
+    return IR.create_operation(
+        "pdl_interp.create_operation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -423,17 +523,21 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arguments..., ]
+    results = IR.Type[result,]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.create_range", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.create_range",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -450,17 +554,21 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_type", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -477,17 +585,21 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "pdl_interp.create_types", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "pdl_interp.create_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -506,16 +618,20 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.erase", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.erase",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -533,17 +649,21 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[range, ]
+    results = IR.Type[result,]
+    operands = Value[range,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.extract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -565,12 +685,16 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.finalize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.finalize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -595,16 +719,20 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values, ]
-    owned_regions = Region[region, ]
-    successors = Block[successor, ]
+    operands = Value[values,]
+    owned_regions = Region[region,]
+    successors = Block[successor,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -626,20 +754,33 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "pdl_interp.func", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -657,17 +798,21 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[attribute,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_attribute", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("name", name),]
+
+    return IR.create_operation(
+        "pdl_interp.get_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -684,17 +829,21 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_attribute_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_attribute_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -713,17 +862,21 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp, ]
-    operands = Value[value, ]
+    results = IR.Type[inputOp,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_defining_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_defining_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -741,17 +894,21 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_operand", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.get_operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -779,18 +936,22 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl_interp.get_operands", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_operands",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -808,17 +969,21 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index), ]
-    
-    IR.create_operation(
-        "pdl_interp.get_result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("index", index),]
+
+    return IR.create_operation(
+        "pdl_interp.get_result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -846,18 +1011,22 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[inputOp, ]
+    results = IR.Type[value,]
+    operands = Value[inputOp,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-    
-    IR.create_operation(
-        "pdl_interp.get_results", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_results",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -879,17 +1048,21 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations, ]
-    operands = Value[value, ]
+    results = IR.Type[operations,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_users", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_users",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -910,17 +1083,21 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.get_value_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.get_value_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -940,16 +1117,20 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest, ]
+    successors = Block[trueDest, falseDest]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.is_not_null", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.is_not_null",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -968,21 +1149,37 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
+function record_match(
+    inputs::Vector{Value},
+    matchedOps::Vector{Value};
+    rewriter,
+    rootKind=nothing,
+    generatedOps=nothing,
+    benefit,
+    dest::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps..., ]
+    operands = Value[inputs..., matchedOps...]
     owned_regions = Region[]
-    successors = Block[dest, ]
-    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
+    successors = Block[dest,]
+    attributes = NamedAttribute[
+        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
+    ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
-    
-    IR.create_operation(
-        "pdl_interp.record_match", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(generatedOps) &&
+        push!(attributes, namedattribute("generatedOps", generatedOps))
+
+    return IR.create_operation(
+        "pdl_interp.record_match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1003,16 +1200,20 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues..., ]
+    operands = Value[inputOp, replValues...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "pdl_interp.replace", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "pdl_interp.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1030,18 +1231,28 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_attribute(
+    attribute::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[attribute, ]
+    operands = Value[attribute,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_attribute", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_attribute",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1059,18 +1270,28 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_operand_count(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_operand_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_operand_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1088,18 +1309,28 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_operation_name(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_operation_name", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1117,18 +1348,28 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_result_count(
+    inputOp::Value;
+    caseValues,
+    defaultDest::Block,
+    cases::Vector{Block},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[inputOp, ]
+    operands = Value[inputOp,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_result_count", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_result_count",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1146,18 +1387,24 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_type(
+    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_type", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1175,18 +1422,24 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
+function switch_types(
+    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases..., ]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
-    
-    IR.create_operation(
-        "pdl_interp.switch_types", location;
-        operands, owned_regions, successors, attributes,
+    successors = Block[defaultDest, cases...]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
+
+    return IR.create_operation(
+        "pdl_interp.switch_types",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/PDLInterp.jl
+++ b/src/Dialects/17/PDLInterp.jl
@@ -1,9 +1,8 @@
 module pdl_interp
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_constraint`
@@ -21,24 +20,18 @@ otherwise the false destination is taken.
 pdl_interp.apply_constraint \"myConstraint\"(%input, %attr, %op : !pdl.value, !pdl.attribute, !pdl.operation) -> ^matchDest, ^failureDest
 ```
 """
-function apply_constraint(
-    args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function apply_constraint(args::Vector{Value}; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[args...,]
+    operands = Value[args..., ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_constraint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_constraint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,24 +57,18 @@ pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation)
 pdl_interp.apply_rewrite \"rewriter\"(%root : !pdl.operation, %value : !pdl.value)
 ```
 """
-function apply_rewrite(
-    args::Vector{Value}; results::Vector{IR.Type}, name, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[args...,]
+function apply_rewrite(args::Vector{Value}; results_::Vector{IR.Type}, name, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[args..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.apply_rewrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.apply_rewrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -98,24 +85,18 @@ otherwise the false destination is taken.
 pdl_interp.are_equal %result1, %result2 : !pdl.value -> ^matchDest, ^failureDest
 ```
 """
-function are_equal(
-    lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location()
-)
+function are_equal(lhs::Value, rhs::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.are_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.are_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -136,18 +117,14 @@ function branch(; dest::Block, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
-    successors = Block[dest,]
+    successors = Block[dest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -164,24 +141,18 @@ true destination, otherwise the false destination is taken.
 pdl_interp.check_attribute %attr is 10 -> ^matchDest, ^failureDest
 ```
 """
-function check_attribute(
-    attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_attribute(attribute::Value; constantValue, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("constantValue", constantValue),]
-
-    return IR.create_operation(
-        "pdl_interp.check_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("constantValue", constantValue), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -204,31 +175,19 @@ pdl_interp.check_operand_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_operand_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_operand_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_operand_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -245,24 +204,18 @@ destination, otherwise the false destination is taken.
 pdl_interp.check_operation_name of %op is \"foo.op\" -> ^matchDest, ^failureDest
 ```
 """
-function check_operation_name(
-    inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_operation_name(inputOp::Value; name, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.check_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -285,31 +238,19 @@ pdl_interp.check_result_count of %op is 2 -> ^matchDest, ^failureDest
 pdl_interp.check_result_count of %op is at_least 2 -> ^matchDest, ^failureDest
 ```
 """
-function check_result_count(
-    inputOp::Value;
-    count,
-    compareAtLeast=nothing,
-    trueDest::Block,
-    falseDest::Block,
-    location=Location(),
-)
+function check_result_count(inputOp::Value; count, compareAtLeast=nothing, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("count", count),]
-    !isnothing(compareAtLeast) &&
-        push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
-
-    return IR.create_operation(
-        "pdl_interp.check_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("count", count), ]
+    !isnothing(compareAtLeast) && push!(attributes, namedattribute("compareAtLeast", compareAtLeast))
+    
+    IR.create_operation(
+        "pdl_interp.check_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,24 +267,18 @@ the false destination is taken.
 pdl_interp.check_type %type is i32 -> ^matchDest, ^failureDest
 ```
 """
-function check_type(
-    value::Value; type, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_type(value::Value; type, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("type", type),]
-
-    return IR.create_operation(
-        "pdl_interp.check_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("type", type), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -360,24 +295,18 @@ to the true destination, otherwise the false destination is taken.
 pdl_interp.check_types %type are [i32, i64] -> ^matchDest, ^failureDest
 ```
 """
-function check_types(
-    value::Value; types, trueDest::Block, falseDest::Block, location=Location()
-)
+function check_types(value::Value; types, trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
-    attributes = NamedAttribute[namedattribute("types", types),]
-
-    return IR.create_operation(
-        "pdl_interp.check_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[trueDest, falseDest, ]
+    attributes = NamedAttribute[namedattribute("types", types), ]
+    
+    IR.create_operation(
+        "pdl_interp.check_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -400,16 +329,12 @@ function continue_(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.continue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.continue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,21 +351,17 @@ interpreter for a specific constant attribute value.
 ```
 """
 function create_attribute(; attribute::IR.Type, value, location=Location())
-    results = IR.Type[attribute,]
+    results = IR.Type[attribute, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,42 +384,20 @@ to this operation.
 %op = pdl_interp.create_operation \"foo.op\"(%arg0 : !pdl.value) {\"attrA\" = %attr0} -> <inferred>
 ```
 """
-function create_operation(
-    inputOperands::Vector{Value},
-    inputAttributes::Vector{Value},
-    inputResultTypes::Vector{Value};
-    resultOp::IR.Type,
-    name,
-    inputAttributeNames,
-    inferredResultTypes=nothing,
-    location=Location(),
-)
-    results = IR.Type[resultOp,]
-    operands = Value[inputOperands..., inputAttributes..., inputResultTypes...]
+function create_operation(inputOperands::Vector{Value}, inputAttributes::Vector{Value}, inputResultTypes::Vector{Value}; resultOp::IR.Type, name, inputAttributeNames, inferredResultTypes=nothing, location=Location())
+    results = IR.Type[resultOp, ]
+    operands = Value[inputOperands..., inputAttributes..., inputResultTypes..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("name", name),
-        namedattribute("inputAttributeNames", inputAttributeNames),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(inputOperands), length(inputAttributes), length(inputResultTypes)
-        ]),
-    )
-    !isnothing(inferredResultTypes) &&
-        push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
-
-    return IR.create_operation(
-        "pdl_interp.create_operation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), namedattribute("inputAttributeNames", inputAttributeNames), ]
+    push!(attributes, operandsegmentsizes([length(inputOperands), length(inputAttributes), length(inputResultTypes), ]))
+    !isnothing(inferredResultTypes) && push!(attributes, namedattribute("inferredResultTypes", inferredResultTypes))
+    
+    IR.create_operation(
+        "pdl_interp.create_operation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -524,21 +423,17 @@ or `!pdl.range<value>` entities.
 ```
 """
 function create_range(arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arguments...,]
+    results = IR.Type[result, ]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.create_range",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.create_range", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -555,21 +450,17 @@ pdl_interp.create_type i64
 ```
 """
 function create_type(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -586,21 +477,17 @@ pdl_interp.create_types [i64, i64]
 ```
 """
 function create_types(; result::IR.Type, value, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "pdl_interp.create_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "pdl_interp.create_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -619,20 +506,16 @@ pdl_interp.erase %root
 """
 function erase(inputOp::Value; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.erase",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.erase", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -650,21 +533,17 @@ at the specified index. If the index is out of range, returns null.
 ```
 """
 function extract(range::Value; result::IR.Type, index, location=Location())
-    results = IR.Type[result,]
-    operands = Value[range,]
+    results = IR.Type[result, ]
+    operands = Value[range, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -686,16 +565,12 @@ function finalize(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.finalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.finalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -720,20 +595,16 @@ pdl_interp.foreach %op : !pdl.operation in %ops {
 """
 function foreach(values::Value; region::Region, successor::Block, location=Location())
     results = IR.Type[]
-    operands = Value[values,]
-    owned_regions = Region[region,]
-    successors = Block[successor,]
+    operands = Value[values, ]
+    owned_regions = Region[region, ]
+    successors = Block[successor, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,33 +626,20 @@ pdl_interp.func @rewriter(%root: !pdl.operation) {
 }
 ```
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "pdl_interp.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -799,21 +657,17 @@ returned.
 ```
 """
 function get_attribute(inputOp::Value; attribute::IR.Type, name, location=Location())
-    results = IR.Type[attribute,]
-    operands = Value[inputOp,]
+    results = IR.Type[attribute, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("name", name), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -830,21 +684,17 @@ specific attribute.
 ```
 """
 function get_attribute_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_attribute_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_attribute_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -863,21 +713,17 @@ or range of operand results, null is returned.
 ```
 """
 function get_defining_op(value::Value; inputOp::IR.Type, location=Location())
-    results = IR.Type[inputOp,]
-    operands = Value[value,]
+    results = IR.Type[inputOp, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -895,21 +741,17 @@ null value is returned.
 ```
 """
 function get_operand(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -937,22 +779,18 @@ the returned operand group corresponds to all operands of the operation.
 ```
 """
 function get_operands(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_operands",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_operands", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -970,21 +808,17 @@ null value is returned.
 ```
 """
 function get_result(inputOp::Value; value::IR.Type, index, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("index", index),]
-
-    return IR.create_operation(
-        "pdl_interp.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("index", index), ]
+    
+    IR.create_operation(
+        "pdl_interp.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1012,22 +846,18 @@ the returned operand group corresponds to all results of the operation.
 ```
 """
 function get_results(inputOp::Value; value::IR.Type, index=nothing, location=Location())
-    results = IR.Type[value,]
-    operands = Value[inputOp,]
+    results = IR.Type[value, ]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(index) && push!(attributes, namedattribute("index", index))
-
-    return IR.create_operation(
-        "pdl_interp.get_results",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_results", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1049,21 +879,17 @@ similarly to ResultRange::getUsers.
 ```
 """
 function get_users(value::Value; operations::IR.Type, location=Location())
-    results = IR.Type[operations,]
-    operands = Value[value,]
+    results = IR.Type[operations, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_users",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_users", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1084,21 +910,17 @@ value or range thereof.
 ```
 """
 function get_value_type(value::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[value,]
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.get_value_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.get_value_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1118,20 +940,16 @@ pdl_interp.is_not_null %value : !pdl.value -> ^matchDest, ^failureDest
 """
 function is_not_null(value::Value; trueDest::Block, falseDest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[trueDest, falseDest]
+    successors = Block[trueDest, falseDest, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.is_not_null",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.is_not_null", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1150,37 +968,21 @@ rewriter.
 pdl_interp.record_match @rewriters::myRewriter(%root : !pdl.operation) : benefit(1), loc([%root, %op1]), root(\"foo.op\") -> ^nextDest
 ```
 """
-function record_match(
-    inputs::Vector{Value},
-    matchedOps::Vector{Value};
-    rewriter,
-    rootKind=nothing,
-    generatedOps=nothing,
-    benefit,
-    dest::Block,
-    location=Location(),
-)
+function record_match(inputs::Vector{Value}, matchedOps::Vector{Value}; rewriter, rootKind=nothing, generatedOps=nothing, benefit, dest::Block, location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., matchedOps...]
+    operands = Value[inputs..., matchedOps..., ]
     owned_regions = Region[]
-    successors = Block[dest,]
-    attributes = NamedAttribute[
-        namedattribute("rewriter", rewriter), namedattribute("benefit", benefit)
-    ]
-    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps)]))
+    successors = Block[dest, ]
+    attributes = NamedAttribute[namedattribute("rewriter", rewriter), namedattribute("benefit", benefit), ]
+    push!(attributes, operandsegmentsizes([length(inputs), length(matchedOps), ]))
     !isnothing(rootKind) && push!(attributes, namedattribute("rootKind", rootKind))
-    !isnothing(generatedOps) &&
-        push!(attributes, namedattribute("generatedOps", generatedOps))
-
-    return IR.create_operation(
-        "pdl_interp.record_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generatedOps) && push!(attributes, namedattribute("generatedOps", generatedOps))
+    
+    IR.create_operation(
+        "pdl_interp.record_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1201,20 +1003,16 @@ pdl_interp.replace %root with (%val0, %val1 : !pdl.type, !pdl.type)
 """
 function replace(inputOp::Value, replValues::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputOp, replValues...]
+    operands = Value[inputOp, replValues..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "pdl_interp.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "pdl_interp.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1232,28 +1030,18 @@ the default destination is taken.
 pdl_interp.switch_attribute %attr to [10, true](^10Dest, ^trueDest) -> ^defaultDest
 ```
 """
-function switch_attribute(
-    attribute::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_attribute(attribute::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[attribute,]
+    operands = Value[attribute, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_attribute",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_attribute", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1271,28 +1059,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_operand_count of %op to [10, 2] -> ^10Dest, ^2Dest, ^defaultDest
 ```
 """
-function switch_operand_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operand_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operand_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operand_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1310,28 +1088,18 @@ the default destination is taken.
 pdl_interp.switch_operation_name of %op to [\"foo.op\", \"bar.op\"](^fooDest, ^barDest) -> ^defaultDest
 ```
 """
-function switch_operation_name(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_operation_name(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,28 +1117,18 @@ otherwise the default destination is taken.
 pdl_interp.switch_result_count of %op to [0, 2](^0Dest, ^2Dest) -> ^defaultDest
 ```
 """
-function switch_result_count(
-    inputOp::Value;
-    caseValues,
-    defaultDest::Block,
-    cases::Vector{Block},
-    location=Location(),
-)
+function switch_result_count(inputOp::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[inputOp,]
+    operands = Value[inputOp, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_result_count",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_result_count", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1388,24 +1146,18 @@ is taken.
 pdl_interp.switch_type %type to [i32, i64] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_type(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_type(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1423,24 +1175,18 @@ destination is taken.
 pdl_interp.switch_types %type is [[i32], [i64, i64]] -> ^i32Dest, ^i64Dest, ^defaultDest
 ```
 """
-function switch_types(
-    value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location()
-)
+function switch_types(value::Value; caseValues, defaultDest::Block, cases::Vector{Block}, location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
-    successors = Block[defaultDest, cases...]
-    attributes = NamedAttribute[namedattribute("caseValues", caseValues),]
-
-    return IR.create_operation(
-        "pdl_interp.switch_types",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    successors = Block[defaultDest, cases..., ]
+    attributes = NamedAttribute[namedattribute("caseValues", caseValues), ]
+    
+    IR.create_operation(
+        "pdl_interp.switch_types", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Quant.jl
+++ b/src/Dialects/17/Quant.jl
@@ -1,8 +1,8 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `dcast`
@@ -19,21 +19,17 @@ all operands to ops that must operate with the expressed type (typically
 math ops prior to lowering to target-specific, quantized kernels).
 """
 function dcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,21 +58,17 @@ it is legal to use a quantized representation (but is not known to be
 acceptable).
 """
 function qcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -102,21 +94,17 @@ vector<4xi8> -> vector<4x!quant<\"uniform[i8:f32]{1.0}\">>
 ```
 """
 function scast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Quant.jl
+++ b/src/Dialects/17/Quant.jl
@@ -1,9 +1,8 @@
 module quant
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `dcast`
@@ -20,21 +19,17 @@ all operands to ops that must operate with the expressed type (typically
 math ops prior to lowering to target-specific, quantized kernels).
 """
 function dcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.dcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.dcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,21 +58,17 @@ it is legal to use a quantized representation (but is not known to be
 acceptable).
 """
 function qcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.qcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.qcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -103,21 +94,17 @@ vector<4xi8> -> vector<4x!quant<\"uniform[i8:f32]{1.0}\">>
 ```
 """
 function scast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res,]
-    operands = Value[arg,]
+    results = IR.Type[res, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "quant.scast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "quant.scast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Quant.jl
+++ b/src/Dialects/17/Quant.jl
@@ -1,8 +1,8 @@
 module quant
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `dcast`
@@ -19,17 +19,21 @@ all operands to ops that must operate with the expressed type (typically
 math ops prior to lowering to target-specific, quantized kernels).
 """
 function dcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.dcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.dcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -58,17 +62,21 @@ it is legal to use a quantized representation (but is not known to be
 acceptable).
 """
 function qcast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.qcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.qcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -94,17 +102,21 @@ vector<4xi8> -> vector<4x!quant<\"uniform[i8:f32]{1.0}\">>
 ```
 """
 function scast(arg::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[arg, ]
+    results = IR.Type[res,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "quant.scast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "quant.scast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/SCF.jl
+++ b/src/Dialects/17/SCF.jl
@@ -1,9 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `condition`
@@ -15,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -74,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -186,30 +177,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -375,48 +354,20 @@ Example with privatized tensors:
 }
 ```
 """
-function forall(
-    dynamicLowerBound::Vector{Value},
-    dynamicUpperBound::Vector{Value},
-    dynamicStep::Vector{Value},
-    outputs::Vector{Value};
-    results::Vector{IR.Type},
-    staticLowerBound,
-    staticUpperBound,
-    staticStep,
-    mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[dynamicLowerBound..., dynamicUpperBound..., dynamicStep..., outputs...]
-    owned_regions = Region[region,]
+function forall(dynamicLowerBound::Vector{Value}, dynamicUpperBound::Vector{Value}, dynamicStep::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, staticLowerBound, staticUpperBound, staticStep, mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[dynamicLowerBound..., dynamicUpperBound..., dynamicStep..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("staticLowerBound", staticLowerBound),
-        namedattribute("staticUpperBound", staticUpperBound),
-        namedattribute("staticStep", staticStep),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(dynamicLowerBound),
-            length(dynamicUpperBound),
-            length(dynamicStep),
-            length(outputs),
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("staticLowerBound", staticLowerBound), namedattribute("staticUpperBound", staticUpperBound), namedattribute("staticStep", staticStep), ]
+    push!(attributes, operandsegmentsizes([length(dynamicLowerBound), length(dynamicUpperBound), length(dynamicStep), length(outputs), ]))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "scf.forall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.forall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -471,28 +422,18 @@ scf.if %b  {
 The types of the yielded values must match the result types of the
 `scf.if`.
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -510,19 +451,15 @@ The result number corresponds to the position of the op in the terminator.
 function forall_in_parallel(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.forall.in_parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.forall.in_parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -557,29 +494,18 @@ default {
 }
 ```
 """
-function index_switch(
-    arg::Value;
-    results::Vector{IR.Type},
-    cases,
-    defaultRegion::Region,
-    caseRegions::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[arg,]
-    owned_regions = Region[defaultRegion, caseRegions...]
+function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[arg, ]
+    owned_regions = Region[defaultRegion, caseRegions..., ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases),]
-
-    return IR.create_operation(
-        "scf.index_switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases), ]
+    
+    IR.create_operation(
+        "scf.index_switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -629,36 +555,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -700,20 +609,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -730,20 +635,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -861,28 +762,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -899,22 +790,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/SCF.jl
+++ b/src/Dialects/17/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `condition`
@@ -14,16 +14,20 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args..., ]
+    operands = Value[condition, args...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.condition", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.condition",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -69,17 +73,21 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0..., ]
+    results = IR.Type[result_0...,]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.execute_region", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.execute_region",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -177,18 +185,30 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[lowerBound, upperBound, step, initArgs..., ]
-    owned_regions = Region[region, ]
+function for_(
+    lowerBound::Value,
+    upperBound::Value,
+    step::Value,
+    initArgs::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[lowerBound, upperBound, step, initArgs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -354,20 +374,48 @@ Example with privatized tensors:
 }
 ```
 """
-function forall(dynamicLowerBound::Vector{Value}, dynamicUpperBound::Vector{Value}, dynamicStep::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, staticLowerBound, staticUpperBound, staticStep, mapping=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[dynamicLowerBound..., dynamicUpperBound..., dynamicStep..., outputs..., ]
-    owned_regions = Region[region, ]
+function forall(
+    dynamicLowerBound::Vector{Value},
+    dynamicUpperBound::Vector{Value},
+    dynamicStep::Vector{Value},
+    outputs::Vector{Value};
+    results::Vector{IR.Type},
+    staticLowerBound,
+    staticUpperBound,
+    staticStep,
+    mapping=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[dynamicLowerBound..., dynamicUpperBound..., dynamicStep..., outputs...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("staticLowerBound", staticLowerBound), namedattribute("staticUpperBound", staticUpperBound), namedattribute("staticStep", staticStep), ]
-    push!(attributes, operandsegmentsizes([length(dynamicLowerBound), length(dynamicUpperBound), length(dynamicStep), length(outputs), ]))
+    attributes = NamedAttribute[
+        namedattribute("staticLowerBound", staticLowerBound),
+        namedattribute("staticUpperBound", staticUpperBound),
+        namedattribute("staticStep", staticStep),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(dynamicLowerBound),
+            length(dynamicUpperBound),
+            length(dynamicStep),
+            length(outputs),
+        ]),
+    )
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-    
-    IR.create_operation(
-        "scf.forall", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.forall",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -422,18 +470,28 @@ scf.if %b  {
 The types of the yielded values must match the result types of the
 `scf.if`.
 """
-function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[condition, ]
-    owned_regions = Region[thenRegion, elseRegion, ]
+function if_(
+    condition::Value;
+    results::Vector{IR.Type},
+    thenRegion::Region,
+    elseRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[condition,]
+    owned_regions = Region[thenRegion, elseRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -451,15 +509,19 @@ The result number corresponds to the position of the op in the terminator.
 function forall_in_parallel(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region, ]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.forall.in_parallel", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.forall.in_parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -494,18 +556,29 @@ default {
 }
 ```
 """
-function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[arg, ]
-    owned_regions = Region[defaultRegion, caseRegions..., ]
+function index_switch(
+    arg::Value;
+    results::Vector{IR.Type},
+    cases,
+    defaultRegion::Region,
+    caseRegions::Vector{Region},
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[arg,]
+    owned_regions = Region[defaultRegion, caseRegions...]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases), ]
-    
-    IR.create_operation(
-        "scf.index_switch", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases),]
+
+    return IR.create_operation(
+        "scf.index_switch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -555,19 +628,36 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
-    owned_regions = Region[region, ]
+function parallel(
+    lowerBound::Vector{Value},
+    upperBound::Vector{Value},
+    step::Vector{Value},
+    initVals::Vector{Value};
+    results::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[lowerBound..., upperBound..., step..., initVals...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
-    
-    IR.create_operation(
-        "scf.parallel", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([
+            length(lowerBound), length(upperBound), length(step), length(initVals)
+        ]),
+    )
+
+    return IR.create_operation(
+        "scf.parallel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -609,16 +699,20 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
-    owned_regions = Region[reductionOperator, ]
+    operands = Value[operand,]
+    owned_regions = Region[reductionOperator,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -635,16 +729,20 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result, ]
+    operands = Value[result,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.reduce.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.reduce.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -762,18 +860,28 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[inits..., ]
-    owned_regions = Region[before, after, ]
+function while_(
+    inits::Vector{Value};
+    results::Vector{IR.Type},
+    before::Region,
+    after::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[inits...,]
+    owned_regions = Region[before, after]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.while", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.while",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -790,18 +898,22 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results_::Vector{Value}; location=Location())
+function yield(results::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results_..., ]
+    operands = Value[results...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "scf.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "scf.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/SCF.jl
+++ b/src/Dialects/17/SCF.jl
@@ -1,8 +1,8 @@
 module scf
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `condition`
@@ -14,20 +14,16 @@ to the entry block of the region. Otherwise, the loop terminates.
 """
 function condition(condition::Value, args::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[condition, args...]
+    operands = Value[condition, args..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.condition",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.condition", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -73,21 +69,17 @@ affine.for %i = 0 to 100 {
 ```
 """
 function execute_region(; result_0::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result_0...,]
+    results = IR.Type[result_0..., ]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.execute_region",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.execute_region", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -185,30 +177,18 @@ func.func @conditional_reduce(%buffer: memref<1024xf32>, %lb: index,
 }
 ```
 """
-function for_(
-    lowerBound::Value,
-    upperBound::Value,
-    step::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound, upperBound, step, initArgs...]
-    owned_regions = Region[region,]
+function for_(lowerBound::Value, upperBound::Value, step::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound, upperBound, step, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -374,48 +354,20 @@ Example with privatized tensors:
 }
 ```
 """
-function forall(
-    dynamicLowerBound::Vector{Value},
-    dynamicUpperBound::Vector{Value},
-    dynamicStep::Vector{Value},
-    outputs::Vector{Value};
-    results::Vector{IR.Type},
-    staticLowerBound,
-    staticUpperBound,
-    staticStep,
-    mapping=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[dynamicLowerBound..., dynamicUpperBound..., dynamicStep..., outputs...]
-    owned_regions = Region[region,]
+function forall(dynamicLowerBound::Vector{Value}, dynamicUpperBound::Vector{Value}, dynamicStep::Vector{Value}, outputs::Vector{Value}; results_::Vector{IR.Type}, staticLowerBound, staticUpperBound, staticStep, mapping=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[dynamicLowerBound..., dynamicUpperBound..., dynamicStep..., outputs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("staticLowerBound", staticLowerBound),
-        namedattribute("staticUpperBound", staticUpperBound),
-        namedattribute("staticStep", staticStep),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(dynamicLowerBound),
-            length(dynamicUpperBound),
-            length(dynamicStep),
-            length(outputs),
-        ]),
-    )
+    attributes = NamedAttribute[namedattribute("staticLowerBound", staticLowerBound), namedattribute("staticUpperBound", staticUpperBound), namedattribute("staticStep", staticStep), ]
+    push!(attributes, operandsegmentsizes([length(dynamicLowerBound), length(dynamicUpperBound), length(dynamicStep), length(outputs), ]))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "scf.forall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.forall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,28 +422,18 @@ scf.if %b  {
 The types of the yielded values must match the result types of the
 `scf.if`.
 """
-function if_(
-    condition::Value;
-    results::Vector{IR.Type},
-    thenRegion::Region,
-    elseRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[condition,]
-    owned_regions = Region[thenRegion, elseRegion]
+function if_(condition::Value; results_::Vector{IR.Type}, thenRegion::Region, elseRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[condition, ]
+    owned_regions = Region[thenRegion, elseRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -509,19 +451,15 @@ The result number corresponds to the position of the op in the terminator.
 function forall_in_parallel(; region::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region,]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.forall.in_parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.forall.in_parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -556,29 +494,18 @@ default {
 }
 ```
 """
-function index_switch(
-    arg::Value;
-    results::Vector{IR.Type},
-    cases,
-    defaultRegion::Region,
-    caseRegions::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[arg,]
-    owned_regions = Region[defaultRegion, caseRegions...]
+function index_switch(arg::Value; results_::Vector{IR.Type}, cases, defaultRegion::Region, caseRegions::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[arg, ]
+    owned_regions = Region[defaultRegion, caseRegions..., ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cases", cases),]
-
-    return IR.create_operation(
-        "scf.index_switch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("cases", cases), ]
+    
+    IR.create_operation(
+        "scf.index_switch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -628,36 +555,19 @@ scf.parallel (%iv) = (%lb) to (%ub) step (%step) init (%init) -> f32 {
 }
 ```
 """
-function parallel(
-    lowerBound::Vector{Value},
-    upperBound::Vector{Value},
-    step::Vector{Value},
-    initVals::Vector{Value};
-    results::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[lowerBound..., upperBound..., step..., initVals...]
-    owned_regions = Region[region,]
+function parallel(lowerBound::Vector{Value}, upperBound::Vector{Value}, step::Vector{Value}, initVals::Vector{Value}; results_::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[lowerBound..., upperBound..., step..., initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([
-            length(lowerBound), length(upperBound), length(step), length(initVals)
-        ]),
-    )
-
-    return IR.create_operation(
-        "scf.parallel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([length(lowerBound), length(upperBound), length(step), length(initVals), ]))
+    
+    IR.create_operation(
+        "scf.parallel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -699,20 +609,16 @@ scf.reduce(%operand) : f32 {
 """
 function reduce(operand::Value; reductionOperator::Region, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
-    owned_regions = Region[reductionOperator,]
+    operands = Value[operand, ]
+    owned_regions = Region[reductionOperator, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -729,20 +635,16 @@ scf.reduce.return %res : f32
 """
 function reduce_return(result::Value; location=Location())
     results = IR.Type[]
-    operands = Value[result,]
+    operands = Value[result, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.reduce.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.reduce.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -860,28 +762,18 @@ assignment-list ::= assignment | assignment `,` assignment-list
 assignment ::= ssa-value `=` ssa-value
 ```
 """
-function while_(
-    inits::Vector{Value};
-    results::Vector{IR.Type},
-    before::Region,
-    after::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[inits...,]
-    owned_regions = Region[before, after]
+function while_(inits::Vector{Value}; results_::Vector{IR.Type}, before::Region, after::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[inits..., ]
+    owned_regions = Region[before, after, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.while",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.while", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -898,22 +790,18 @@ left out in the custom syntax and the builders will insert one implicitly.
 Otherwise, it has to be present in the syntax to indicate which values are
 yielded.
 """
-function yield(results::Vector{Value}; location=Location())
+function yield(results_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[results...,]
+    operands = Value[results_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "scf.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "scf.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/SPIRV.jl
+++ b/src/Dialects/17/SPIRV.jl
@@ -1,9 +1,8 @@
 module spirv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `AccessChain`
@@ -47,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -93,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spirv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spirv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,31 +137,18 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -222,35 +198,18 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -278,35 +237,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -343,31 +285,18 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -404,31 +333,18 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -464,26 +380,18 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -518,26 +426,18 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -575,31 +475,18 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -636,31 +523,18 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -698,31 +572,18 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -760,31 +621,18 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -822,31 +670,18 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -884,31 +719,18 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -946,31 +768,18 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1006,25 +815,19 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1070,30 +873,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1139,29 +931,19 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1189,29 +971,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1243,25 +1015,19 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1305,21 +1071,17 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1349,28 +1111,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1400,28 +1153,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1451,28 +1195,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1510,36 +1245,20 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spirv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spirv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1565,20 +1284,16 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1607,25 +1322,19 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1654,23 +1363,19 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1699,23 +1404,19 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1744,23 +1445,19 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1789,25 +1486,19 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1837,25 +1528,19 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1884,25 +1569,19 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1931,25 +1610,19 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1976,29 +1649,19 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2027,23 +1690,19 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2073,25 +1732,19 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2116,24 +1769,18 @@ when the end of the format string is encountered.
 %0 = spirv.CL.printf %0 %1 %2 : (!spirv.ptr<i8, UniformConstant>, (i32, i32)) -> i32
 ```
 """
-function CL_printf(
-    format::Value, arguments::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[format, arguments...]
+function CL_printf(format::Value, arguments::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[format, arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CL.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2162,25 +1809,19 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rint", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2208,25 +1849,19 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2255,25 +1890,19 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2302,25 +1931,19 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2346,25 +1969,19 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2390,25 +2007,19 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2437,23 +2048,19 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2482,25 +2089,19 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2529,25 +2130,19 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2573,25 +2168,19 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2617,25 +2206,19 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2673,24 +2256,18 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2723,24 +2300,18 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2773,24 +2344,18 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2830,21 +2395,17 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spirv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spirv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2894,28 +2455,18 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2944,21 +2495,17 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2988,21 +2535,17 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3032,21 +2575,17 @@ ptr-to-u-convert-op ::= ssa-id `=` `spirv.ConvertPtrToUOp` ssa-use
 ```
 """
 function ConvertPtrToU(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertPtrToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertPtrToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3075,21 +2614,17 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3118,21 +2653,17 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3163,21 +2694,17 @@ u-to-ptr-convert-op ::= ssa-id `=` `spirv.ConvertUToPtr` ssa-use
 ```
 """
 function ConvertUToPtr(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3210,37 +2737,22 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spirv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spirv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3282,31 +2794,18 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.EXT.AtomicFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.EXT.AtomicFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3356,21 +2855,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spirv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spirv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3408,21 +2899,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spirv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spirv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3450,28 +2933,19 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3501,21 +2975,17 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3545,28 +3015,19 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3597,28 +3058,19 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3648,28 +3100,19 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3697,25 +3140,19 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3745,28 +3182,18 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3796,28 +3223,18 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3847,28 +3264,18 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3898,28 +3305,18 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3949,28 +3346,18 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4000,28 +3387,18 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4053,28 +3430,19 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4103,28 +3471,19 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4154,28 +3513,18 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4205,28 +3554,18 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4256,28 +3595,18 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4307,28 +3636,18 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4358,28 +3677,18 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4409,28 +3718,18 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4463,39 +3762,21 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_name,
-    function_control,
-    linkage_attributes=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, linkage_attributes=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(linkage_attributes) &&
-        push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
-
-    return IR.create_operation(
-        "spirv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(linkage_attributes) && push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
+    
+    IR.create_operation(
+        "spirv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4529,28 +3810,19 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    return_value=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(return_value) && push!(results, return_value)
-
-    return IR.create_operation(
-        "spirv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4583,25 +3855,19 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4634,25 +3900,19 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4685,25 +3945,19 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4733,25 +3987,19 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4782,23 +4030,19 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4829,25 +4073,19 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4878,23 +4116,19 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4923,25 +4157,19 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4971,21 +4199,17 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5015,25 +4239,19 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5063,25 +4281,19 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5103,29 +4315,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5154,25 +4356,19 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5189,25 +4385,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5237,25 +4427,19 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5295,21 +4479,17 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5352,21 +4532,17 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5395,25 +4571,19 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5451,25 +4621,19 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spirv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5501,23 +4665,19 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5550,25 +4710,19 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5599,25 +4753,19 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.RoundEven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.RoundEven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5649,25 +4797,19 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5695,25 +4837,19 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5742,21 +4878,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5785,25 +4917,19 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5832,25 +4958,19 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5878,25 +4998,19 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5927,23 +5041,19 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5974,25 +5084,19 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6021,25 +5125,19 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6070,23 +5168,19 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6117,25 +5211,19 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6164,21 +5252,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6207,25 +5291,19 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6254,25 +5332,19 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6299,21 +5371,17 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtrExplicit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtrExplicit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6337,21 +5405,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6395,42 +5459,24 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    linkage_attributes=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, linkage_attributes=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-    !isnothing(linkage_attributes) &&
-        push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
-
-    return IR.create_operation(
-        "spirv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(linkage_attributes) && push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
+    
+    IR.create_operation(
+        "spirv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6479,29 +5525,19 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6537,32 +5573,19 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6598,32 +5621,19 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6659,32 +5669,19 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6721,32 +5718,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupFMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6782,32 +5766,19 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6844,32 +5815,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupIMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6902,24 +5860,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6964,29 +5916,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7011,25 +5953,19 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7075,33 +6011,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7150,33 +6072,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7225,33 +6133,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7297,33 +6191,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7367,33 +6247,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7437,33 +6303,19 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7507,33 +6359,19 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7577,33 +6415,19 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7632,29 +6456,19 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7681,29 +6495,19 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7731,29 +6535,19 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7781,29 +6575,19 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(
-    value::Value,
-    mask::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, mask]
+    operands = Value[value, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7848,33 +6632,19 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7919,33 +6689,19 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7982,32 +6738,19 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8044,32 +6787,19 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8105,32 +6835,19 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8167,32 +6884,19 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8226,21 +6930,17 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.IAddCarry",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAddCarry", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8275,28 +6975,19 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8326,28 +7017,18 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8382,28 +7063,19 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8432,21 +7104,17 @@ convert-bf16-to-f-op ::= ssa-id `=` `spirv.INTEL.ConvertBF16ToF` ssa-use
 ```
 """
 function INTEL_ConvertBF16ToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.ConvertBF16ToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.ConvertBF16ToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8477,21 +7145,17 @@ convert-f-to-bf16-op ::= ssa-id `=` `spirv.INTEL.ConvertFToBF16` ssa-use
 ```
 """
 function INTEL_ConvertFToBF16(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.ConvertFToBF16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.ConvertFToBF16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8525,36 +7189,20 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8592,30 +7240,19 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    scope,
-    location=Location(),
-)
+function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope),]
+    attributes = NamedAttribute[namedattribute("scope", scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixMad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixMad", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8653,36 +7290,20 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8707,25 +7328,19 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(;
-    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
-)
+function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8761,21 +7376,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8811,20 +7422,16 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8854,28 +7461,18 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8911,21 +7508,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8960,28 +7553,19 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9021,32 +7605,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spirv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spirv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9066,25 +7637,18 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(
-    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[sampledimage,]
+function Image(sampledimage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Image", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9123,21 +7687,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9163,28 +7723,18 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9214,23 +7764,18 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsInf(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsInf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9260,23 +7805,18 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsNan(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsNan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9299,20 +7839,16 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.AssumeTrue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.AssumeTrue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9336,27 +7872,19 @@ cooperative-matrix-length-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLength
        !spirv.coopmatrix<8x16xi32, Subgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function KHR_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9408,31 +7936,19 @@ cooperative-matrix-load-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLoad`
          as !spirv.KHR.coopmatrix<16x8xi32, Workgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    matrix_layout,
-    memory_operand=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function KHR_CooperativeMatrixLoad(pointer::Value, stride::Value; result::IR.Type, matrix_layout, memory_operand=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout),]
-    !isnothing(memory_operand) &&
-        push!(attributes, namedattribute("memory_operand", memory_operand))
-
-    return IR.create_operation(
-        "spirv.KHR.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout), ]
+    !isnothing(memory_operand) && push!(attributes, namedattribute("memory_operand", memory_operand))
+    
+    IR.create_operation(
+        "spirv.KHR.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9483,31 +7999,19 @@ inactive.
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<16x8xi32, Workgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    matrix_layout,
-    memory_operand=nothing,
-    location=Location(),
-)
+function KHR_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value; matrix_layout, memory_operand=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout),]
-    !isnothing(memory_operand) &&
-        push!(attributes, namedattribute("memory_operand", memory_operand))
-
-    return IR.create_operation(
-        "spirv.KHR.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout), ]
+    !isnothing(memory_operand) && push!(attributes, namedattribute("memory_operand", memory_operand))
+    
+    IR.create_operation(
+        "spirv.KHR.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9542,21 +8046,17 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.SubgroupBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.SubgroupBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9593,31 +8093,20 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9646,28 +8135,18 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9696,28 +8175,18 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9746,28 +8215,18 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9793,25 +8252,18 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[operand,]
+function LogicalNot(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9840,28 +8292,18 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9895,19 +8337,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9940,24 +8378,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9988,28 +8420,19 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value,
-    scalar::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, scalar]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10052,20 +8475,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10084,16 +8500,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10140,34 +8552,20 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spirv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10192,27 +8590,19 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.NV.coopmatrix<8x16xi32, Subgroup>
 ```
 """
-function NV_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10269,31 +8659,19 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.NV.coopmatrix<16x8xi32, Workgroup>
 ```
 """
-function NV_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10344,29 +8722,19 @@ For example:
   !spirv.NV.coopmatrix<8x16xi32, Subgroup>
 ```
 """
-function NV_CooperativeMatrixMulAdd(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10409,31 +8777,19 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.NV.coopmatrix<16x8xi32, Workgroup>
 ```
 """
-function NV_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10463,23 +8819,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10510,28 +8862,18 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Ordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10580,28 +8922,18 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10625,21 +8957,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrCastToGeneric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrCastToGeneric", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10669,21 +8997,17 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spirv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spirv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10704,16 +9028,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10740,20 +9060,16 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10783,21 +9099,17 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10829,28 +9141,19 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10893,30 +9196,19 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10954,25 +9246,19 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11002,28 +9288,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11053,28 +9329,18 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11104,28 +9370,18 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11155,28 +9411,18 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11209,28 +9455,19 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11259,24 +9496,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11300,25 +9531,19 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11351,28 +9576,19 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11417,30 +9633,19 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11480,25 +9685,19 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11541,29 +9740,19 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11591,19 +9780,15 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11643,28 +9828,19 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11701,28 +9877,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11760,28 +9927,19 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11826,21 +9984,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11880,19 +10030,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11966,21 +10110,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12013,27 +10153,20 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12066,21 +10199,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12111,21 +10240,17 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12156,28 +10281,19 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12222,30 +10338,19 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12285,25 +10390,19 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12333,28 +10432,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12384,28 +10473,18 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12435,28 +10514,18 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12486,28 +10555,18 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12538,28 +10597,19 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12589,24 +10639,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12633,21 +10677,17 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12678,28 +10718,18 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Unordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12720,16 +10750,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12767,28 +10793,19 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spirv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12814,25 +10831,18 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12870,29 +10880,19 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12933,24 +10933,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spirv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spirv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12972,24 +10966,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -13014,20 +11002,16 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/SPIRV.jl
+++ b/src/Dialects/17/SPIRV.jl
@@ -1,8 +1,8 @@
 module spirv
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `AccessChain`
@@ -46,18 +46,24 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
-    results = IR.Type[component_ptr, ]
-    operands = Value[base_ptr, indices..., ]
+function AccessChain(
+    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
+)
+    results = IR.Type[component_ptr,]
+    operands = Value[base_ptr, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.AccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.AccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -86,17 +92,21 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer, ]
+    results = IR.Type[pointer,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable), ]
-    
-    IR.create_operation(
-        "spirv.mlir.addressof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable),]
+
+    return IR.create_operation(
+        "spirv.mlir.addressof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -137,18 +147,31 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicAnd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicAnd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -198,18 +221,35 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, comparator, ]
+function AtomicCompareExchange(
+    pointer::Value,
+    value::Value,
+    comparator::Value;
+    result::IR.Type,
+    memory_scope,
+    equal_semantics,
+    unequal_semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value, comparator]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicCompareExchange", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("equal_semantics", equal_semantics),
+        namedattribute("unequal_semantics", unequal_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicCompareExchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -237,18 +277,35 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, comparator, ]
+function AtomicCompareExchangeWeak(
+    pointer::Value,
+    value::Value,
+    comparator::Value;
+    result::IR.Type,
+    memory_scope,
+    equal_semantics,
+    unequal_semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value, comparator]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("equal_semantics", equal_semantics),
+        namedattribute("unequal_semantics", unequal_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -285,18 +342,31 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicExchange(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicExchange", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicExchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -333,18 +403,31 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicIAdd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicIAdd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -380,18 +463,26 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+function AtomicIDecrement(
+    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicIDecrement", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicIDecrement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -426,18 +517,26 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+function AtomicIIncrement(
+    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicIIncrement", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicIIncrement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -475,18 +574,31 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicISub(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicISub", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicISub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -523,18 +635,31 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicOr(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicOr", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -572,18 +697,31 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicSMax(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicSMax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -621,18 +759,31 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicSMin(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicSMin", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -670,18 +821,31 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicUMax(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicUMax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -719,18 +883,31 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicUMin(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicUMin", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -768,18 +945,31 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function AtomicXor(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.AtomicXor", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.AtomicXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -815,19 +1005,25 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitCount(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitCount", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitCount",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -873,19 +1069,30 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldInsert(
+    base::Value,
+    insert::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, insert, offset, count, ]
+    operands = Value[base, insert, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitFieldInsert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitFieldInsert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -931,19 +1138,29 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldSExtract(
+    base::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, offset, count, ]
+    operands = Value[base, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitFieldSExtract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitFieldSExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -971,19 +1188,29 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitFieldUExtract(
+    base::Value,
+    offset::Value,
+    count::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, offset, count, ]
+    operands = Value[base, offset, count]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitFieldUExtract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitFieldUExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1015,19 +1242,25 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitReverse(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitReverse", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitReverse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1071,17 +1304,21 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1111,19 +1348,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseAnd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitwiseAnd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitwiseAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1153,19 +1399,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseOr(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitwiseOr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitwiseOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1195,19 +1450,28 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function BitwiseXor(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.BitwiseXor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.BitwiseXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1245,20 +1509,36 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
+function BranchConditional(
+    condition::Value,
+    trueTargetOperands::Vector{Value},
+    falseTargetOperands::Vector{Value};
+    branch_weights=nothing,
+    trueTarget::Block,
+    falseTarget::Block,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget, ]
+    successors = Block[trueTarget, falseTarget]
     attributes = NamedAttribute[]
-    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
-    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
-    
-    IR.create_operation(
-        "spirv.BranchConditional", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
+    )
+    !isnothing(branch_weights) &&
+        push!(attributes, namedattribute("branch_weights", branch_weights))
+
+    return IR.create_operation(
+        "spirv.BranchConditional",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1284,16 +1564,20 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands..., ]
+    operands = Value[targetOperands...,]
     owned_regions = Region[]
-    successors = Block[target, ]
+    successors = Block[target,]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Branch", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1322,19 +1606,25 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_ceil(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1363,19 +1653,23 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1404,19 +1698,23 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1445,19 +1743,23 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1486,19 +1788,25 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fabs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fabs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fabs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1528,19 +1836,25 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fmax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fmax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1569,19 +1883,25 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fmin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fmin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fmin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1610,19 +1930,25 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_floor(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1649,19 +1975,29 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_fma(
+    x::Value,
+    y::Value,
+    z::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, z, ]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1690,19 +2026,23 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1732,19 +2072,25 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1769,18 +2115,24 @@ when the end of the format string is encountered.
 %0 = spirv.CL.printf %0 %1 %2 : (!spirv.ptr<i8, UniformConstant>, (i32, i32)) -> i32
 ```
 """
-function CL_printf(format::Value, arguments::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[format, arguments..., ]
+function CL_printf(
+    format::Value, arguments::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[format, arguments...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.CL.printf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.printf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1809,19 +2161,25 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_rint(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.rint", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.rint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1849,19 +2207,25 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_round(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1890,19 +2254,25 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_rsqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1931,19 +2301,25 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_abs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.s_abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.s_abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1969,19 +2345,25 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.s_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.s_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2007,19 +2389,25 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_s_min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.s_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.s_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2048,19 +2436,23 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2089,19 +2481,25 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_sqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2130,19 +2528,25 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_tanh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2168,19 +2572,25 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_u_max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.u_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.u_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2206,19 +2616,25 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function CL_u_min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.CL.u_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CL.u_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2256,18 +2672,24 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[constituents..., ]
+function CompositeConstruct(
+    constituents::Vector{Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[constituents...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.CompositeConstruct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.CompositeConstruct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2300,18 +2722,24 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
-    results = IR.Type[component, ]
-    operands = Value[composite, ]
+function CompositeExtract(
+    composite::Value; component::IR.Type, indices, location=Location()
+)
+    results = IR.Type[component,]
+    operands = Value[composite,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices), ]
-    
-    IR.create_operation(
-        "spirv.CompositeExtract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices),]
+
+    return IR.create_operation(
+        "spirv.CompositeExtract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2344,18 +2772,24 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[object, composite, ]
+function CompositeInsert(
+    object::Value, composite::Value; result::IR.Type, indices, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[object, composite]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices), ]
-    
-    IR.create_operation(
-        "spirv.CompositeInsert", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices),]
+
+    return IR.create_operation(
+        "spirv.CompositeInsert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2395,17 +2829,21 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant, ]
+    results = IR.Type[constant,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "spirv.Constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "spirv.Constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2455,18 +2893,28 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
+function ControlBarrier(;
+    execution_scope, memory_scope, memory_semantics, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
-    
-    IR.create_operation(
-        "spirv.ControlBarrier", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("memory_semantics", memory_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.ControlBarrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2495,17 +2943,21 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertFToS", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertFToS",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2535,17 +2987,21 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertFToU", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertFToU",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2575,17 +3031,21 @@ ptr-to-u-convert-op ::= ssa-id `=` `spirv.ConvertPtrToUOp` ssa-use
 ```
 """
 function ConvertPtrToU(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertPtrToU", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertPtrToU",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2614,17 +3074,21 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertSToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertSToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2653,17 +3117,21 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertUToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertUToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2694,17 +3162,21 @@ u-to-ptr-convert-op ::= ssa-id `=` `spirv.ConvertUToPtr` ssa-use
 ```
 """
 function ConvertUToPtr(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ConvertUToPtr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ConvertUToPtr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2737,22 +3209,37 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
+function CopyMemory(
+    target::Value,
+    source::Value;
+    memory_access=nothing,
+    alignment=nothing,
+    source_memory_access=nothing,
+    source_alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, source, ]
+    operands = Value[target, source]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
-    
-    IR.create_operation(
-        "spirv.CopyMemory", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(source_memory_access) &&
+        push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) &&
+        push!(attributes, namedattribute("source_alignment", source_alignment))
+
+    return IR.create_operation(
+        "spirv.CopyMemory",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2794,18 +3281,31 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, value, ]
+function EXT_AtomicFAdd(
+    pointer::Value,
+    value::Value;
+    result::IR.Type,
+    memory_scope,
+    semantics,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
-    
-    IR.create_operation(
-        "spirv.EXT.AtomicFAdd", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
+    ]
+
+    return IR.create_operation(
+        "spirv.EXT.AtomicFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2855,13 +3355,21 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
-    
-    IR.create_operation(
-        "spirv.EntryPoint", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("execution_model", execution_model),
+        namedattribute("fn", fn),
+        namedattribute("interface", interface),
+    ]
+
+    return IR.create_operation(
+        "spirv.EntryPoint",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2899,13 +3407,21 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
-    
-    IR.create_operation(
-        "spirv.ExecutionMode", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("fn", fn),
+        namedattribute("execution_mode", execution_mode),
+        namedattribute("values", values),
+    ]
+
+    return IR.create_operation(
+        "spirv.ExecutionMode",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2933,19 +3449,28 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FAdd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -2975,17 +3500,21 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3015,19 +3544,28 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3058,19 +3596,28 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3100,19 +3647,28 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FMul(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3140,19 +3696,25 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FNegate(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FNegate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FNegate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3182,18 +3744,28 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3223,18 +3795,28 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3264,18 +3846,28 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3305,18 +3897,28 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdLessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3346,18 +3948,28 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdLessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdLessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3387,18 +3999,28 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FOrdNotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FOrdNotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FOrdNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3430,19 +4052,28 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FRem(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FRem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FRem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3471,19 +4102,28 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function FSub(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.FSub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FSub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3513,18 +4153,28 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3554,18 +4204,28 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3595,18 +4255,28 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3636,18 +4306,28 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordLessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3677,18 +4357,28 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordLessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordLessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3718,18 +4408,28 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function FUnordNotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.FUnordNotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.FUnordNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3762,21 +4462,39 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, linkage_attributes=nothing, body::Region, location=Location())
+function func(;
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_name,
+    function_control,
+    linkage_attributes=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
+    attributes = NamedAttribute[
+        namedattribute("function_type", function_type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("function_control", function_control),
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(linkage_attributes) && push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
-    
-    IR.create_operation(
-        "spirv.func", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(linkage_attributes) &&
+        push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
+
+    return IR.create_operation(
+        "spirv.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3810,19 +4528,28 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
+function FunctionCall(
+    arguments::Vector{Value};
+    return_value=nothing::Union{Nothing,IR.Type},
+    callee,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arguments..., ]
+    operands = Value[arguments...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee), ]
+    attributes = NamedAttribute[namedattribute("callee", callee),]
     !isnothing(return_value) && push!(results, return_value)
-    
-    IR.create_operation(
-        "spirv.FunctionCall", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.FunctionCall",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3855,19 +4582,25 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Acos(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Acos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Acos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3900,19 +4633,25 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Asin(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Asin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Asin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3945,19 +4684,25 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Atan(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Atan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Atan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -3987,19 +4732,25 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Ceil(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4030,19 +4781,23 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Cos", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Cos",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4073,19 +4828,25 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Cosh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Cosh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Cosh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4116,19 +4877,23 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4157,19 +4922,25 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FAbs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FAbs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FAbs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4199,17 +4970,21 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.FClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4239,19 +5014,25 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4281,19 +5062,25 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4315,19 +5102,29 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FMix(
+    x::Value,
+    y::Value,
+    a::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, a, ]
+    operands = Value[x, y, a]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FMix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FMix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4356,19 +5153,25 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FSign(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FSign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FSign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4385,19 +5188,25 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_FindUMsb(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.FindUMsb", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FindUMsb",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4427,19 +5236,25 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Floor(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4479,17 +5294,21 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.Fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4532,17 +5351,21 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.FrexpStruct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.FrexpStruct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4571,19 +5394,25 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_InverseSqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.InverseSqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.InverseSqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4621,19 +5450,25 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Ldexp(
+    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, exp, ]
+    operands = Value[x, exp]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-    
-    IR.create_operation(
-        "spirv.GL.Ldexp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Ldexp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4665,19 +5500,23 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4710,19 +5549,25 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Pow(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4753,19 +5598,25 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_RoundEven(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.RoundEven", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.RoundEven",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4797,19 +5648,25 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Round(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Round", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Round",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4837,19 +5694,25 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SAbs(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SAbs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SAbs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4878,17 +5741,21 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.SClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4917,19 +5784,25 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4958,19 +5831,25 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4998,19 +5877,25 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_SSign(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.SSign", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.SSign",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5041,19 +5926,23 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Sin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Sin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5084,19 +5973,25 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sinh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Sinh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Sinh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5125,19 +6020,25 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Sqrt(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Sqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Sqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5168,19 +6069,23 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Tan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Tan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5211,19 +6116,25 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_Tanh(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.Tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.Tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5252,17 +6163,21 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[x, y, z, ]
+    results = IR.Type[result,]
+    operands = Value[x, y, z]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GL.UClamp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.UClamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5291,19 +6206,25 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_UMax(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.UMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.UMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5332,19 +6253,25 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function GL_UMin(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GL.UMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GL.UMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5371,17 +6298,21 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GenericCastToPtrExplicit", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GenericCastToPtrExplicit",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5405,17 +6336,21 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.GenericCastToPtr", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GenericCastToPtr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5459,24 +6394,42 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, linkage_attributes=nothing, location=Location())
+function GlobalVariable(;
+    type,
+    sym_name,
+    initializer=nothing,
+    location_=nothing,
+    binding=nothing,
+    descriptor_set=nothing,
+    builtin=nothing,
+    linkage_attributes=nothing,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
+    attributes = NamedAttribute[
+        namedattribute("type", type), namedattribute("sym_name", sym_name)
+    ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) &&
+        push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-    !isnothing(linkage_attributes) && push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
-    
-    IR.create_operation(
-        "spirv.GlobalVariable", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(linkage_attributes) &&
+        push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
+
+    return IR.create_operation(
+        "spirv.GlobalVariable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5525,19 +6478,29 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupBroadcast(
+    value::Value,
+    localid::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, localid, ]
+    operands = Value[value, localid]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupBroadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupBroadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5573,19 +6536,32 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupFAdd(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupFAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5621,19 +6597,32 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupFMax(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupFMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupFMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5669,19 +6658,32 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupFMin(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupFMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupFMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5718,19 +6720,32 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function KHR_GroupFMul(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.KHR.GroupFMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.GroupFMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5766,19 +6781,32 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupIAdd(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupIAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5815,19 +6843,32 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function KHR_GroupIMul(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.KHR.GroupIMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.GroupIMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5860,18 +6901,24 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[predicate, ]
+function GroupNonUniformBallot(
+    predicate::Value; result::IR.Type, execution_scope, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[predicate,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformBallot", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformBallot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5916,19 +6963,29 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformBroadcast(
+    value::Value,
+    id::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, id, ]
+    operands = Value[value, id]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformBroadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformBroadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -5953,19 +7010,25 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformElect(;
+    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformElect", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformElect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6011,19 +7074,33 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFAdd(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6072,19 +7149,33 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6133,19 +7224,33 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6191,19 +7296,33 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformFMul(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformFMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformFMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6247,19 +7366,33 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformIAdd(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformIAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformIAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6303,19 +7436,33 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformIMul(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformIMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformIMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6359,19 +7506,33 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformSMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformSMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6415,19 +7576,33 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformSMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformSMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6456,19 +7631,29 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffleDown(
+    value::Value,
+    delta::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, delta, ]
+    operands = Value[value, delta]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6495,19 +7680,29 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffle(
+    value::Value,
+    id::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, id, ]
+    operands = Value[value, id]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6535,19 +7730,29 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffleUp(
+    value::Value,
+    delta::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, delta, ]
+    operands = Value[value, delta]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6575,19 +7780,29 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
+function GroupNonUniformShuffleXor(
+    value::Value,
+    mask::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, mask, ]
+    operands = Value[value, mask]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6632,19 +7847,33 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformUMax(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformUMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6689,19 +7918,33 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[value, ]
+function GroupNonUniformUMin(
+    value::Value,
+    cluster_size=nothing::Union{Nothing,Value};
+    result::IR.Type,
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-    
-    IR.create_operation(
-        "spirv.GroupNonUniformUMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupNonUniformUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6738,19 +7981,32 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupSMax(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupSMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupSMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6787,19 +8043,32 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupSMin(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupSMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupSMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6835,19 +8104,32 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupUMax(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupUMax", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupUMax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6884,19 +8166,32 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
+function GroupUMin(
+    x::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    execution_scope,
+    group_operation,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, ]
+    operands = Value[x,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
+    attributes = NamedAttribute[
+        namedattribute("execution_scope", execution_scope),
+        namedattribute("group_operation", group_operation),
+    ]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.GroupUMin", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.GroupUMin",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -6930,17 +8225,21 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IAddCarry", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.IAddCarry",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -6975,19 +8274,28 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function IAdd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.IAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.IAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7017,18 +8325,28 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function IEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.IEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7063,19 +8381,28 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function IMul(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.IMul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.IMul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7104,17 +8431,21 @@ convert-bf16-to-f-op ::= ssa-id `=` `spirv.INTEL.ConvertBF16ToF` ssa-use
 ```
 """
 function INTEL_ConvertBF16ToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INTEL.ConvertBF16ToF", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.ConvertBF16ToF",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7145,17 +8476,21 @@ convert-f-to-bf16-op ::= ssa-id `=` `spirv.INTEL.ConvertFToBF16` ssa-use
 ```
 """
 function INTEL_ConvertFToBF16(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INTEL.ConvertFToBF16", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.ConvertFToBF16",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7189,20 +8524,36 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, stride, ]
+function INTEL_JointMatrixLoad(
+    pointer::Value,
+    stride::Value;
+    result::IR.Type,
+    layout,
+    scope,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, stride]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[
+        namedattribute("layout", layout), namedattribute("scope", scope)
+    ]
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7240,19 +8591,30 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
+function INTEL_JointMatrixMad(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    scope,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope), ]
+    attributes = NamedAttribute[namedattribute("scope", scope),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixMad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixMad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7290,20 +8652,36 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+function INTEL_JointMatrixStore(
+    pointer::Value,
+    object::Value,
+    stride::Value;
+    layout,
+    scope,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[pointer, object, stride, ]
+    operands = Value[pointer, object, stride]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[
+        namedattribute("layout", layout), namedattribute("scope", scope)
+    ]
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixStore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixStore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7328,19 +8706,25 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
+function INTEL_JointMatrixWorkItemLength(;
+    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7376,17 +8760,21 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[ptr, ]
+    results = IR.Type[value,]
+    operands = Value[ptr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7422,16 +8810,20 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value, ]
+    operands = Value[ptr, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7461,18 +8853,28 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function INotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.INotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.INotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7508,17 +8910,21 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ISubBorrow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ISubBorrow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7553,19 +8959,28 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ISub(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ISub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ISub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7605,19 +9020,32 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
+function ImageDrefGather(
+    sampledimage::Value,
+    coordinate::Value,
+    dref::Value,
+    operand_arguments::Vector{Value};
+    result::IR.Type,
+    imageoperands=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
-    
-    IR.create_operation(
-        "spirv.ImageDrefGather", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(imageoperands) &&
+        push!(attributes, namedattribute("imageoperands", imageoperands))
+
+    return IR.create_operation(
+        "spirv.ImageDrefGather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7637,18 +9065,25 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(sampledimage::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[sampledimage, ]
+function Image(
+    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[sampledimage,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Image", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.Image",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7687,17 +9122,21 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[image, ]
+    results = IR.Type[result,]
+    operands = Value[image,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ImageQuerySize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ImageQuerySize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7723,18 +9162,28 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base_ptr, element, indices..., ]
+function InBoundsPtrAccessChain(
+    base_ptr::Value,
+    element::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base_ptr, element, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.InBoundsPtrAccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.InBoundsPtrAccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7764,18 +9213,23 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IsInf", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.IsInf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7805,18 +9259,23 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+    results = IR.Type[]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.IsNan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.IsNan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7839,16 +9298,20 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition, ]
+    operands = Value[condition,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.KHR.AssumeTrue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.AssumeTrue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7872,19 +9335,27 @@ cooperative-matrix-length-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLength
        !spirv.coopmatrix<8x16xi32, Subgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
+function KHR_CooperativeMatrixLength(;
+    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
+    attributes = NamedAttribute[namedattribute(
+        "cooperative_matrix_type", cooperative_matrix_type
+    ),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.KHR.CooperativeMatrixLength", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.CooperativeMatrixLength",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -7936,19 +9407,31 @@ cooperative-matrix-load-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLoad`
          as !spirv.KHR.coopmatrix<16x8xi32, Workgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixLoad(pointer::Value, stride::Value; result::IR.Type, matrix_layout, memory_operand=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, stride, ]
+function KHR_CooperativeMatrixLoad(
+    pointer::Value,
+    stride::Value;
+    result::IR.Type,
+    matrix_layout,
+    memory_operand=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, stride]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout), ]
-    !isnothing(memory_operand) && push!(attributes, namedattribute("memory_operand", memory_operand))
-    
-    IR.create_operation(
-        "spirv.KHR.CooperativeMatrixLoad", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout),]
+    !isnothing(memory_operand) &&
+        push!(attributes, namedattribute("memory_operand", memory_operand))
+
+    return IR.create_operation(
+        "spirv.KHR.CooperativeMatrixLoad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -7999,19 +9482,31 @@ inactive.
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<16x8xi32, Workgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value; matrix_layout, memory_operand=nothing, location=Location())
+function KHR_CooperativeMatrixStore(
+    pointer::Value,
+    object::Value,
+    stride::Value;
+    matrix_layout,
+    memory_operand=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[pointer, object, stride, ]
+    operands = Value[pointer, object, stride]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout), ]
-    !isnothing(memory_operand) && push!(attributes, namedattribute("memory_operand", memory_operand))
-    
-    IR.create_operation(
-        "spirv.KHR.CooperativeMatrixStore", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout),]
+    !isnothing(memory_operand) &&
+        push!(attributes, namedattribute("memory_operand", memory_operand))
+
+    return IR.create_operation(
+        "spirv.KHR.CooperativeMatrixStore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8046,17 +9541,21 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[predicate, ]
+    results = IR.Type[result,]
+    operands = Value[predicate,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.KHR.SubgroupBallot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.KHR.SubgroupBallot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8093,20 +9592,31 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
-    results = IR.Type[value, ]
-    operands = Value[ptr, ]
+function Load(
+    ptr::Value;
+    value::IR.Type,
+    memory_access=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[value,]
+    operands = Value[ptr,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.Load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8135,18 +9645,28 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalAnd(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalAnd", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalAnd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8175,18 +9695,28 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8215,18 +9745,28 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalNotEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalNotEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalNotEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8252,18 +9792,25 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+function LogicalNot(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalNot", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalNot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8292,18 +9839,28 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function LogicalOr(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.LogicalOr", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.LogicalOr",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8337,15 +9894,19 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
-    
-    IR.create_operation(
-        "spirv.mlir.loop", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
+
+    return IR.create_operation(
+        "spirv.mlir.loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8378,18 +9939,24 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[leftmatrix, rightmatrix, ]
+function MatrixTimesMatrix(
+    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[leftmatrix, rightmatrix]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.MatrixTimesMatrix", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.MatrixTimesMatrix",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8420,19 +9987,28 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function MatrixTimesScalar(
+    matrix::Value,
+    scalar::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[matrix, scalar, ]
+    operands = Value[matrix, scalar]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.MatrixTimesScalar", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.MatrixTimesScalar",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8475,13 +10051,20 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
-    
-    IR.create_operation(
-        "spirv.MemoryBarrier", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("memory_scope", memory_scope),
+        namedattribute("memory_semantics", memory_semantics),
+    ]
+
+    return IR.create_operation(
+        "spirv.MemoryBarrier",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8500,12 +10083,16 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.mlir.merge", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.mlir.merge",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8552,20 +10139,34 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
+function module_(;
+    addressing_model,
+    memory_model,
+    vce_triple=nothing,
+    sym_name=nothing,
+    region_0::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0, ]
+    owned_regions = Region[region_0,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
+    attributes = NamedAttribute[
+        namedattribute("addressing_model", addressing_model),
+        namedattribute("memory_model", memory_model),
+    ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-    
-    IR.create_operation(
-        "spirv.module", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.module",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8590,19 +10191,27 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.NV.coopmatrix<8x16xi32, Subgroup>
 ```
 """
-function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
+function NV_CooperativeMatrixLength(;
+    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
+    attributes = NamedAttribute[namedattribute(
+        "cooperative_matrix_type", cooperative_matrix_type
+    ),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8659,19 +10268,31 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.NV.coopmatrix<16x8xi32, Workgroup>
 ```
 """
-function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, stride, columnmajor, ]
+function NV_CooperativeMatrixLoad(
+    pointer::Value,
+    stride::Value,
+    columnmajor::Value;
+    result::IR.Type,
+    memory_access=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[pointer, stride, columnmajor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8722,19 +10343,29 @@ For example:
   !spirv.NV.coopmatrix<8x16xi32, Subgroup>
 ```
 """
-function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function NV_CooperativeMatrixMulAdd(
+    a::Value,
+    b::Value,
+    c::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8777,19 +10408,31 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.NV.coopmatrix<16x8xi32, Workgroup>
 ```
 """
-function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
+function NV_CooperativeMatrixStore(
+    pointer::Value,
+    object::Value,
+    stride::Value,
+    columnmajor::Value;
+    memory_access=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor, ]
+    operands = Value[pointer, object, stride, columnmajor]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
-    
-    IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
+
+    return IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8819,19 +10462,23 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.Not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8862,18 +10509,28 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function Ordered(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Ordered", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.Ordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -8922,18 +10579,28 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base_ptr, element, indices..., ]
+function PtrAccessChain(
+    base_ptr::Value,
+    element::Value,
+    indices::Vector{Value};
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base_ptr, element, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.PtrAccessChain", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.PtrAccessChain",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8957,17 +10624,21 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[pointer, ]
+    results = IR.Type[result,]
+    operands = Value[pointer,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.PtrCastToGeneric", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.PtrCastToGeneric",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -8997,17 +10668,21 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference, ]
+    results = IR.Type[reference,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
-    
-    IR.create_operation(
-        "spirv.mlir.referenceof", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
+
+    return IR.create_operation(
+        "spirv.mlir.referenceof",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9028,12 +10703,16 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9060,16 +10739,20 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ReturnValue", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ReturnValue",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9099,17 +10782,21 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9141,19 +10828,28 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9196,19 +10892,30 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, accumulator, ]
+function SDotAccSat(
+    vector1::Value,
+    vector2::Value,
+    accumulator::Value;
+    result::IR.Type,
+    format=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SDotAccSat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SDotAccSat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9246,19 +10953,25 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function SDot(
+    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SDot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SDot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9288,18 +11001,28 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9329,18 +11052,28 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9370,18 +11103,28 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SLessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SLessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SLessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9411,18 +11154,28 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SLessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SLessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.SLessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9455,19 +11208,28 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9496,18 +11258,24 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function SMulExtended(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SMulExtended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SMulExtended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9531,19 +11299,25 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SNegate(
+    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SNegate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SNegate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9576,19 +11350,28 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function SRem(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.SRem", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SRem",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9633,19 +11416,30 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, accumulator, ]
+function SUDotAccSat(
+    vector1::Value,
+    vector2::Value,
+    accumulator::Value;
+    result::IR.Type,
+    format=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SUDotAccSat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SUDotAccSat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9685,19 +11479,25 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function SUDot(
+    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.SUDot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SUDot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9740,19 +11540,29 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function Select(
+    condition::Value,
+    true_value::Value,
+    false_value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value, ]
+    operands = Value[condition, true_value, false_value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.Select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9780,15 +11590,19 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
-    
-    IR.create_operation(
-        "spirv.mlir.selection", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
+
+    return IR.create_operation(
+        "spirv.mlir.selection",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -9828,19 +11642,28 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftLeftLogical(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ShiftLeftLogical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ShiftLeftLogical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9877,19 +11700,28 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftRightArithmetic(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ShiftRightArithmetic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ShiftRightArithmetic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9927,19 +11759,28 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function ShiftRightLogical(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.ShiftRightLogical", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.ShiftRightLogical",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -9984,13 +11825,21 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
-    
-    IR.create_operation(
-        "spirv.SpecConstantComposite", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("type", type),
+        namedattribute("sym_name", sym_name),
+        namedattribute("constituents", constituents),
+    ]
+
+    return IR.create_operation(
+        "spirv.SpecConstantComposite",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10030,13 +11879,19 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
-    
-    IR.create_operation(
-        "spirv.SpecConstant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
+    ]
+
+    return IR.create_operation(
+        "spirv.SpecConstant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10110,17 +11965,21 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.SpecConstantOperation", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.SpecConstantOperation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10153,20 +12012,27 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
+function Store(
+    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[ptr, value, ]
+    operands = Value[ptr, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) &&
+        push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "spirv.Store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10199,17 +12065,21 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[matrix, ]
+    results = IR.Type[result,]
+    operands = Value[matrix,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10240,17 +12110,21 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand, ]
+    results = IR.Type[result,]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UConvert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UConvert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10281,19 +12155,28 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function UDiv(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.UDiv", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UDiv",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10338,19 +12221,30 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, accumulator, ]
+function UDotAccSat(
+    vector1::Value,
+    vector2::Value,
+    accumulator::Value;
+    result::IR.Type,
+    format=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2, accumulator]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.UDotAccSat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UDotAccSat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10390,19 +12284,25 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function UDot(
+    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-    
-    IR.create_operation(
-        "spirv.UDot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UDot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10432,18 +12332,28 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UGreaterThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UGreaterThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.UGreaterThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10473,18 +12383,28 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UGreaterThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UGreaterThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.UGreaterThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10514,18 +12434,28 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function ULessThanEqual(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ULessThanEqual", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.ULessThanEqual",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10555,18 +12485,28 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function ULessThan(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.ULessThan", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.ULessThan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10597,19 +12537,28 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function UMod(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand1, operand2, ]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.UMod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UMod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10639,18 +12588,24 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function UMulExtended(
+    operand1::Value, operand2::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.UMulExtended", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.UMulExtended",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10677,17 +12632,21 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Undef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Undef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10718,18 +12677,28 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand1, operand2, ]
+function Unordered(
+    operand1::Value,
+    operand2::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[operand1, operand2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Unordered", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.Unordered",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10750,12 +12719,16 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.Unreachable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Unreachable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10793,19 +12766,28 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
-    results = IR.Type[pointer, ]
+function Variable(
+    initializer=nothing::Union{Nothing,Value};
+    pointer::IR.Type,
+    storage_class,
+    location=Location(),
+)
+    results = IR.Type[pointer,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
     !isnothing(initializer) && push!(operands, initializer)
-    
-    IR.create_operation(
-        "spirv.Variable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.Variable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10831,18 +12813,25 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, index, ]
+function VectorExtractDynamic(
+    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
+    results = IR.Type[]
+    operands = Value[vector, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.VectorExtractDynamic", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "spirv.VectorExtractDynamic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10880,19 +12869,29 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function VectorInsertDynamic(
+    vector::Value,
+    component::Value,
+    index::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, component, index, ]
+    operands = Value[vector, component, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "spirv.VectorInsertDynamic", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.VectorInsertDynamic",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -10933,18 +12932,24 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector1, vector2, ]
+function VectorShuffle(
+    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector1, vector2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components), ]
-    
-    IR.create_operation(
-        "spirv.VectorShuffle", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("components", components),]
+
+    return IR.create_operation(
+        "spirv.VectorShuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -10966,18 +12971,24 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, scalar, ]
+function VectorTimesScalar(
+    vector::Value, scalar::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[vector, scalar]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.VectorTimesScalar", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.VectorTimesScalar",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -11002,16 +13013,20 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand, ]
+    operands = Value[operand,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "spirv.mlir.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "spirv.mlir.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/SPIRV.jl
+++ b/src/Dialects/17/SPIRV.jl
@@ -1,8 +1,8 @@
 module spirv
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `AccessChain`
@@ -46,24 +46,18 @@ access-chain-op ::= ssa-id `=` `spirv.AccessChain` ssa-use
 %3 = spirv.Load \"Function\" %2 [\"Volatile\"] : !spirv.array<4xf32>
 ```
 """
-function AccessChain(
-    base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location()
-)
-    results = IR.Type[component_ptr,]
-    operands = Value[base_ptr, indices...]
+function AccessChain(base_ptr::Value, indices::Vector{Value}; component_ptr::IR.Type, location=Location())
+    results = IR.Type[component_ptr, ]
+    operands = Value[base_ptr, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.AccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.AccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,21 +86,17 @@ spv-address-of-op ::= ssa-id `=` `spirv.mlir.addressof` symbol-ref-id
 ```
 """
 function mlir_addressof(; pointer::IR.Type, variable, location=Location())
-    results = IR.Type[pointer,]
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("variable", variable),]
-
-    return IR.create_operation(
-        "spirv.mlir.addressof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("variable", variable), ]
+    
+    IR.create_operation(
+        "spirv.mlir.addressof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -147,31 +137,18 @@ atomic-and-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicAnd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicAnd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicAnd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -221,35 +198,18 @@ atomic-compare-exchange-op ::=
                                 : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchange(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchange(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -277,35 +237,18 @@ atomic-compare-exchange-weak-op ::=
                                    : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicCompareExchangeWeak(
-    pointer::Value,
-    value::Value,
-    comparator::Value;
-    result::IR.Type,
-    memory_scope,
-    equal_semantics,
-    unequal_semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value, comparator]
+function AtomicCompareExchangeWeak(pointer::Value, value::Value, comparator::Value; result::IR.Type, memory_scope, equal_semantics, unequal_semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, comparator, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("equal_semantics", equal_semantics),
-        namedattribute("unequal_semantics", unequal_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicCompareExchangeWeak",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("equal_semantics", equal_semantics), namedattribute("unequal_semantics", unequal_semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicCompareExchangeWeak", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -342,31 +285,18 @@ atomic-exchange-op ::=
                         : !spirv.ptr<i32, WorkGroup>
 ```
 """
-function AtomicExchange(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicExchange(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicExchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicExchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -403,31 +333,18 @@ atomic-iadd-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicIAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -463,26 +380,18 @@ atomic-idecrement-op ::=
                           !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIDecrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIDecrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIDecrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIDecrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -517,26 +426,18 @@ atomic-iincrement-op ::=
                          !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicIIncrement(
-    pointer::Value; result::IR.Type, memory_scope, semantics, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+function AtomicIIncrement(pointer::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicIIncrement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicIIncrement", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -574,31 +475,18 @@ atomic-isub-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicISub(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicISub(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicISub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -635,31 +523,18 @@ atomic-or-op ::=
                   !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicOr(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicOr(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicOr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -697,31 +572,18 @@ atomic-smax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -759,31 +621,18 @@ atomic-smin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicSMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicSMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -821,31 +670,18 @@ atomic-umax-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMax(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMax(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -883,31 +719,18 @@ atomic-umin-op ::=
                     !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicUMin(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicUMin(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -945,31 +768,18 @@ atomic-xor-op ::=
                    !spirv.ptr<i32, StorageBuffer>
 ```
 """
-function AtomicXor(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function AtomicXor(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.AtomicXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.AtomicXor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1005,25 +815,19 @@ Results are computed per component.
     %3 = spirv.BitCount %1: vector<4xi32>
     ```
 """
-function BitCount(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitCount(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitCount",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitCount", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1069,30 +873,19 @@ The type of Base and Insert must be the same as Result Type.
     %0 = spirv.BitFieldInsert %base, %insert, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldInsert(
-    base::Value,
-    insert::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldInsert(base::Value, insert::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, insert, offset, count]
+    operands = Value[base, insert, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldInsert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1138,29 +931,19 @@ The type of Base must be the same as Result Type.
     %0 = spirv.BitFieldSExtract %base, %offset, %count : vector<3xi32>, i8, i8
     ```
 """
-function BitFieldSExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldSExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldSExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldSExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1188,29 +971,19 @@ bitfield-extract-u-op ::= ssa-id `=` `spirv.BitFieldUExtract` ssa-use
 %0 = spirv.BitFieldUExtract %base, %offset, %count : vector<3xi32>, i8, i8
 ```
 """
-function BitFieldUExtract(
-    base::Value,
-    offset::Value,
-    count::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitFieldUExtract(base::Value, offset::Value, count::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[base, offset, count]
+    operands = Value[base, offset, count, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitFieldUExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitFieldUExtract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1242,25 +1015,19 @@ The type of Base must be the same as Result Type.
     %3 = spirv.BitReverse %1 : vector<4xi32>
     ```
 """
-function BitReverse(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function BitReverse(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitReverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitReverse", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1304,21 +1071,17 @@ bitcast-op ::= ssa-id `=` `spirv.Bitcast` ssa-use
 ```
 """
 function Bitcast(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1111,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseAnd %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseAnd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseAnd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1399,28 +1153,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseOr %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseOr(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseOr", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1450,28 +1195,19 @@ Results are computed per component, and within each component, per bit.
     %2 = spirv.BitwiseXor %0, %1 : vector<4xi32>
     ```
 """
-function BitwiseXor(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function BitwiseXor(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.BitwiseXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.BitwiseXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1509,36 +1245,20 @@ spirv.BranchConditional %condition, ^true_branch, ^false_branch
 spirv.BranchConditional %condition, ^true_branch(%0: i32), ^false_branch(%1: i32)
 ```
 """
-function BranchConditional(
-    condition::Value,
-    trueTargetOperands::Vector{Value},
-    falseTargetOperands::Vector{Value};
-    branch_weights=nothing,
-    trueTarget::Block,
-    falseTarget::Block,
-    location=Location(),
-)
+function BranchConditional(condition::Value, trueTargetOperands::Vector{Value}, falseTargetOperands::Vector{Value}; branch_weights=nothing, trueTarget::Block, falseTarget::Block, location=Location())
     results = IR.Type[]
-    operands = Value[condition, trueTargetOperands..., falseTargetOperands...]
+    operands = Value[condition, trueTargetOperands..., falseTargetOperands..., ]
     owned_regions = Region[]
-    successors = Block[trueTarget, falseTarget]
+    successors = Block[trueTarget, falseTarget, ]
     attributes = NamedAttribute[]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands)]),
-    )
-    !isnothing(branch_weights) &&
-        push!(attributes, namedattribute("branch_weights", branch_weights))
-
-    return IR.create_operation(
-        "spirv.BranchConditional",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([1, length(trueTargetOperands), length(falseTargetOperands), ]))
+    !isnothing(branch_weights) && push!(attributes, namedattribute("branch_weights", branch_weights))
+    
+    IR.create_operation(
+        "spirv.BranchConditional", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1564,20 +1284,16 @@ spirv.Branch ^target(%0, %1: i32, f32)
 """
 function Branch(targetOperands::Vector{Value}; target::Block, location=Location())
     results = IR.Type[]
-    operands = Value[targetOperands...,]
+    operands = Value[targetOperands..., ]
     owned_regions = Region[]
-    successors = Block[target,]
+    successors = Block[target, ]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1606,25 +1322,19 @@ ceil-op ::= ssa-id `=` `spirv.CL.ceil` ssa-use `:`
 %3 = spirv.CL.ceil %1 : vector<3xf16>
 ```
 """
-function CL_ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1653,23 +1363,19 @@ cos-op ::= ssa-id `=` `spirv.CL.cos` ssa-use `:`
 %3 = spirv.CL.cos %1 : vector<3xf16>
 ```
 """
-function CL_cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1698,23 +1404,19 @@ erf-op ::= ssa-id `=` `spirv.CL.erf` ssa-use `:`
 %3 = spirv.CL.erf %1 : vector<3xf16>
 ```
 """
-function CL_erf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_erf(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.erf", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1743,23 +1445,19 @@ exp-op ::= ssa-id `=` `spirv.CL.exp` ssa-use `:`
 %3 = spirv.CL.exp %1 : vector<3xf16>
 ```
 """
-function CL_exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1788,25 +1486,19 @@ abs-op ::= ssa-id `=` `spirv.CL.fabs` ssa-use `:`
 %3 = spirv.CL.fabs %1 : vector<3xf16>
 ```
 """
-function CL_fabs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fabs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fabs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fabs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1836,25 +1528,19 @@ fmax-op ::= ssa-id `=` `spirv.CL.fmax` ssa-use `:`
 %3 = spirv.CL.fmax %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1883,25 +1569,19 @@ fmin-op ::= ssa-id `=` `spirv.CL.fmin` ssa-use `:`
 %3 = spirv.CL.fmin %0, %1 : vector<3xf16>
 ```
 """
-function CL_fmin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_fmin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fmin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fmin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1930,25 +1610,19 @@ floor-op ::= ssa-id `=` `spirv.CL.floor` ssa-use `:`
 %3 = spirv.CL.ceifloorl %1 : vector<3xf16>
 ```
 """
-function CL_floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1975,29 +1649,19 @@ fma-op ::= ssa-id `=` `spirv.CL.fma` ssa-use, ssa-use, ssa-use `:`
 %1 = spirv.CL.fma %a, %b, %c : vector<3xf16>
 ```
 """
-function CL_fma(
-    x::Value,
-    y::Value,
-    z::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function CL_fma(x::Value, y::Value, z::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, z]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2026,23 +1690,19 @@ log-op ::= ssa-id `=` `spirv.CL.log` ssa-use `:`
 %3 = spirv.CL.log %1 : vector<3xf16>
 ```
 """
-function CL_log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2072,25 +1732,19 @@ pow-op ::= ssa-id `=` `spirv.CL.pow` ssa-use `:`
 %3 = spirv.CL.pow %0, %1 : vector<3xf16>
 ```
 """
-function CL_pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2115,24 +1769,18 @@ when the end of the format string is encountered.
 %0 = spirv.CL.printf %0 %1 %2 : (!spirv.ptr<i8, UniformConstant>, (i32, i32)) -> i32
 ```
 """
-function CL_printf(
-    format::Value, arguments::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[format, arguments...]
+function CL_printf(format::Value, arguments::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[format, arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CL.printf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.printf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2161,25 +1809,19 @@ rint-op ::= ssa-id `=` `spirv.CL.rint` ssa-use `:`
 %1 = spirv.CL.rint %1 : vector<3xf16>
 ```
 """
-function CL_rint(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rint(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rint", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2207,25 +1849,19 @@ round-op ::= ssa-id `=` `spirv.CL.round` ssa-use `:`
 %3 = spirv.CL.round %0 : vector<3xf16>
 ```
 """
-function CL_round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2254,25 +1890,19 @@ rsqrt-op ::= ssa-id `=` `spirv.CL.rsqrt` ssa-use `:`
 %3 = spirv.CL.rsqrt %1 : vector<3xf16>
 ```
 """
-function CL_rsqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_rsqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2301,25 +1931,19 @@ abs-op ::= ssa-id `=` `spirv.CL.s_abs` ssa-use `:`
 %3 = spirv.CL.s_abs %1 : vector<3xi16>
 ```
 """
-function CL_s_abs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_abs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_abs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2345,25 +1969,19 @@ smax-op ::= ssa-id `=` `spirv.CL.s_max` ssa-use `:`
 %3 = spirv.CL.s_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2389,25 +2007,19 @@ smin-op ::= ssa-id `=` `spirv.CL.s_min` ssa-use `:`
 %3 = spirv.CL.s_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_s_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_s_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.s_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.s_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2436,23 +2048,19 @@ sin-op ::= ssa-id `=` `spirv.CL.sin` ssa-use `:`
 %3 = spirv.CL.sin %1 : vector<3xf16>
 ```
 """
-function CL_sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function CL_sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2481,25 +2089,19 @@ sqrt-op ::= ssa-id `=` `spirv.CL.sqrt` ssa-use `:`
 %3 = spirv.CL.sqrt %1 : vector<3xf16>
 ```
 """
-function CL_sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2528,25 +2130,19 @@ tanh-op ::= ssa-id `=` `spirv.CL.tanh` ssa-use `:`
 %3 = spirv.CL.tanh %1 : vector<3xf16>
 ```
 """
-function CL_tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2572,25 +2168,19 @@ umax-op ::= ssa-id `=` `spirv.CL.u_max` ssa-use `:`
 %3 = spirv.CL.u_max %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2616,25 +2206,19 @@ umin-op ::= ssa-id `=` `spirv.CL.u_min` ssa-use `:`
 %3 = spirv.CL.u_min %0, %1 : vector<3xi16>
 ```
 """
-function CL_u_min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function CL_u_min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.CL.u_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CL.u_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -2672,24 +2256,18 @@ composite-construct-op ::= ssa-id `=` `spirv.CompositeConstruct`
 %0 = spirv.CompositeConstruct %1, %2, %3 : vector<3xf32>
 ```
 """
-function CompositeConstruct(
-    constituents::Vector{Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[constituents...,]
+function CompositeConstruct(constituents::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[constituents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.CompositeConstruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.CompositeConstruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2722,24 +2300,18 @@ composite-extract-op ::= ssa-id `=` `spirv.CompositeExtract` ssa-use
 %2 = spirv.CompositeExtract %1[1 : i32] : !spirv.array<4x!spirv.array<4xf32>>
 ```
 """
-function CompositeExtract(
-    composite::Value; component::IR.Type, indices, location=Location()
-)
-    results = IR.Type[component,]
-    operands = Value[composite,]
+function CompositeExtract(composite::Value; component::IR.Type, indices, location=Location())
+    results = IR.Type[component, ]
+    operands = Value[composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeExtract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeExtract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2772,24 +2344,18 @@ composite-insert-op ::= ssa-id `=` `spirv.CompositeInsert` ssa-use, ssa-use
 %0 = spirv.CompositeInsert %object, %composite[1 : i32] : f32 into !spirv.array<4xf32>
 ```
 """
-function CompositeInsert(
-    object::Value, composite::Value; result::IR.Type, indices, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[object, composite]
+function CompositeInsert(object::Value, composite::Value; result::IR.Type, indices, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[object, composite, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indices", indices),]
-
-    return IR.create_operation(
-        "spirv.CompositeInsert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("indices", indices), ]
+    
+    IR.create_operation(
+        "spirv.CompositeInsert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2829,21 +2395,17 @@ spirv.Constant-op ::= ssa-id `=` `spirv.Constant` attribute-value
 TODO: support constant structs
 """
 function Constant(; constant::IR.Type, value, location=Location())
-    results = IR.Type[constant,]
+    results = IR.Type[constant, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "spirv.Constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "spirv.Constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2893,28 +2455,18 @@ spirv.ControlBarrier \"Workgroup\", \"Device\", \"Acquire|UniformMemory\"
 
 ```
 """
-function ControlBarrier(;
-    execution_scope, memory_scope, memory_semantics, location=Location()
-)
+function ControlBarrier(; execution_scope, memory_scope, memory_semantics, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.ControlBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.ControlBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2943,21 +2495,17 @@ convert-f-to-s-op ::= ssa-id `=` `spirv.ConvertFToSOp` ssa-use
 ```
 """
 function ConvertFToS(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToS",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToS", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2987,21 +2535,17 @@ convert-f-to-u-op ::= ssa-id `=` `spirv.ConvertFToUOp` ssa-use
 ```
 """
 function ConvertFToU(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertFToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertFToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3031,21 +2575,17 @@ ptr-to-u-convert-op ::= ssa-id `=` `spirv.ConvertPtrToUOp` ssa-use
 ```
 """
 function ConvertPtrToU(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertPtrToU",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertPtrToU", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3074,21 +2614,17 @@ convert-s-to-f-op ::= ssa-id `=` `spirv.ConvertSToFOp` ssa-use
 ```
 """
 function ConvertSToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertSToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertSToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3117,21 +2653,17 @@ convert-u-to-f-op ::= ssa-id `=` `spirv.ConvertUToFOp` ssa-use
 ```
 """
 function ConvertUToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3162,21 +2694,17 @@ u-to-ptr-convert-op ::= ssa-id `=` `spirv.ConvertUToPtr` ssa-use
 ```
 """
 function ConvertUToPtr(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ConvertUToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ConvertUToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3209,37 +2737,22 @@ copy-memory-op ::= `spirv.CopyMemory ` storage-class ssa-use
 spirv.CopyMemory \"Function\" %0, \"Function\" %1 : f32
 ```
 """
-function CopyMemory(
-    target::Value,
-    source::Value;
-    memory_access=nothing,
-    alignment=nothing,
-    source_memory_access=nothing,
-    source_alignment=nothing,
-    location=Location(),
-)
+function CopyMemory(target::Value, source::Value; memory_access=nothing, alignment=nothing, source_memory_access=nothing, source_alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, source]
+    operands = Value[target, source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    !isnothing(source_memory_access) &&
-        push!(attributes, namedattribute("source_memory_access", source_memory_access))
-    !isnothing(source_alignment) &&
-        push!(attributes, namedattribute("source_alignment", source_alignment))
-
-    return IR.create_operation(
-        "spirv.CopyMemory",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(source_memory_access) && push!(attributes, namedattribute("source_memory_access", source_memory_access))
+    !isnothing(source_alignment) && push!(attributes, namedattribute("source_alignment", source_alignment))
+    
+    IR.create_operation(
+        "spirv.CopyMemory", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3281,31 +2794,18 @@ atomic-fadd-op ::=
                        !spirv.ptr<f32, StorageBuffer>
 ```
 """
-function EXT_AtomicFAdd(
-    pointer::Value,
-    value::Value;
-    result::IR.Type,
-    memory_scope,
-    semantics,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, value]
+function EXT_AtomicFAdd(pointer::Value, value::Value; result::IR.Type, memory_scope, semantics, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics)
-    ]
-
-    return IR.create_operation(
-        "spirv.EXT.AtomicFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("semantics", semantics), ]
+    
+    IR.create_operation(
+        "spirv.EXT.AtomicFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3355,21 +2855,13 @@ function EntryPoint(; execution_model, fn, interface, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_model", execution_model),
-        namedattribute("fn", fn),
-        namedattribute("interface", interface),
-    ]
-
-    return IR.create_operation(
-        "spirv.EntryPoint",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_model", execution_model), namedattribute("fn", fn), namedattribute("interface", interface), ]
+    
+    IR.create_operation(
+        "spirv.EntryPoint", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3407,21 +2899,13 @@ function ExecutionMode(; fn, execution_mode, values, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("fn", fn),
-        namedattribute("execution_mode", execution_mode),
-        namedattribute("values", values),
-    ]
-
-    return IR.create_operation(
-        "spirv.ExecutionMode",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fn", fn), namedattribute("execution_mode", execution_mode), namedattribute("values", values), ]
+    
+    IR.create_operation(
+        "spirv.ExecutionMode", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3449,28 +2933,19 @@ fadd-op ::= ssa-id `=` `spirv.FAdd` ssa-use, ssa-use
 %5 = spirv.FAdd %2, %3 : vector<4xf32>
 ```
 """
-function FAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3500,21 +2975,17 @@ f-convert-op ::= ssa-id `=` `spirv.FConvertOp` ssa-use
 ```
 """
 function FConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.FConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3544,28 +3015,19 @@ fdiv-op ::= ssa-id `=` `spirv.FDiv` ssa-use, ssa-use
 %5 = spirv.FDiv %2, %3 : vector<4xf32>
 ```
 """
-function FDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3596,28 +3058,19 @@ fmod-op ::= ssa-id `=` `spirv.FMod` ssa-use, ssa-use
 %5 = spirv.FMod %2, %3 : vector<4xf32>
 ```
 """
-function FMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3647,28 +3100,19 @@ fmul-op ::= `spirv.FMul` ssa-use, ssa-use
 %5 = spirv.FMul %2, %3 : vector<4xf32>
 ```
 """
-function FMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3696,25 +3140,19 @@ fmul-op ::= `spirv.FNegate` ssa-use `:` float-scalar-vector-type
 %3 = spirv.FNegate %2 : vector<4xf32>
 ```
 """
-function FNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function FNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -3744,28 +3182,18 @@ fordequal-op ::= ssa-id `=` `spirv.FOrdEqual` ssa-use, ssa-use
 %5 = spirv.FOrdEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3795,28 +3223,18 @@ fordgte-op ::= ssa-id `=` `spirv.FOrdGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3846,28 +3264,18 @@ fordgt-op ::= ssa-id `=` `spirv.FOrdGreaterThan` ssa-use, ssa-use
 %5 = spirv.FOrdGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3897,28 +3305,18 @@ fordlte-op ::= ssa-id `=` `spirv.FOrdLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FOrdLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3948,28 +3346,18 @@ fordlt-op ::= ssa-id `=` `spirv.FOrdLessThan` ssa-use, ssa-use
 %5 = spirv.FOrdLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FOrdLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -3999,28 +3387,18 @@ fordneq-op ::= ssa-id `=` `spirv.FOrdNotEqual` ssa-use, ssa-use
 %5 = spirv.FOrdNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FOrdNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FOrdNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FOrdNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FOrdNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4052,28 +3430,19 @@ frem-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4102,28 +3471,19 @@ fsub-op ::= ssa-id `=` `spirv.FRemOp` ssa-use, ssa-use
 %5 = spirv.FRemOp %2, %3 : vector<4xf32>
 ```
 """
-function FSub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function FSub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FSub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FSub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4153,28 +3513,18 @@ funordequal-op ::= ssa-id `=` `spirv.FUnordEqual` ssa-use, ssa-use
 %5 = spirv.FUnordEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4204,28 +3554,18 @@ funordgte-op ::= ssa-id `=` `spirv.FUnordGreaterThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4255,28 +3595,18 @@ funordgt-op ::= ssa-id `=` `spirv.FUnordGreaterThan` ssa-use, ssa-use
 %5 = spirv.FUnordGreaterThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4306,28 +3636,18 @@ funordlte-op ::= ssa-id `=` `spirv.FUnordLessThanEqual` ssa-use, ssa-use
 %5 = spirv.FUnordLessThanEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4357,28 +3677,18 @@ funordlt-op ::= ssa-id `=` `spirv.FUnordLessThan` ssa-use, ssa-use
 %5 = spirv.FUnordLessThan %2, %3 : vector<4xf32>
 ```
 """
-function FUnordLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4408,28 +3718,18 @@ funordneq-op ::= ssa-id `=` `spirv.FUnordNotEqual` ssa-use, ssa-use
 %5 = spirv.FUnordNotEqual %2, %3 : vector<4xf32>
 ```
 """
-function FUnordNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function FUnordNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.FUnordNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.FUnordNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -4462,39 +3762,21 @@ spirv.func @foo() -> () \"None\" { ... }
 spirv.func @bar() -> () \"Inline|Pure\" { ... }
 ```
 """
-function func(;
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_name,
-    function_control,
-    linkage_attributes=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; function_type, arg_attrs=nothing, res_attrs=nothing, sym_name, function_control, linkage_attributes=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("function_type", function_type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("function_control", function_control),
-    ]
+    attributes = NamedAttribute[namedattribute("function_type", function_type), namedattribute("sym_name", sym_name), namedattribute("function_control", function_control), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(linkage_attributes) &&
-        push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
-
-    return IR.create_operation(
-        "spirv.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(linkage_attributes) && push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
+    
+    IR.create_operation(
+        "spirv.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4528,28 +3810,19 @@ spirv.FunctionCall @f_void(%arg0) : (i32) ->  ()
 %0 = spirv.FunctionCall @f_iadd(%arg0, %arg1) : (i32, i32) -> i32
 ```
 """
-function FunctionCall(
-    arguments::Vector{Value};
-    return_value=nothing::Union{Nothing,IR.Type},
-    callee,
-    location=Location(),
-)
+function FunctionCall(arguments::Vector{Value}; return_value=nothing::Union{Nothing, IR.Type}, callee, location=Location())
     results = IR.Type[]
-    operands = Value[arguments...,]
+    operands = Value[arguments..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("callee", callee),]
+    attributes = NamedAttribute[namedattribute("callee", callee), ]
     !isnothing(return_value) && push!(results, return_value)
-
-    return IR.create_operation(
-        "spirv.FunctionCall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.FunctionCall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4582,25 +3855,19 @@ acos-op ::= ssa-id `=` `spirv.GL.Acos` ssa-use `:`
 %3 = spirv.GL.Acos %1 : vector<3xf16>
 ```
 """
-function GL_Acos(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Acos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Acos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Acos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4633,25 +3900,19 @@ asin-op ::= ssa-id `=` `spirv.GL.Asin` ssa-use `:`
 %3 = spirv.GL.Asin %1 : vector<3xf16>
 ```
 """
-function GL_Asin(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Asin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Asin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Asin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4684,25 +3945,19 @@ atan-op ::= ssa-id `=` `spirv.GL.Atan` ssa-use `:`
 %3 = spirv.GL.Atan %1 : vector<3xf16>
 ```
 """
-function GL_Atan(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Atan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Atan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Atan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4732,25 +3987,19 @@ ceil-op ::= ssa-id `=` `spirv.GL.Ceil` ssa-use `:`
 %3 = spirv.GL.Ceil %1 : vector<3xf16>
 ```
 """
-function GL_Ceil(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ceil(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ceil", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4781,23 +4030,19 @@ cos-op ::= ssa-id `=` `spirv.GL.Cos` ssa-use `:`
 %3 = spirv.GL.Cos %1 : vector<3xf16>
 ```
 """
-function GL_Cos(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Cos(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cos",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cos", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4828,25 +4073,19 @@ cosh-op ::= ssa-id `=` `spirv.GL.Cosh` ssa-use `:`
 %3 = spirv.GL.Cosh %1 : vector<3xf16>
 ```
 """
-function GL_Cosh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Cosh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Cosh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Cosh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4877,23 +4116,19 @@ exp-op ::= ssa-id `=` `spirv.GL.Exp` ssa-use `:`
 %3 = spirv.GL.Exp %1 : vector<3xf16>
 ```
 """
-function GL_Exp(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Exp(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Exp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4922,25 +4157,19 @@ abs-op ::= ssa-id `=` `spirv.GL.FAbs` ssa-use `:`
 %3 = spirv.GL.FAbs %1 : vector<3xf16>
 ```
 """
-function GL_FAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -4970,21 +4199,17 @@ fclamp-op ::= ssa-id `=` `spirv.GL.FClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_FClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5014,25 +4239,19 @@ fmax-op ::= ssa-id `=` `spirv.GL.FMax` ssa-use `:`
 %3 = spirv.GL.FMax %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5062,25 +4281,19 @@ fmin-op ::= ssa-id `=` `spirv.GL.FMin` ssa-use `:`
 %3 = spirv.GL.FMin %0, %1 : vector<3xf16>
 ```
 """
-function GL_FMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5102,29 +4315,19 @@ Result Type and the type of all operands must be the same type. Results are comp
 %0 = spirv.GL.FMix %x : vector<4xf32>, %y : vector<4xf32>, %a : vector<4xf32> -> vector<4xf32>
 ```
 """
-function GL_FMix(
-    x::Value,
-    y::Value,
-    a::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function GL_FMix(x::Value, y::Value, a::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, a]
+    operands = Value[x, y, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FMix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FMix", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5153,25 +4356,19 @@ sign-op ::= ssa-id `=` `spirv.GL.FSign` ssa-use `:`
 %3 = spirv.GL.FSign %1 : vector<3xf16>
 ```
 """
-function GL_FSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5188,25 +4385,19 @@ computed per component.
 
 This instruction is currently limited to 32-bit width components.
 """
-function GL_FindUMsb(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_FindUMsb(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.FindUMsb",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FindUMsb", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5236,25 +4427,19 @@ floor-op ::= ssa-id `=` `spirv.GL.Floor` ssa-use `:`
 %3 = spirv.GL.Floor %1 : vector<3xf16>
 ```
 """
-function GL_Floor(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Floor(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Floor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5294,21 +4479,17 @@ fma-op ::= ssa-id `=` `spirv.GL.Fma` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_Fma(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.Fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Fma", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5351,21 +4532,17 @@ frexpstruct-op ::= ssa-id `=` `spirv.GL.FrexpStruct` ssa-use `:`
 ```
 """
 function GL_FrexpStruct(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.FrexpStruct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.FrexpStruct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5394,25 +4571,19 @@ rsqrt-op ::= ssa-id `=` `spirv.GL.InverseSqrt` ssa-use `:`
 %3 = spirv.GL.InverseSqrt %1 : vector<3xf16>
 ```
 """
-function GL_InverseSqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_InverseSqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.InverseSqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.InverseSqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5450,25 +4621,19 @@ component.
 %y = spirv.GL.Ldexp %x : vector<3xf32>, %exp : vector<3xi32> -> vector<3xf32>
 ```
 """
-function GL_Ldexp(
-    x::Value, exp::Value; y=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Ldexp(x::Value, exp::Value; y=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[x, exp]
+    operands = Value[x, exp, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(y) && push!(results, y)
-
-    return IR.create_operation(
-        "spirv.GL.Ldexp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Ldexp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5500,23 +4665,19 @@ log-op ::= ssa-id `=` `spirv.GL.Log` ssa-use `:`
 %3 = spirv.GL.Log %1 : vector<3xf16>
 ```
 """
-function GL_Log(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Log(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Log", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5549,25 +4710,19 @@ pow-op ::= ssa-id `=` `spirv.GL.Pow` ssa-use `:`
 %3 = spirv.GL.Pow %0, %1 : vector<3xf16>
 ```
 """
-function GL_Pow(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Pow(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Pow", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5598,25 +4753,19 @@ round-even-op ::= ssa-id `=` `spirv.GL.RoundEven` ssa-use `:`
 %3 = spirv.GL.RoundEven %1 : vector<3xf16>
 ```
 """
-function GL_RoundEven(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_RoundEven(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.RoundEven",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.RoundEven", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5648,25 +4797,19 @@ round-op ::= ssa-id `=` `spirv.GL.Round` ssa-use `:`
 %3 = spirv.GL.Round %1 : vector<3xf16>
 ```
 """
-function GL_Round(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Round(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Round",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Round", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5694,25 +4837,19 @@ abs-op ::= ssa-id `=` `spirv.GL.SAbs` ssa-use `:`
 %3 = spirv.GL.SAbs %1 : vector<3xi16>
 ```
 """
-function GL_SAbs(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SAbs(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SAbs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SAbs", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5741,21 +4878,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_SClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.SClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5784,25 +4917,19 @@ smax-op ::= ssa-id `=` `spirv.GL.SMax` ssa-use `:`
 %3 = spirv.GL.SMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5831,25 +4958,19 @@ smin-op ::= ssa-id `=` `spirv.GL.SMin` ssa-use `:`
 %3 = spirv.GL.SMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_SMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5877,25 +4998,19 @@ sign-op ::= ssa-id `=` `spirv.GL.SSign` ssa-use `:`
 %3 = spirv.GL.SSign %1 : vector<3xi16>
 ```
 """
-function GL_SSign(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_SSign(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.SSign",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.SSign", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5926,23 +5041,19 @@ sin-op ::= ssa-id `=` `spirv.GL.Sin` ssa-use `:`
 %3 = spirv.GL.Sin %1 : vector<3xf16>
 ```
 """
-function GL_Sin(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Sin(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5973,25 +5084,19 @@ sinh-op ::= ssa-id `=` `spirv.GL.Sinh` ssa-use `:`
 %3 = spirv.GL.Sinh %1 : vector<3xf16>
 ```
 """
-function GL_Sinh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sinh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sinh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sinh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6020,25 +5125,19 @@ sqrt-op ::= ssa-id `=` `spirv.GL.Sqrt` ssa-use `:`
 %3 = spirv.GL.Sqrt %1 : vector<3xf16>
 ```
 """
-function GL_Sqrt(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Sqrt(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Sqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Sqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6069,23 +5168,19 @@ tan-op ::= ssa-id `=` `spirv.GL.Tan` ssa-use `:`
 %3 = spirv.GL.Tan %1 : vector<3xf16>
 ```
 """
-function GL_Tan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function GL_Tan(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6116,25 +5211,19 @@ tanh-op ::= ssa-id `=` `spirv.GL.Tanh` ssa-use `:`
 %3 = spirv.GL.Tanh %1 : vector<3xf16>
 ```
 """
-function GL_Tanh(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_Tanh(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.Tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.Tanh", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6163,21 +5252,17 @@ uclamp-op ::= ssa-id `=` `spirv.GL.UClamp` ssa-use, ssa-use, ssa-use `:`
 ```
 """
 function GL_UClamp(x::Value, y::Value, z::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[x, y, z]
+    results = IR.Type[result, ]
+    operands = Value[x, y, z, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GL.UClamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UClamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6206,25 +5291,19 @@ smax-op ::= ssa-id `=` `spirv.GL.UMax` ssa-use `:`
 %3 = spirv.GL.UMax %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMax(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMax(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6253,25 +5332,19 @@ smin-op ::= ssa-id `=` `spirv.GL.UMin` ssa-use `:`
 %3 = spirv.GL.UMin %0, %1 : vector<3xi16>
 ```
 """
-function GL_UMin(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function GL_UMin(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GL.UMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GL.UMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6298,21 +5371,17 @@ Workgroup, CrossWorkgroup, or Function.
 ```
 """
 function GenericCastToPtrExplicit(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtrExplicit",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtrExplicit", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6336,21 +5405,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function GenericCastToPtr(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.GenericCastToPtr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GenericCastToPtr", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6394,42 +5459,24 @@ spirv.GlobalVariable @var2 bind(1, 2) : !spirv.ptr<f32, Uniform>
 spirv.GlobalVariable @var3 built_in(\"GlobalInvocationId\") : !spirv.ptr<vector<3xi32>, Input>
 ```
 """
-function GlobalVariable(;
-    type,
-    sym_name,
-    initializer=nothing,
-    location_=nothing,
-    binding=nothing,
-    descriptor_set=nothing,
-    builtin=nothing,
-    linkage_attributes=nothing,
-    location=Location(),
-)
+function GlobalVariable(; type, sym_name, initializer=nothing, location_=nothing, binding=nothing, descriptor_set=nothing, builtin=nothing, linkage_attributes=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type), namedattribute("sym_name", sym_name)
-    ]
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), ]
     !isnothing(initializer) && push!(attributes, namedattribute("initializer", initializer))
     !isnothing(location) && push!(attributes, namedattribute("location", location_))
     !isnothing(binding) && push!(attributes, namedattribute("binding", binding))
-    !isnothing(descriptor_set) &&
-        push!(attributes, namedattribute("descriptor_set", descriptor_set))
+    !isnothing(descriptor_set) && push!(attributes, namedattribute("descriptor_set", descriptor_set))
     !isnothing(builtin) && push!(attributes, namedattribute("builtin", builtin))
-    !isnothing(linkage_attributes) &&
-        push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
-
-    return IR.create_operation(
-        "spirv.GlobalVariable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(linkage_attributes) && push!(attributes, namedattribute("linkage_attributes", linkage_attributes))
+    
+    IR.create_operation(
+        "spirv.GlobalVariable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6478,29 +5525,19 @@ group-broadcast-op ::= ssa-id `=` `spirv.GroupBroadcast` scope ssa_use,
   vector<4xf32>, vector<3xi32>
 ```
 """
-function GroupBroadcast(
-    value::Value,
-    localid::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupBroadcast(value::Value, localid::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, localid]
+    operands = Value[value, localid, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6536,32 +5573,19 @@ op ::= ssa-id `=` `spirv.GroupFAdd` scope operation ssa-use
 %0 = spirv.GroupFAdd <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6597,32 +5621,19 @@ op ::= ssa-id `=` `spirv.GroupFMax` scope operation ssa-use
 %0 = spirv.GroupFMax <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6658,32 +5669,19 @@ op ::= ssa-id `=` `spirv.GroupFMin` scope operation ssa-use
 %0 = spirv.GroupFMin <Workgroup> <Reduce> %value : f32
 ```
 """
-function GroupFMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupFMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupFMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6720,32 +5718,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupFMul` scope operation ssa-use
 %0 = spirv.KHR.GroupFMul <Workgroup> <Reduce> %value : f32
 ```
 """
-function KHR_GroupFMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupFMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupFMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6781,32 +5766,19 @@ op ::= ssa-id `=` `spirv.GroupIAdd` scope operation ssa-use
 %0 = spirv.GroupIAdd <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupIAdd(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupIAdd(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6843,32 +5815,19 @@ op ::= ssa-id `=` `spirv.KHR.GroupIMul` scope operation ssa-use
 %0 = spirv.KHR.GroupIMul <Workgroup> <Reduce> %value : i32
 ```
 """
-function KHR_GroupIMul(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function KHR_GroupIMul(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.GroupIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.GroupIMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -6901,24 +5860,18 @@ non-uniform-ballot-op ::= ssa-id `=` `spirv.GroupNonUniformBallot` scope
 %0 = spirv.GroupNonUniformBallot \"SubGroup\" %predicate : vector<4xi32>
 ```
 """
-function GroupNonUniformBallot(
-    predicate::Value; result::IR.Type, execution_scope, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+function GroupNonUniformBallot(predicate::Value; result::IR.Type, execution_scope, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6963,29 +5916,19 @@ group-non-uniform-broadcast-op ::= ssa-id `=`
   vector<4xf32>, i32
 ```
 """
-function GroupNonUniformBroadcast(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformBroadcast(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformBroadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformBroadcast", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7010,25 +5953,19 @@ non-uniform-elect-op ::= ssa-id `=` `spirv.GroupNonUniformElect` scope
 %0 = spirv.GroupNonUniformElect : i1
 ```
 """
-function GroupNonUniformElect(;
-    result=nothing::Union{Nothing,IR.Type}, execution_scope, location=Location()
-)
+function GroupNonUniformElect(; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformElect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformElect", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7074,33 +6011,19 @@ non-uniform-fadd-op ::= ssa-id `=` `spirv.GroupNonUniformFAdd` scope operation
 %1 = spirv.GroupNonUniformFAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7149,33 +6072,19 @@ non-uniform-fmax-op ::= ssa-id `=` `spirv.GroupNonUniformFMax` scope operation
 %1 = spirv.GroupNonUniformFMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7224,33 +6133,19 @@ non-uniform-fmin-op ::= ssa-id `=` `spirv.GroupNonUniformFMin` scope operation
 %1 = spirv.GroupNonUniformFMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7296,33 +6191,19 @@ non-uniform-fmul-op ::= ssa-id `=` `spirv.GroupNonUniformFMul` scope operation
 %1 = spirv.GroupNonUniformFMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xf32>
 ```
 """
-function GroupNonUniformFMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformFMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformFMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformFMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7366,33 +6247,19 @@ non-uniform-iadd-op ::= ssa-id `=` `spirv.GroupNonUniformIAdd` scope operation
 %1 = spirv.GroupNonUniformIAdd \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIAdd(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIAdd(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIAdd", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7436,33 +6303,19 @@ non-uniform-imul-op ::= ssa-id `=` `spirv.GroupNonUniformIMul` scope operation
 %1 = spirv.GroupNonUniformIMul \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformIMul(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformIMul(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformIMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformIMul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7506,33 +6359,19 @@ non-uniform-smax-op ::= ssa-id `=` `spirv.GroupNonUniformSMax` scope operation
 %1 = spirv.GroupNonUniformSMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7576,33 +6415,19 @@ non-uniform-smin-op ::= ssa-id `=` `spirv.GroupNonUniformSMin` scope operation
 %1 = spirv.GroupNonUniformSMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformSMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformSMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformSMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7631,29 +6456,19 @@ invocation or greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleDown <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleDown(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleDown(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleDown",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleDown", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7680,29 +6495,19 @@ greater than or equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffle <Subgroup> %val, %id : f32, i32
 ```
 """
-function GroupNonUniformShuffle(
-    value::Value,
-    id::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffle(value::Value, id::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, id]
+    operands = Value[value, id, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7730,29 +6535,19 @@ the selected lane is inactive.
 %0 = spirv.GroupNonUniformShuffleUp <Subgroup> %val, %delta : f32, i32
 ```
 """
-function GroupNonUniformShuffleUp(
-    value::Value,
-    delta::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleUp(value::Value, delta::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, delta]
+    operands = Value[value, delta, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleUp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleUp", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7780,29 +6575,19 @@ equal to the size of the group.
 %0 = spirv.GroupNonUniformShuffleXor <Subgroup> %val, %mask : f32, i32
 ```
 """
-function GroupNonUniformShuffleXor(
-    value::Value,
-    mask::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    location=Location(),
-)
+function GroupNonUniformShuffleXor(value::Value, mask::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, location=Location())
     results = IR.Type[]
-    operands = Value[value, mask]
+    operands = Value[value, mask, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope),]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformShuffleXor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformShuffleXor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -7847,33 +6632,19 @@ non-uniform-umax-op ::= ssa-id `=` `spirv.GroupNonUniformUMax` scope operation
 %1 = spirv.GroupNonUniformUMax \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMax(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMax(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7918,33 +6689,19 @@ non-uniform-umin-op ::= ssa-id `=` `spirv.GroupNonUniformUMin` scope operation
 %1 = spirv.GroupNonUniformUMin \"Subgroup\" \"ClusteredReduce\" %vector cluster_size(%four) : vector<4xi32>
 ```
 """
-function GroupNonUniformUMin(
-    value::Value,
-    cluster_size=nothing::Union{Nothing,Value};
-    result::IR.Type,
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[value,]
+function GroupNonUniformUMin(value::Value, cluster_size=nothing::Union{Nothing, Value}; result::IR.Type, execution_scope, group_operation, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(cluster_size) && push!(operands, cluster_size)
-
-    return IR.create_operation(
-        "spirv.GroupNonUniformUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupNonUniformUMin", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -7981,32 +6738,19 @@ op ::= ssa-id `=` `spirv.GroupSMax` scope operation ssa-use
 %0 = spirv.GroupSMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8043,32 +6787,19 @@ op ::= ssa-id `=` `spirv.GroupSMin` scope operation ssa-use
 %0 = spirv.GroupSMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupSMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupSMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupSMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupSMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8104,32 +6835,19 @@ op ::= ssa-id `=` `spirv.GroupUMax` scope operation ssa-use
 %0 = spirv.GroupUMax <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMax(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMax(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMax", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8166,32 +6884,19 @@ op ::= ssa-id `=` `spirv.GroupUMin` scope operation ssa-use
 %0 = spirv.GroupUMin <Workgroup> <Reduce> %value : i32
 ```
 """
-function GroupUMin(
-    x::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    execution_scope,
-    group_operation,
-    location=Location(),
-)
+function GroupUMin(x::Value; result=nothing::Union{Nothing, IR.Type}, execution_scope, group_operation, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
+    operands = Value[x, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("execution_scope", execution_scope),
-        namedattribute("group_operation", group_operation),
-    ]
+    attributes = NamedAttribute[namedattribute("execution_scope", execution_scope), namedattribute("group_operation", group_operation), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.GroupUMin",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.GroupUMin", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8225,21 +6930,17 @@ the component width, and 0 otherwise.
 ```
 """
 function IAddCarry(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.IAddCarry",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAddCarry", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8274,28 +6975,19 @@ iadd-op ::= ssa-id `=` `spirv.IAdd` ssa-use, ssa-use
 
 ```
 """
-function IAdd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IAdd(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8325,28 +7017,18 @@ iequal-op ::= ssa-id `=` `spirv.IEqual` ssa-use, ssa-use
 
 ```
 """
-function IEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function IEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8381,28 +7063,19 @@ imul-op ::= ssa-id `=` `spirv.IMul` ssa-use, ssa-use
 
 ```
 """
-function IMul(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function IMul(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IMul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.IMul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8431,21 +7104,17 @@ convert-bf16-to-f-op ::= ssa-id `=` `spirv.INTEL.ConvertBF16ToF` ssa-use
 ```
 """
 function INTEL_ConvertBF16ToF(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.ConvertBF16ToF",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.ConvertBF16ToF", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8476,21 +7145,17 @@ convert-f-to-bf16-op ::= ssa-id `=` `spirv.INTEL.ConvertFToBF16` ssa-use
 ```
 """
 function INTEL_ConvertFToBF16(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.ConvertFToBF16",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.ConvertFToBF16", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8524,36 +7189,20 @@ present, it is the same as specifying the memory operand None.
      !spirv.jointmatrix<8x16xi32, ColumnMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function INTEL_JointMatrixLoad(pointer::Value, stride::Value; result::IR.Type, layout, scope, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8591,30 +7240,19 @@ integer type.
      -> !spirv.jointmatrix<8x8xi32,  RowMajor, Subgroup>
 ```
 """
-function INTEL_JointMatrixMad(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    scope,
-    location=Location(),
-)
+function INTEL_JointMatrixMad(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, scope, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scope", scope),]
+    attributes = NamedAttribute[namedattribute("scope", scope), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixMad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixMad", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8652,36 +7290,20 @@ spirv.INTEL.JointMatrixStore <Subgroup> <ColumnMajor> %ptr, %m, %stride
 !spirv.jointmatrix<8x16xi32, RowMajor, Subgroup>, i32)
 ```
 """
-function INTEL_JointMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    layout,
-    scope,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
+function INTEL_JointMatrixStore(pointer::Value, object::Value, stride::Value; layout, scope, memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("layout", layout), namedattribute("scope", scope)
-    ]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    attributes = NamedAttribute[namedattribute("layout", layout), namedattribute("scope", scope), ]
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8706,25 +7328,19 @@ For example:
 %0 = spirv.INTEL.JointMatrixWorkItemLength : !spirv.jointmatrix<Subgroup, i32, 8, 16>
 ```
 """
-function INTEL_JointMatrixWorkItemLength(;
-    result=nothing::Union{Nothing,IR.Type}, joint_matrix_type, location=Location()
-)
+function INTEL_JointMatrixWorkItemLength(; result=nothing::Union{Nothing, IR.Type}, joint_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type),]
+    attributes = NamedAttribute[namedattribute("joint_matrix_type", joint_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INTEL.JointMatrixWorkItemLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.JointMatrixWorkItemLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -8760,21 +7376,17 @@ subgroup-block-read-INTEL-op ::= ssa-id `=` `spirv.INTEL.SubgroupBlockRead`
 ```
 """
 function INTEL_SubgroupBlockRead(ptr::Value; value::IR.Type, location=Location())
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockRead",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockRead", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8810,20 +7422,16 @@ spirv.INTEL.SubgroupBlockWrite \"StorageBuffer\" %ptr, %value : i32
 """
 function INTEL_SubgroupBlockWrite(ptr::Value, value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.INTEL.SubgroupBlockWrite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.INTEL.SubgroupBlockWrite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8853,28 +7461,18 @@ inot-equal-op ::= ssa-id `=` `spirv.INotEqual` ssa-use, ssa-use
 
 ```
 """
-function INotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function INotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.INotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.INotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -8910,21 +7508,17 @@ otherwise.
 ```
 """
 function ISubBorrow(operand1::Value, operand2::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ISubBorrow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISubBorrow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -8959,28 +7553,19 @@ isub-op ::= `spirv.ISub` ssa-use, ssa-use
 
 ```
 """
-function ISub(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ISub(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ISub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ISub", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9020,32 +7605,19 @@ image-operands ::= `\"None\"` | `\"Bias\"` | `\"Lod\"` | `\"Grad\"`
 %0 = spirv.ImageDrefGather %1 : !spirv.sampled_image<!spirv.image<i32, Dim2D, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>, %2 : vector<4xf32>, %3 : f32 [\"NonPrivateTexel\"] : f32, f32 -> vector<4xi32>
 ```
 """
-function ImageDrefGather(
-    sampledimage::Value,
-    coordinate::Value,
-    dref::Value,
-    operand_arguments::Vector{Value};
-    result::IR.Type,
-    imageoperands=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[sampledimage, coordinate, dref, operand_arguments...]
+function ImageDrefGather(sampledimage::Value, coordinate::Value, dref::Value, operand_arguments::Vector{Value}; result::IR.Type, imageoperands=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, coordinate, dref, operand_arguments..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(imageoperands) &&
-        push!(attributes, namedattribute("imageoperands", imageoperands))
-
-    return IR.create_operation(
-        "spirv.ImageDrefGather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(imageoperands) && push!(attributes, namedattribute("imageoperands", imageoperands))
+    
+    IR.create_operation(
+        "spirv.ImageDrefGather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9065,25 +7637,18 @@ same as Result Type.
 %0 = spirv.Image %1 : !spirv.sampled_image<!spirv.image<f32, Cube, NoDepth, NonArrayed, SingleSampled, NoSampler, Unknown>>
 ```
 """
-function Image(
-    sampledimage::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[sampledimage,]
+function Image(sampledimage::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[sampledimage, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Image",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Image", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9122,21 +7687,17 @@ See the client API specification for additional image type restrictions.
 ```
 """
 function ImageQuerySize(image::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[image,]
+    results = IR.Type[result, ]
+    operands = Value[image, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ImageQuerySize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ImageQuerySize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9162,28 +7723,18 @@ func @inbounds_ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : 
 }
 ```
 """
-function InBoundsPtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function InBoundsPtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.InBoundsPtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.InBoundsPtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9213,23 +7764,18 @@ isinf-op ::= ssa-id `=` `spirv.IsInf` ssa-use
 %3 = spirv.IsInf %1: vector<4xi32>
 ```
 """
-function IsInf(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsInf(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsInf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsInf", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9259,23 +7805,18 @@ isnan-op ::= ssa-id `=` `spirv.IsNan` ssa-use
 %3 = spirv.IsNan %1: vector<4xi32>
 ```
 """
-function IsNan(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
-    results = IR.Type[]
-    operands = Value[operand,]
+function IsNan(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.IsNan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.IsNan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9298,20 +7839,16 @@ spirv.KHR.AssumeTrue %arg
 """
 function KHR_AssumeTrue(condition::Value; location=Location())
     results = IR.Type[]
-    operands = Value[condition,]
+    operands = Value[condition, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.AssumeTrue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.AssumeTrue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9335,27 +7872,19 @@ cooperative-matrix-length-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLength
        !spirv.coopmatrix<8x16xi32, Subgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function KHR_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.KHR.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -9407,31 +7936,19 @@ cooperative-matrix-load-op ::= ssa-id `=` `spirv.KHR.CooperativeMatrixLoad`
          as !spirv.KHR.coopmatrix<16x8xi32, Workgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value;
-    result::IR.Type,
-    matrix_layout,
-    memory_operand=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride]
+function KHR_CooperativeMatrixLoad(pointer::Value, stride::Value; result::IR.Type, matrix_layout, memory_operand=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout),]
-    !isnothing(memory_operand) &&
-        push!(attributes, namedattribute("memory_operand", memory_operand))
-
-    return IR.create_operation(
-        "spirv.KHR.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout), ]
+    !isnothing(memory_operand) && push!(attributes, namedattribute("memory_operand", memory_operand))
+    
+    IR.create_operation(
+        "spirv.KHR.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9482,31 +7999,19 @@ inactive.
     !spirv.ptr<i32, StorageBuffer>, !spirv.coopmatrix<16x8xi32, Workgroup, MatrixA>
 ```
 """
-function KHR_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value;
-    matrix_layout,
-    memory_operand=nothing,
-    location=Location(),
-)
+function KHR_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value; matrix_layout, memory_operand=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride]
+    operands = Value[pointer, object, stride, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout),]
-    !isnothing(memory_operand) &&
-        push!(attributes, namedattribute("memory_operand", memory_operand))
-
-    return IR.create_operation(
-        "spirv.KHR.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("matrix_layout", matrix_layout), ]
+    !isnothing(memory_operand) && push!(attributes, namedattribute("memory_operand", memory_operand))
+    
+    IR.create_operation(
+        "spirv.KHR.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9541,21 +8046,17 @@ subgroup-ballot-op ::= ssa-id `=` `spirv.KHR.SubgroupBallot`
 ```
 """
 function KHR_SubgroupBallot(predicate::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[predicate,]
+    results = IR.Type[result, ]
+    operands = Value[predicate, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.KHR.SubgroupBallot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.KHR.SubgroupBallot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9592,31 +8093,20 @@ load-op ::= ssa-id ` = spirv.Load ` storage-class ssa-use
 %3 = spirv.Load \"Function\" %0 [\"Aligned\", 4] : f32
 ```
 """
-function Load(
-    ptr::Value;
-    value::IR.Type,
-    memory_access=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[value,]
-    operands = Value[ptr,]
+function Load(ptr::Value; value::IR.Type, memory_access=nothing, alignment=nothing, location=Location())
+    results = IR.Type[value, ]
+    operands = Value[ptr, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9645,28 +8135,18 @@ logical-and ::= `spirv.LogicalAnd` ssa-use `,` ssa-use
 %2 = spirv.LogicalAnd %0, %1 : vector<4xi1>
 ```
 """
-function LogicalAnd(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalAnd(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalAnd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalAnd", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9695,28 +8175,18 @@ logical-equal ::= `spirv.LogicalEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9745,28 +8215,18 @@ logical-not-equal ::= `spirv.LogicalNotEqual` ssa-use `,` ssa-use
 %2 = spirv.LogicalNotEqual %0, %1 : vector<4xi1>
 ```
 """
-function LogicalNotEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalNotEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNotEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNotEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9792,25 +8252,18 @@ logical-not ::= `spirv.LogicalNot` ssa-use `:` operand-type
 %2 = spirv.LogicalNot %0 : vector<4xi1>
 ```
 """
-function LogicalNot(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[operand,]
+function LogicalNot(operand::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalNot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalNot", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9839,28 +8292,18 @@ logical-or ::= `spirv.LogicalOr` ssa-use `,` ssa-use
 %2 = spirv.LogicalOr %0, %1 : vector<4xi1>
 ```
 """
-function LogicalOr(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function LogicalOr(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.LogicalOr",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.LogicalOr", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -9894,19 +8337,15 @@ block, except the entry block, branching to the header block.
 function mlir_loop(; loop_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("loop_control", loop_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("loop_control", loop_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9939,24 +8378,18 @@ ssa-use `:` matrix-type `,` matrix-type `->` matrix-type
     !spirv.matrix<4 x vector<4xf32>>
 ```
 """
-function MatrixTimesMatrix(
-    leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[leftmatrix, rightmatrix]
+function MatrixTimesMatrix(leftmatrix::Value, rightmatrix::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[leftmatrix, rightmatrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.MatrixTimesMatrix",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesMatrix", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -9987,28 +8420,19 @@ ssa-use `:` matrix-type `,` float-type `->` matrix-type
 
 ```
 """
-function MatrixTimesScalar(
-    matrix::Value,
-    scalar::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function MatrixTimesScalar(matrix::Value, scalar::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[matrix, scalar]
+    operands = Value[matrix, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.MatrixTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.MatrixTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10051,20 +8475,13 @@ function MemoryBarrier(; memory_scope, memory_semantics, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("memory_scope", memory_scope),
-        namedattribute("memory_semantics", memory_semantics),
-    ]
-
-    return IR.create_operation(
-        "spirv.MemoryBarrier",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("memory_scope", memory_scope), namedattribute("memory_semantics", memory_semantics), ]
+    
+    IR.create_operation(
+        "spirv.MemoryBarrier", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10083,16 +8500,12 @@ function mlir_merge(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.merge",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.merge", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10139,34 +8552,20 @@ spirv.module Logical Vulkan
 }
 ```
 """
-function module_(;
-    addressing_model,
-    memory_model,
-    vce_triple=nothing,
-    sym_name=nothing,
-    region_0::Region,
-    location=Location(),
-)
+function module_(; addressing_model, memory_model, vce_triple=nothing, sym_name=nothing, region_0::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[region_0,]
+    owned_regions = Region[region_0, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("addressing_model", addressing_model),
-        namedattribute("memory_model", memory_model),
-    ]
+    attributes = NamedAttribute[namedattribute("addressing_model", addressing_model), namedattribute("memory_model", memory_model), ]
     !isnothing(vce_triple) && push!(attributes, namedattribute("vce_triple", vce_triple))
     !isnothing(sym_name) && push!(attributes, namedattribute("sym_name", sym_name))
-
-    return IR.create_operation(
-        "spirv.module",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.module", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10191,27 +8590,19 @@ For example:
 %0 = spirv.NV.CooperativeMatrixLength : !spirv.NV.coopmatrix<8x16xi32, Subgroup>
 ```
 """
-function NV_CooperativeMatrixLength(;
-    result=nothing::Union{Nothing,IR.Type}, cooperative_matrix_type, location=Location()
-)
+function NV_CooperativeMatrixLength(; result=nothing::Union{Nothing, IR.Type}, cooperative_matrix_type, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "cooperative_matrix_type", cooperative_matrix_type
-    ),]
+    attributes = NamedAttribute[namedattribute("cooperative_matrix_type", cooperative_matrix_type), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLength",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLength", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10268,31 +8659,19 @@ For example:
      : !spirv.ptr<i32, StorageBuffer> as !spirv.NV.coopmatrix<16x8xi32, Workgroup>
 ```
 """
-function NV_CooperativeMatrixLoad(
-    pointer::Value,
-    stride::Value,
-    columnmajor::Value;
-    result::IR.Type,
-    memory_access=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[pointer, stride, columnmajor]
+function NV_CooperativeMatrixLoad(pointer::Value, stride::Value, columnmajor::Value; result::IR.Type, memory_access=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[pointer, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixLoad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixLoad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10343,29 +8722,19 @@ For example:
   !spirv.NV.coopmatrix<8x16xi32, Subgroup>
 ```
 """
-function NV_CooperativeMatrixMulAdd(
-    a::Value,
-    b::Value,
-    c::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function NV_CooperativeMatrixMulAdd(a::Value, b::Value, c::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixMulAdd",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixMulAdd", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10408,31 +8777,19 @@ For example:
     !spirv.ptr<i32, StorageBuffer>, !spirv.NV.coopmatrix<16x8xi32, Workgroup>
 ```
 """
-function NV_CooperativeMatrixStore(
-    pointer::Value,
-    object::Value,
-    stride::Value,
-    columnmajor::Value;
-    memory_access=nothing,
-    location=Location(),
-)
+function NV_CooperativeMatrixStore(pointer::Value, object::Value, stride::Value, columnmajor::Value; memory_access=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[pointer, object, stride, columnmajor]
+    operands = Value[pointer, object, stride, columnmajor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
-
-    return IR.create_operation(
-        "spirv.NV.CooperativeMatrixStore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
+    
+    IR.create_operation(
+        "spirv.NV.CooperativeMatrixStore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10462,23 +8819,19 @@ Results are computed per component, and within each component, per bit.
     %3 = spirv.Not %1 : vector<4xi32>
     ```
 """
-function Not(operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function Not(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Not", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10509,28 +8862,18 @@ ordered-op ::= ssa-id `=` `spirv.Ordered` ssa-use, ssa-use
 %5 = spirv.Ordered %2, %3 : vector<4xf32>
 ```
 """
-function Ordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Ordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Ordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Ordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -10579,28 +8922,18 @@ func @ptr_access_chain(%arg0: !spirv.ptr<f32, CrossWorkgroup>, %arg1 : i64) -> (
 }
 ```
 """
-function PtrAccessChain(
-    base_ptr::Value,
-    element::Value,
-    indices::Vector{Value};
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base_ptr, element, indices...]
+function PtrAccessChain(base_ptr::Value, element::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base_ptr, element, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrAccessChain",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrAccessChain", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10624,21 +8957,17 @@ Result Type and Pointer must point to the same type.
 ```
 """
 function PtrCastToGeneric(pointer::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[pointer,]
+    results = IR.Type[result, ]
+    operands = Value[pointer, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.PtrCastToGeneric",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.PtrCastToGeneric", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10668,21 +8997,17 @@ spv-reference-of-op ::= ssa-id `=` `spirv.mlir.referenceof` symbol-ref-id
 TODO Add support for composite specialization constants.
 """
 function mlir_referenceof(; reference::IR.Type, spec_const, location=Location())
-    results = IR.Type[reference,]
+    results = IR.Type[reference, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("spec_const", spec_const),]
-
-    return IR.create_operation(
-        "spirv.mlir.referenceof",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("spec_const", spec_const), ]
+    
+    IR.create_operation(
+        "spirv.mlir.referenceof", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10703,16 +9028,12 @@ function Return(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10739,20 +9060,16 @@ spirv.ReturnValue %0 : f32
 """
 function ReturnValue(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.ReturnValue",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ReturnValue", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10782,21 +9099,17 @@ s-convert-op ::= ssa-id `=` `spirv.SConvertOp` ssa-use
 ```
 """
 function SConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10828,28 +9141,19 @@ sdiv-op ::= ssa-id `=` `spirv.SDiv` ssa-use, ssa-use
 
 ```
 """
-function SDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -10892,30 +9196,19 @@ is undefined.
 %r = spirv.SDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -10953,25 +9246,19 @@ overflow and underflow.
 %r = spirv.SDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11001,28 +9288,18 @@ sgreater-than-equal-op ::= ssa-id `=` `spirv.SGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11052,28 +9329,18 @@ sgreater-than-op ::= ssa-id `=` `spirv.SGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function SGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11103,28 +9370,18 @@ sless-than-equal-op ::= ssa-id `=` `spirv.SLessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function SLessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11154,28 +9411,18 @@ sless-than-op ::= ssa-id `=` `spirv.SLessThan` ssa-use, ssa-use
 
 ```
 """
-function SLessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function SLessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SLessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.SLessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -11208,28 +9455,19 @@ smod-op ::= ssa-id `=` `spirv.SMod` ssa-use, ssa-use
 
 ```
 """
-function SMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11258,24 +9496,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.SMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function SMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function SMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11299,25 +9531,19 @@ must equal the component width in Result Type.
 %3 = spirv.SNegate %2 : vector<4xi32>
 ```
 """
-function SNegate(
-    operand::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function SNegate(operand::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SNegate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SNegate", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11350,28 +9576,19 @@ srem-op ::= ssa-id `=` `spirv.SRem` ssa-use, ssa-use
 
 ```
 """
-function SRem(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function SRem(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.SRem",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SRem", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11416,30 +9633,19 @@ is undefined.
 %r = spirv.SUDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function SUDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function SUDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11479,25 +9685,19 @@ avoid overflow and underflow.
 %r = spirv.SUDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function SUDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function SUDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.SUDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SUDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11540,29 +9740,19 @@ select-op ::= ssa-id `=` `spirv.Select` ssa-use, ssa-use, ssa-use
 %3 = spirv.Select %0, %1, %2 : vector<3xi1>, vector<3xf32>
 ```
 """
-function Select(
-    condition::Value,
-    true_value::Value,
-    false_value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function Select(condition::Value, true_value::Value, false_value::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[condition, true_value, false_value]
+    operands = Value[condition, true_value, false_value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11590,19 +9780,15 @@ The merge block should only contain a `spirv.mlir.merge` op.
 function mlir_selection(; selection_control, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("selection_control", selection_control),]
-
-    return IR.create_operation(
-        "spirv.mlir.selection",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("selection_control", selection_control), ]
+    
+    IR.create_operation(
+        "spirv.mlir.selection", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11642,28 +9828,19 @@ shift-left-logical-op ::= ssa-id `=` `spirv.ShiftLeftLogical`
 %5 = spirv.ShiftLeftLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftLeftLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftLeftLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftLeftLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftLeftLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11700,28 +9877,19 @@ shift-right-arithmetic-op ::= ssa-id `=` `spirv.ShiftRightArithmetic`
 %5 = spirv.ShiftRightArithmetic %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightArithmetic(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightArithmetic(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightArithmetic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightArithmetic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11759,28 +9927,19 @@ shift-right-logical-op ::= ssa-id `=` `spirv.ShiftRightLogical`
 %5 = spirv.ShiftRightLogical %3, %4 : vector<3xi32>, vector<3xi16>
 ```
 """
-function ShiftRightLogical(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function ShiftRightLogical(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ShiftRightLogical",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.ShiftRightLogical", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -11825,21 +9984,13 @@ function SpecConstantComposite(; type, sym_name, constituents, location=Location
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("type", type),
-        namedattribute("sym_name", sym_name),
-        namedattribute("constituents", constituents),
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstantComposite",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("type", type), namedattribute("sym_name", sym_name), namedattribute("constituents", constituents), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstantComposite", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11879,19 +10030,13 @@ function SpecConstant(; sym_name, default_value, location=Location())
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("default_value", default_value)
-    ]
-
-    return IR.create_operation(
-        "spirv.SpecConstant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("default_value", default_value), ]
+    
+    IR.create_operation(
+        "spirv.SpecConstant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -11965,21 +10110,17 @@ TODO Add capability-specific ops when supported.
 ```
 """
 function SpecConstantOperation(; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.SpecConstantOperation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.SpecConstantOperation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12012,27 +10153,20 @@ spirv.Store \"Function\" %0, %1 [\"Volatile\"] : f32
 spirv.Store \"Function\" %0, %1 [\"Aligned\", 4] : f32
 ```
 """
-function Store(
-    ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location()
-)
+function Store(ptr::Value, value::Value; memory_access=nothing, alignment=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[ptr, value]
+    operands = Value[ptr, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_access) &&
-        push!(attributes, namedattribute("memory_access", memory_access))
+    !isnothing(memory_access) && push!(attributes, namedattribute("memory_access", memory_access))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "spirv.Store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12065,21 +10199,17 @@ matrix-type
 ```
 """
 function Transpose(matrix::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[matrix,]
+    results = IR.Type[result, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12110,21 +10240,17 @@ u-convert-op ::= ssa-id `=` `spirv.UConvertOp` ssa-use
 ```
 """
 function UConvert(operand::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[operand,]
+    results = IR.Type[result, ]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UConvert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UConvert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12155,28 +10281,19 @@ udiv-op ::= ssa-id `=` `spirv.UDiv` ssa-use, ssa-use
 
 ```
 """
-function UDiv(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UDiv(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UDiv",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDiv", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12221,30 +10338,19 @@ is undefined.
 %r = spirv.UDotAccSat %a, %b, %acc : (vector<4xi8>, vector<4xi8>, i32) -> i32
 ```
 """
-function UDotAccSat(
-    vector1::Value,
-    vector2::Value,
-    accumulator::Value;
-    result::IR.Type,
-    format=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2, accumulator]
+function UDotAccSat(vector1::Value, vector2::Value, accumulator::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, accumulator, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDotAccSat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDotAccSat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12284,25 +10390,19 @@ overflow and underflow.
 %r = spirv.UDot %a, %b : (vector<4xi8>, vector<4xi8>) -> i32
 ```
 """
-function UDot(
-    vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function UDot(vector1::Value, vector2::Value; result::IR.Type, format=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(format) && push!(attributes, namedattribute("format", format))
-
-    return IR.create_operation(
-        "spirv.UDot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UDot", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12332,28 +10432,18 @@ ugreater-than-equal-op ::= ssa-id `=` `spirv.UGreaterThanEqual` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12383,28 +10473,18 @@ ugreater-than-op ::= ssa-id `=` `spirv.UGreaterThan` ssa-use, ssa-use
 
 ```
 """
-function UGreaterThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function UGreaterThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UGreaterThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.UGreaterThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12434,28 +10514,18 @@ uless-than-equal-op ::= ssa-id `=` `spirv.ULessThanEqual` ssa-use, ssa-use
 
 ```
 """
-function ULessThanEqual(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThanEqual(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThanEqual",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThanEqual", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12485,28 +10555,18 @@ uless-than-op ::= ssa-id `=` `spirv.ULessThan` ssa-use, ssa-use
 
 ```
 """
-function ULessThan(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function ULessThan(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.ULessThan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.ULessThan", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12537,28 +10597,19 @@ umod-op ::= ssa-id `=` `spirv.UMod` ssa-use, ssa-use
 
 ```
 """
-function UMod(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function UMod(operand1::Value, operand2::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand1, operand2]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.UMod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12588,24 +10639,18 @@ Member 1 of the result gets the high-order bits of the multiplication.
 %2 = spirv.UMulExtended %0, %1 : !spirv.struct<(vector<2xi32>, vector<2xi32>)>
 ```
 """
-function UMulExtended(
-    operand1::Value, operand2::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand1, operand2]
+function UMulExtended(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.UMulExtended",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.UMulExtended", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12632,21 +10677,17 @@ undef-op ::= `spirv.Undef` `:` spirv-type
 ```
 """
 function Undef(; result::IR.Type, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Undef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Undef", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12677,28 +10718,18 @@ unordered-op ::= ssa-id `=` `spirv.Unordered` ssa-use, ssa-use
 %5 = spirv.Unordered %2, %3 : vector<4xf32>
 ```
 """
-function Unordered(
-    operand1::Value,
-    operand2::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[operand1, operand2]
+function Unordered(operand1::Value, operand2::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand1, operand2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.Unordered",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.Unordered", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12719,16 +10750,12 @@ function Unreachable(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.Unreachable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Unreachable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12766,28 +10793,19 @@ where `init` specifies initializer.
 %2 = spirv.Variable init(%0): !spirv.ptr<f32, Function>
 ```
 """
-function Variable(
-    initializer=nothing::Union{Nothing,Value};
-    pointer::IR.Type,
-    storage_class,
-    location=Location(),
-)
-    results = IR.Type[pointer,]
+function Variable(initializer=nothing::Union{Nothing, Value}; pointer::IR.Type, storage_class, location=Location())
+    results = IR.Type[pointer, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("storage_class", storage_class),]
+    attributes = NamedAttribute[namedattribute("storage_class", storage_class), ]
     !isnothing(initializer) && push!(operands, initializer)
-
-    return IR.create_operation(
-        "spirv.Variable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.Variable", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12813,25 +10831,18 @@ or equal to the number of components in Vector.
 %2 = spirv.VectorExtractDynamic %0[%1] : vector<8xf32>, i32
 ```
 """
-function VectorExtractDynamic(
-    vector::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
-    results = IR.Type[]
-    operands = Value[vector, index]
+function VectorExtractDynamic(vector::Value, index::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorExtractDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "spirv.VectorExtractDynamic", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -12869,29 +10880,19 @@ vector-insert-dynamic-op ::= `spirv.VectorInsertDynamic ` ssa-use `,`
 %2 = spirv.VectorInsertDynamic %scalar %0[%1] : f32, vector<8xf32>, i32
 ```
 """
-function VectorInsertDynamic(
-    vector::Value,
-    component::Value,
-    index::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function VectorInsertDynamic(vector::Value, component::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[vector, component, index]
+    operands = Value[vector, component, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "spirv.VectorInsertDynamic",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorInsertDynamic", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -12932,24 +10933,18 @@ operands, or using an OpUndef for one of the Vector operands.
                     -> vector<3xf32>
 ```
 """
-function VectorShuffle(
-    vector1::Value, vector2::Value; result::IR.Type, components, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector1, vector2]
+function VectorShuffle(vector1::Value, vector2::Value; result::IR.Type, components, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector1, vector2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("components", components),]
-
-    return IR.create_operation(
-        "spirv.VectorShuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("components", components), ]
+    
+    IR.create_operation(
+        "spirv.VectorShuffle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -12971,24 +10966,18 @@ Scalar must have the same type as the Component Type in Result Type.
 %0 = spirv.VectorTimesScalar %vector, %scalar : vector<4xf32>
 ```
 """
-function VectorTimesScalar(
-    vector::Value, scalar::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[vector, scalar]
+function VectorTimesScalar(vector::Value, scalar::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, scalar, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.VectorTimesScalar",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.VectorTimesScalar", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -13013,20 +11002,16 @@ spirv.mlir.yield %0
 """
 function mlir_yield(operand::Value; location=Location())
     results = IR.Type[]
-    operands = Value[operand,]
+    operands = Value[operand, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "spirv.mlir.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "spirv.mlir.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Shape.jl
+++ b/src/Dialects/17/Shape.jl
@@ -1,9 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `add`
@@ -15,25 +14,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -54,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -92,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -124,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -153,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -195,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -229,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -260,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -289,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -324,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -361,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -396,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -437,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -467,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -495,25 +422,19 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(
-    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, index]
+    operands = Value[value, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -534,25 +455,19 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -563,25 +478,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -598,25 +507,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -627,36 +530,21 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -679,28 +567,19 @@ shape.function_library {
 }
 ```
 """
-function function_library(;
-    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
-)
+function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -710,25 +589,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -741,25 +614,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -781,25 +648,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -811,25 +672,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -860,30 +715,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -895,25 +740,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -927,25 +766,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -958,25 +791,19 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -985,23 +812,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1039,28 +862,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1071,22 +884,18 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1099,25 +908,19 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1127,23 +930,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1155,25 +954,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1201,24 +994,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1232,21 +1019,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1269,21 +1052,17 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1295,21 +1074,17 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_of", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1348,28 +1123,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1377,22 +1143,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Shape.jl
+++ b/src/Dialects/17/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `add`
@@ -14,19 +14,25 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function add(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -47,17 +53,21 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[inputs..., ]
+    results = IR.Type[result,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.any", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -81,19 +91,25 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function assuming_all(
+    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[inputs..., ]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.assuming_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -107,18 +123,24 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[witness, ]
-    owned_regions = Region[doRegion, ]
+function assuming(
+    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
+)
+    results = IR.Type[results...,]
+    operands = Value[witness,]
+    owned_regions = Region[doRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.assuming", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -130,18 +152,22 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands_::Vector{Value}; location=Location())
+function assuming_yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.assuming_yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.assuming_yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -168,19 +194,25 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[shapes..., ]
+function broadcast(
+    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-    
-    IR.create_operation(
-        "shape.broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -196,17 +228,21 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[lhs, rhs, ]
+    results = IR.Type[result,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.concat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.concat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -223,19 +259,23 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape), ]
+    attributes = NamedAttribute[namedattribute("shape", shape),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -248,19 +288,23 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -279,19 +323,25 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
+function const_witness(;
+    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing), ]
+    attributes = NamedAttribute[namedattribute("passing", passing),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.const_witness", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.const_witness",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -310,19 +360,25 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cstr_broadcastable(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_broadcastable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_broadcastable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -339,19 +395,25 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function cstr_eq(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -374,19 +436,25 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
+function cstr_require(
+    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
+)
     results = IR.Type[]
-    operands = Value[pred, ]
+    operands = Value[pred,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg), ]
+    attributes = NamedAttribute[namedattribute("msg", msg),]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.cstr_require", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.cstr_require",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -398,17 +466,21 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.debug_print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.debug_print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -422,19 +494,25 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[value, index, ]
+    operands = Value[value, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-    
-    IR.create_operation(
-        "shape.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -455,19 +533,25 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function div(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -478,19 +562,25 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function from_extent_tensor(
+    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.from_extent_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.from_extent_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -507,19 +597,25 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
+function from_extents(
+    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[extents..., ]
+    operands = Value[extents...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-    
-    IR.create_operation(
-        "shape.from_extents", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.from_extents",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -530,21 +626,36 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
+function func(;
+    sym_name,
+    function_type,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    sym_visibility=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "shape.func", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "shape.func",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -567,19 +678,28 @@ shape.function_library {
 }
 ```
 """
-function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
+function function_library(;
+    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
-    
-    IR.create_operation(
-        "shape.function_library", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+
+    return IR.create_operation(
+        "shape.function_library",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -589,19 +709,25 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
+function get_extent(
+    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shape, dim, ]
+    operands = Value[shape, dim]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-    
-    IR.create_operation(
-        "shape.get_extent", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.get_extent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -614,19 +740,25 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function index_to_size(
+    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.index_to_size", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.index_to_size",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -648,19 +780,25 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function is_broadcastable(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.is_broadcastable", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.is_broadcastable",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -672,19 +810,25 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function max(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -715,20 +859,30 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
+function meet(
+    arg0::Value,
+    arg1::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    error=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[arg0, arg1, ]
+    operands = Value[arg0, arg1]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-    
-    IR.create_operation(
-        "shape.meet", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.meet",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -740,19 +894,25 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function min(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -766,19 +926,25 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function mul(
+    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, ]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.mul", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -791,19 +957,25 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function num_elements(
+    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shape, ]
+    operands = Value[shape,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.num_elements", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.num_elements",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -812,19 +984,23 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, ]
+    operands = Value[shape,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-    
-    IR.create_operation(
-        "shape.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -862,18 +1038,28 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
-    results = IR.Type[result..., ]
-    operands = Value[shape, initVals..., ]
-    owned_regions = Region[region, ]
+function reduce(
+    shape::Value,
+    initVals::Vector{Value};
+    result::Vector{IR.Type},
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result...,]
+    operands = Value[shape, initVals...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -884,18 +1070,22 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands_::Vector{Value}; location=Location())
+function return_(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.return", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.return",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -908,19 +1098,25 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shape_eq(
+    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[shapes..., ]
+    operands = Value[shapes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.shape_eq", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.shape_eq",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -930,19 +1126,23 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.shape_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.shape_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -954,19 +1154,25 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function size_to_index(
+    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[arg, ]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.size_to_index", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.size_to_index",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -994,18 +1200,24 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
-    results = IR.Type[head, tail, ]
-    operands = Value[operand, index, ]
+function split_at(
+    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
+)
+    results = IR.Type[head, tail]
+    operands = Value[operand, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.split_at", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.split_at",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1019,17 +1231,21 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[input, ]
+    results = IR.Type[result,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.to_extent_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.to_extent_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1052,17 +1268,21 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arg, ]
+    results = IR.Type[result,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.value_as_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.value_as_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1074,17 +1294,21 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[arg, ]
+    results = IR.Type[result,]
+    operands = Value[arg,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.value_of", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.value_of",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1123,19 +1347,28 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function with_shape(
+    operand::Value,
+    shape::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand, shape, ]
+    operands = Value[operand, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "shape.with_shape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.with_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1143,18 +1376,22 @@ end
 `yield`
 
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "shape.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "shape.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Shape.jl
+++ b/src/Dialects/17/Shape.jl
@@ -1,8 +1,8 @@
 module shape
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `add`
@@ -14,25 +14,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function add(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function add(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.add", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -53,21 +47,17 @@ inputs have differing ranks or differ in extents of shared dimensions.
 ```
 """
 function any(inputs::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.any", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -91,25 +81,19 @@ ready to execute.
 %wt = shape.assuming_all %w0, %w2 // Passing
 ```
 """
-function assuming_all(
-    inputs::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function assuming_all(inputs::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.assuming_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -123,24 +107,18 @@ compiler, information for dependent code to rely on (by assuming), and
 nothing else. They should not exist after a program is fully lowered and
 ready to execute.
 """
-function assuming(
-    witness::Value; results::Vector{IR.Type}, doRegion::Region, location=Location()
-)
-    results = IR.Type[results...,]
-    operands = Value[witness,]
-    owned_regions = Region[doRegion,]
+function assuming(witness::Value; results_::Vector{IR.Type}, doRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[witness, ]
+    owned_regions = Region[doRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -152,22 +130,18 @@ This yield operation represents a return operation within the
 operands and produces no results. The operand number and types must match
 the number and types of parent `shape.assuming` results.
 """
-function assuming_yield(operands::Vector{Value}; location=Location())
+function assuming_yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.assuming_yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.assuming_yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -194,25 +168,19 @@ value. If the result type is an extent tensor (and can therefore not hold
 the error value) the behavior may be undefined. The optional string
 attribute can be used to describe the error case.
 """
-function broadcast(
-    shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[shapes...,]
+function broadcast(shapes::Vector{Value}; result::IR.Type, error=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -228,21 +196,17 @@ concat([], []) -> []
 concat([], [4,5,6]) -> [4,5,6]
 """
 function concat(lhs::Value, rhs::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[lhs, rhs]
+    results = IR.Type[result, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.concat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -259,23 +223,19 @@ rank.
 %2 = shape.const_shape [4, 5, 6] : tensor<3xindex>
 ```
 """
-function const_shape(; result=nothing::Union{Nothing,IR.Type}, shape, location=Location())
+function const_shape(; result=nothing::Union{Nothing, IR.Type}, shape, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shape", shape),]
+    attributes = NamedAttribute[namedattribute("shape", shape), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -288,23 +248,19 @@ Creates a `shape.size` type representing the constant size given by `value`.
 %x = shape.const_size 10
 ```
 """
-function const_size(; result=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_size(; result=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -323,25 +279,19 @@ pass.
 %w2 = shape.assuming_all(%w0, %w2) // Can be folded to \"const_witness true\"
 ```
 """
-function const_witness(;
-    result=nothing::Union{Nothing,IR.Type}, passing, location=Location()
-)
+function const_witness(; result=nothing::Union{Nothing, IR.Type}, passing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("passing", passing),]
+    attributes = NamedAttribute[namedattribute("passing", passing), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.const_witness",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.const_witness", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -360,25 +310,19 @@ shape.broadcast documents.
 %w1 = shape.cstr_broadcastable [2,2], [3,2] // Failure
 ```
 """
-function cstr_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -395,25 +339,19 @@ Given 1 or more input shapes, determine if all shapes are the exact same.
 %w1 = shape.cstr_eq [2,2], [1,2] // Failure
 ```
 """
-function cstr_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function cstr_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -436,25 +374,19 @@ Since this op can be used to express many different possible assertions
 (depending on whatever computation calculated `pred`), the `msg`
 should clarify the nature of the assertion for users.
 """
-function cstr_require(
-    pred::Value; result=nothing::Union{Nothing,IR.Type}, msg, location=Location()
-)
+function cstr_require(pred::Value; result=nothing::Union{Nothing, IR.Type}, msg, location=Location())
     results = IR.Type[]
-    operands = Value[pred,]
+    operands = Value[pred, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("msg", msg),]
+    attributes = NamedAttribute[namedattribute("msg", msg), ]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.cstr_require",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.cstr_require", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -466,21 +398,17 @@ Prints the input dim or shape and passes through input.
 Note: This is intended for testing and debugging only.
 """
 function debug_print(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.debug_print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.debug_print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -494,25 +422,19 @@ return type carries error information else the behavior is undefined.
 This is a convenience op that performs the equivalent of getting the extent
 of a shape (e.g., `dim(x, i) == get_extent(shape_of(x), i)`).
 """
-function dim(
-    value::Value, index::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(value::Value, index::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, index]
+    operands = Value[value, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -533,25 +455,19 @@ toward negative infinity, i.e. floor(lhs / rhs), such that
 always holds. If any of the values is of type `size`, the behavior for
 negative value is undefined.
 """
-function div(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function div(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.div", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -562,25 +478,19 @@ Creates a shape from a 1D integral tensor of extents. The rank of the
 resulting shape equals the number of elements in the tensor, and the
 extents match the values of the elements.
 """
-function from_extent_tensor(
-    input::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extent_tensor(input::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.from_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -597,25 +507,19 @@ the shape.
 %s1 = shape.from_extents
 ```
 """
-function from_extents(
-    extents::Vector{Value}; shape=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function from_extents(extents::Vector{Value}; shape=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[extents...,]
+    operands = Value[extents..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(shape) && push!(results, shape)
-
-    return IR.create_operation(
-        "shape.from_extents",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.from_extents", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -626,36 +530,21 @@ An operation with a name containing a single `SSACFG` region which
 represents a shape transfer function or helper function for shape transfer
 function.
 """
-function func(;
-    sym_name,
-    function_type,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    sym_visibility=nothing,
-    body::Region,
-    location=Location(),
-)
+function func(; sym_name, function_type, arg_attrs=nothing, res_attrs=nothing, sym_visibility=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.func",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.func", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -678,28 +567,19 @@ shape.function_library {
 }
 ```
 """
-function function_library(;
-    sym_name, sym_visibility=nothing, mapping, body::Region, location=Location()
-)
+function function_library(; sym_name, sym_visibility=nothing, mapping, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("mapping", mapping)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
-
-    return IR.create_operation(
-        "shape.function_library",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("mapping", mapping), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    
+    IR.create_operation(
+        "shape.function_library", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -709,25 +589,19 @@ end
 Gets the extent indexed by `dim` from the `shape` operand. If the shape is
 an error then it returns an invalid size.
 """
-function get_extent(
-    shape::Value, dim::Value; extent=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function get_extent(shape::Value, dim::Value; extent=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape, dim]
+    operands = Value[shape, dim, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(extent) && push!(results, extent)
-
-    return IR.create_operation(
-        "shape.get_extent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.get_extent", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -740,25 +614,19 @@ and the shape dialect.
 
 The behavior is undefined for negative indices.
 """
-function index_to_size(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function index_to_size(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.index_to_size",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.index_to_size", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -780,25 +648,19 @@ assertion failure.
 %false = shape.is_broadcastable [2,2], [3,2]
 ```
 """
-function is_broadcastable(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function is_broadcastable(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.is_broadcastable",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.is_broadcastable", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -810,25 +672,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function max(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function max(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -859,30 +715,20 @@ used to return an error to the user upon mismatch of dimensions.
 %c = shape.meet %a, %b, error=\"<reason>\" : !shape.shape, !shape.shape -> !shape.shape
 ```
 """
-function meet(
-    arg0::Value,
-    arg1::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    error=nothing,
-    location=Location(),
-)
+function meet(arg0::Value, arg1::Value; result=nothing::Union{Nothing, IR.Type}, error=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[arg0, arg1]
+    operands = Value[arg0, arg1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(error) && push!(attributes, namedattribute("error", error))
-
-    return IR.create_operation(
-        "shape.meet",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.meet", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,25 +740,19 @@ If either operand is an error, then an error will be propagated to the
 result. If the input types mismatch or the ranks do not match, then the
 result is an error.
 """
-function min(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function min(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -926,25 +766,19 @@ at least one of the operands can hold an error, i.e. if it is of type
 possible because both operands are of type `index` then the result may be
 of type `size` or `index`.
 """
-function mul(
-    lhs::Value, rhs::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function mul(lhs::Value, rhs::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.mul", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -957,25 +791,19 @@ type `size` and potential errors will be propagated. Otherwise, if the
 argument is and extent tensor `tensor<?xindex>` then the result will be of
 type `index`.
 """
-function num_elements(
-    shape::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function num_elements(shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.num_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.num_elements", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -984,23 +812,19 @@ end
 
 Returns the rank of the shape or extent tensor, i.e. the number of extents.
 """
-function rank(shape::Value; rank=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(shape::Value; rank=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shape,]
+    operands = Value[shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(rank) && push!(results, rank)
-
-    return IR.create_operation(
-        "shape.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1038,28 +862,18 @@ func.func @reduce(%shape : !shape.shape, %init : !shape.size) ->
 }
 ```
 """
-function reduce(
-    shape::Value,
-    initVals::Vector{Value};
-    result::Vector{IR.Type},
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result...,]
-    operands = Value[shape, initVals...]
-    owned_regions = Region[region,]
+function reduce(shape::Value, initVals::Vector{Value}; result::Vector{IR.Type}, region::Region, location=Location())
+    results = IR.Type[result..., ]
+    operands = Value[shape, initVals..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1070,22 +884,18 @@ The `shape.return` operation represents a return operation within a
 function.  The operation takes variable number of operands and produces no
 results.
 """
-function return_(operands::Vector{Value}; location=Location())
+function return_(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.return",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.return", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1098,25 +908,19 @@ regarded as their equivalent non-error shapes. Error shapes can be tested
 for equality like any other shape value, meaning that the error value is
 equal to itself.
 """
-function shape_eq(
-    shapes::Vector{Value}; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function shape_eq(shapes::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[shapes...,]
+    operands = Value[shapes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_eq",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_eq", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1126,23 +930,19 @@ end
 The operation takes a value or a shaped operand as an argument and it
 returns a shape or extent tensor.
 """
-function shape_of(arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location())
+function shape_of(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.shape_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.shape_of", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1154,25 +954,19 @@ inverse, `index_to_size`, facilitate index conversion between the standard
 and the shape dialect. The behavior is undefined for unknown and invalid
 arguments.
 """
-function size_to_index(
-    arg::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function size_to_index(arg::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[arg,]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.size_to_index",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.size_to_index", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1200,24 +994,18 @@ Examples:
 Requires:
 - `index` is in the range [-rank(operand),rank(operand)]
 """
-function split_at(
-    operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location()
-)
-    results = IR.Type[head, tail]
-    operands = Value[operand, index]
+function split_at(operand::Value, index::Value; head::IR.Type, tail::IR.Type, location=Location())
+    results = IR.Type[head, tail, ]
+    operands = Value[operand, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.split_at",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.split_at", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1231,21 +1019,17 @@ extents of the shape.
 If the shape represents an error, this op\'s behavior is undefined.
 """
 function to_extent_tensor(input::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[input,]
+    results = IR.Type[result, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.to_extent_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.to_extent_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1268,21 +1052,17 @@ E.g.,
 This operation is the complement of `shape_of` wrt ValueShape values.
 """
 function value_as_shape(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_as_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_as_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1294,21 +1074,17 @@ argument, and returns its value. The behavior is undefined for unknown and
 invalid arguments.
 """
 function value_of(arg::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[arg,]
+    results = IR.Type[result, ]
+    operands = Value[arg, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.value_of",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.value_of", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1347,28 +1123,19 @@ the result may be less specified than `operand`\'s shape as `shape` is
 merely used to construct the new ValueShape. If join behavior is desired
 then a join op should be used.
 """
-function with_shape(
-    operand::Value,
-    shape::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function with_shape(operand::Value, shape::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[operand, shape]
+    operands = Value[operand, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "shape.with_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.with_shape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1376,22 +1143,18 @@ end
 `yield`
 
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "shape.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "shape.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/SparseTensor.jl
+++ b/src/Dialects/17/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `binary`
@@ -110,20 +110,36 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[x, y, ]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
+function binary(
+    x::Value,
+    y::Value;
+    output::IR.Type,
+    left_identity=nothing,
+    right_identity=nothing,
+    overlapRegion::Region,
+    leftRegion::Region,
+    rightRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[x, y]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
-    
-    IR.create_operation(
-        "sparse_tensor.binary", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(left_identity) &&
+        push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) &&
+        push!(attributes, namedattribute("right_identity", right_identity))
+
+    return IR.create_operation(
+        "sparse_tensor.binary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -151,19 +167,32 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, lvlCoords::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function compress(
+    values::Value,
+    filled::Value,
+    added::Value,
+    count::Value,
+    tensor::Value,
+    lvlCoords::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, lvlCoords..., ]
+    operands = Value[values, filled, added, count, tensor, lvlCoords...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "sparse_tensor.compress", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -187,17 +216,21 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[inputs..., ]
+    results = IR.Type[result,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
-    
-    IR.create_operation(
-        "sparse_tensor.concatenate", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension),]
+
+    return IR.create_operation(
+        "sparse_tensor.concatenate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -241,17 +274,21 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.convert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.convert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -289,18 +326,29 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
-    results = IR.Type[values, filled, added, count, ]
-    operands = Value[tensor, ]
+function expand(
+    tensor::Value;
+    values::IR.Type,
+    filled::IR.Type,
+    added::IR.Type,
+    count::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[values, filled, added, count]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.expand", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.expand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -378,19 +426,30 @@ sparse_tensor.foreach in %0 {order=affine_map<(i,j)->(j,i)>}: tensor<2x3xf64> do
 
 ```
 """
-function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, order=nothing, region::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[tensor, initArgs..., ]
-    owned_regions = Region[region, ]
+function foreach(
+    tensor::Value,
+    initArgs::Vector{Value};
+    results::Vector{IR.Type},
+    order=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[tensor, initArgs...]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(order) && push!(attributes, namedattribute("order", order))
-    
-    IR.create_operation(
-        "sparse_tensor.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -406,20 +465,30 @@ Example of querying the size of the coordinates array for level 0:
      : !sparse_tensor.storage_specifier<#COO>
 ```
 """
-function storage_specifier_get(specifier::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, level=nothing, location=Location())
+function storage_specifier_get(
+    specifier::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    specifierKind,
+    level=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[specifier, ]
+    operands = Value[specifier,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
     !isnothing(result) && push!(results, result)
     !isnothing(level) && push!(attributes, namedattribute("level", level))
-    
-    IR.create_operation(
-        "sparse_tensor.storage_specifier.get", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.storage_specifier.get",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -452,19 +521,29 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(value::Value, tensor::Value, lvlCoords::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function insert(
+    value::Value,
+    tensor::Value,
+    lvlCoords::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[value, tensor, lvlCoords..., ]
+    operands = Value[value, tensor, lvlCoords...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "sparse_tensor.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -496,20 +575,29 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
+function load(
+    tensor::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    hasInserts=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-    
-    IR.create_operation(
-        "sparse_tensor.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -536,17 +624,21 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.new", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.new",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -564,19 +656,25 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function number_of_entries(
+    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "sparse_tensor.number_of_entries", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.number_of_entries",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -601,16 +699,20 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest, ]
+    operands = Value[tensor, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.out", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.out",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -652,17 +754,21 @@ does not yet support them.
 ```
 """
 function pack(values::Value, levels::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[values, levels..., ]
+    results = IR.Type[result,]
+    operands = Value[values, levels...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.pack", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.pack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -710,9 +816,18 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
+function push_back(
+    curSize::Value,
+    inBuffer::Value,
+    value::Value,
+    n=nothing::Union{Nothing,Value};
+    outBuffer=nothing::Union{Nothing,IR.Type},
+    newSize=nothing::Union{Nothing,IR.Type},
+    inbounds=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value, ]
+    operands = Value[curSize, inBuffer, value]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -720,12 +835,16 @@ function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Uni
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-    
-    IR.create_operation(
-        "sparse_tensor.push_back", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.push_back",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -771,19 +890,30 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
+function reduce(
+    x::Value,
+    y::Value,
+    identity::Value;
+    output=nothing::Union{Nothing,IR.Type},
+    region::Region,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[x, y, identity, ]
-    owned_regions = Region[region, ]
+    operands = Value[x, y, identity]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "sparse_tensor.reduce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.reduce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -837,19 +967,25 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
+function select(
+    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
+)
     results = IR.Type[]
-    operands = Value[x, ]
-    owned_regions = Region[region, ]
+    operands = Value[x,]
+    owned_regions = Region[region,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "sparse_tensor.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -866,20 +1002,31 @@ Example of updating the sizes of the coordinates array for level 0:
    : !sparse_tensor.storage_specifier<#COO>
 ```
 """
-function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, level=nothing, location=Location())
+function storage_specifier_set(
+    specifier::Value,
+    value::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    specifierKind,
+    level=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[specifier, value, ]
+    operands = Value[specifier, value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
     !isnothing(result) && push!(results, result)
     !isnothing(level) && push!(attributes, namedattribute("level", level))
-    
-    IR.create_operation(
-        "sparse_tensor.storage_specifier.set", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.storage_specifier.set",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -911,20 +1058,32 @@ sparse_tensor.sort hybrid_quick_sort %n, %xy jointly %y1
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, algorithm, location=Location())
+function sort_coo(
+    n::Value,
+    xy::Value,
+    ys::Vector{Value};
+    nx=nothing,
+    ny=nothing,
+    algorithm,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[n, xy, ys..., ]
+    operands = Value[n, xy, ys...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("algorithm", algorithm), ]
+    attributes = NamedAttribute[namedattribute("algorithm", algorithm),]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
-    
-    IR.create_operation(
-        "sparse_tensor.sort_coo", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.sort_coo",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -969,19 +1128,25 @@ sparse_tensor.sort hybrid_quick_sort %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; algorithm, location=Location())
+function sort(
+    n::Value, xs::Vector{Value}, ys::Vector{Value}; algorithm, location=Location()
+)
     results = IR.Type[]
-    operands = Value[n, xs..., ys..., ]
+    operands = Value[n, xs..., ys...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("algorithm", algorithm), ]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
-    
-    IR.create_operation(
-        "sparse_tensor.sort", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("algorithm", algorithm),]
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
+
+    return IR.create_operation(
+        "sparse_tensor.sort",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1012,19 +1177,25 @@ is subject to change in the future.
        !sparse_tensor.storage_specifier<#CSR_SLICE>
 ```
 """
-function storage_specifier_init(source=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
+function storage_specifier_init(
+    source=nothing::Union{Nothing,Value}; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(source) && push!(operands, source)
-    
-    IR.create_operation(
-        "sparse_tensor.storage_specifier.init", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.storage_specifier.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1054,17 +1225,21 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function coordinates_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.coordinates_buffer", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.coordinates_buffer",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1089,17 +1264,21 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function coordinates(tensor::Value; result::IR.Type, level, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("level", level), ]
-    
-    IR.create_operation(
-        "sparse_tensor.coordinates", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("level", level),]
+
+    return IR.create_operation(
+        "sparse_tensor.coordinates",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1124,17 +1303,21 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function positions(tensor::Value; result::IR.Type, level, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("level", level), ]
-    
-    IR.create_operation(
-        "sparse_tensor.positions", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("level", level),]
+
+    return IR.create_operation(
+        "sparse_tensor.positions",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1159,19 +1342,25 @@ with `enable-runtime-library=false`).
 // %2 = %v2
 ```
 """
-function slice_offset(slice::Value; offset=nothing::Union{Nothing, IR.Type}, dim, location=Location())
+function slice_offset(
+    slice::Value; offset=nothing::Union{Nothing,IR.Type}, dim, location=Location()
+)
     results = IR.Type[]
-    operands = Value[slice, ]
+    operands = Value[slice,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim), ]
+    attributes = NamedAttribute[namedattribute("dim", dim),]
     !isnothing(offset) && push!(results, offset)
-    
-    IR.create_operation(
-        "sparse_tensor.slice.offset", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.slice.offset",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1197,19 +1386,25 @@ with `enable-runtime-library=false`).
 
 ```
 """
-function slice_stride(slice::Value; stride=nothing::Union{Nothing, IR.Type}, dim, location=Location())
+function slice_stride(
+    slice::Value; stride=nothing::Union{Nothing,IR.Type}, dim, location=Location()
+)
     results = IR.Type[]
-    operands = Value[slice, ]
+    operands = Value[slice,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim), ]
+    attributes = NamedAttribute[namedattribute("dim", dim),]
     !isnothing(stride) && push!(results, stride)
-    
-    IR.create_operation(
-        "sparse_tensor.slice.stride", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.slice.stride",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1233,17 +1428,21 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, ]
+    results = IR.Type[result,]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.values", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.values",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1331,18 +1530,28 @@ the output, while missing values are filled with 1):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[x, ]
-    owned_regions = Region[presentRegion, absentRegion, ]
+function unary(
+    x::Value;
+    output::IR.Type,
+    presentRegion::Region,
+    absentRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[x,]
+    owned_regions = Region[presentRegion, absentRegion]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.unary", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.unary",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1378,18 +1587,31 @@ TODO: the current implementation does not yet support non-identity mappings.
 // %c_len = 6 (3x2)
 ```
 """
-function unpack(tensor::Value, out_values::Value, out_levels::Vector{Value}; ret_values::IR.Type, ret_levels::Vector{IR.Type}, val_len::IR.Type, lvl_lens::Vector{IR.Type}, location=Location())
-    results = IR.Type[ret_values, ret_levels..., val_len, lvl_lens..., ]
-    operands = Value[tensor, out_values, out_levels..., ]
+function unpack(
+    tensor::Value,
+    out_values::Value,
+    out_levels::Vector{Value};
+    ret_values::IR.Type,
+    ret_levels::Vector{IR.Type},
+    val_len::IR.Type,
+    lvl_lens::Vector{IR.Type},
+    location=Location(),
+)
+    results = IR.Type[ret_values, ret_levels..., val_len, lvl_lens...]
+    operands = Value[tensor, out_values, out_levels...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "sparse_tensor.unpack", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.unpack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1412,19 +1634,23 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing, Value}; location=Location())
+function yield(result=nothing::Union{Nothing,Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-    
-    IR.create_operation(
-        "sparse_tensor.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "sparse_tensor.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/SparseTensor.jl
+++ b/src/Dialects/17/SparseTensor.jl
@@ -1,9 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `binary`
@@ -111,36 +110,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,32 +151,19 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value,
-    tensor::Value,
-    lvlCoords::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, lvlCoords::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, lvlCoords...]
+    operands = Value[values, filled, added, count, tensor, lvlCoords..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -217,21 +187,17 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.concatenate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.concatenate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -275,21 +241,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -327,29 +289,18 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -427,30 +378,19 @@ sparse_tensor.foreach in %0 {order=affine_map<(i,j)->(j,i)>}: tensor<2x3xf64> do
 
 ```
 """
-function foreach(
-    tensor::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    order=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tensor, initArgs...]
-    owned_regions = Region[region,]
+function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, order=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tensor, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(order) && push!(attributes, namedattribute("order", order))
-
-    return IR.create_operation(
-        "sparse_tensor.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -466,30 +406,20 @@ Example of querying the size of the coordinates array for level 0:
      : !sparse_tensor.storage_specifier<#COO>
 ```
 """
-function storage_specifier_get(
-    specifier::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    level=nothing,
-    location=Location(),
-)
+function storage_specifier_get(specifier::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, level=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier,]
+    operands = Value[specifier, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(level) && push!(attributes, namedattribute("level", level))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.get",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.get", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -522,29 +452,19 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(
-    value::Value,
-    tensor::Value,
-    lvlCoords::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert(value::Value, tensor::Value, lvlCoords::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, tensor, lvlCoords...]
+    operands = Value[value, tensor, lvlCoords..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -576,29 +496,20 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -625,21 +536,17 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -657,25 +564,19 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(
-    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.number_of_entries",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.number_of_entries", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -700,20 +601,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,21 +652,17 @@ does not yet support them.
 ```
 """
 function pack(values::Value, levels::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[values, levels...]
+    results = IR.Type[result, ]
+    operands = Value[values, levels..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -817,18 +710,9 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(
-    curSize::Value,
-    inBuffer::Value,
-    value::Value,
-    n=nothing::Union{Nothing,Value};
-    outBuffer=nothing::Union{Nothing,IR.Type},
-    newSize=nothing::Union{Nothing,IR.Type},
-    inbounds=nothing,
-    location=Location(),
-)
+function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value]
+    operands = Value[curSize, inBuffer, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -836,16 +720,12 @@ function push_back(
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "sparse_tensor.push_back",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.push_back", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -891,30 +771,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -968,25 +837,19 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(
-    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
-)
+function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1003,31 +866,20 @@ Example of updating the sizes of the coordinates array for level 0:
    : !sparse_tensor.storage_specifier<#COO>
 ```
 """
-function storage_specifier_set(
-    specifier::Value,
-    value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    level=nothing,
-    location=Location(),
-)
+function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, level=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier, value]
+    operands = Value[specifier, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(level) && push!(attributes, namedattribute("level", level))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.set",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.set", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1059,32 +911,20 @@ sparse_tensor.sort hybrid_quick_sort %n, %xy jointly %y1
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(
-    n::Value,
-    xy::Value,
-    ys::Vector{Value};
-    nx=nothing,
-    ny=nothing,
-    algorithm,
-    location=Location(),
-)
+function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, algorithm, location=Location())
     results = IR.Type[]
-    operands = Value[n, xy, ys...]
+    operands = Value[n, xy, ys..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("algorithm", algorithm),]
+    attributes = NamedAttribute[namedattribute("algorithm", algorithm), ]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
-
-    return IR.create_operation(
-        "sparse_tensor.sort_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1129,25 +969,19 @@ sparse_tensor.sort hybrid_quick_sort %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(
-    n::Value, xs::Vector{Value}, ys::Vector{Value}; algorithm, location=Location()
-)
+function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; algorithm, location=Location())
     results = IR.Type[]
-    operands = Value[n, xs..., ys...]
+    operands = Value[n, xs..., ys..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("algorithm", algorithm),]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
-
-    return IR.create_operation(
-        "sparse_tensor.sort",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("algorithm", algorithm), ]
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
+    
+    IR.create_operation(
+        "sparse_tensor.sort", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1178,25 +1012,19 @@ is subject to change in the future.
        !sparse_tensor.storage_specifier<#CSR_SLICE>
 ```
 """
-function storage_specifier_init(
-    source=nothing::Union{Nothing,Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
+function storage_specifier_init(source=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(source) && push!(operands, source)
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1226,21 +1054,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function coordinates_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.coordinates_buffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.coordinates_buffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1265,21 +1089,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function coordinates(tensor::Value; result::IR.Type, level, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("level", level),]
-
-    return IR.create_operation(
-        "sparse_tensor.coordinates",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("level", level), ]
+    
+    IR.create_operation(
+        "sparse_tensor.coordinates", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1304,21 +1124,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function positions(tensor::Value; result::IR.Type, level, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("level", level),]
-
-    return IR.create_operation(
-        "sparse_tensor.positions",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("level", level), ]
+    
+    IR.create_operation(
+        "sparse_tensor.positions", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1343,25 +1159,19 @@ with `enable-runtime-library=false`).
 // %2 = %v2
 ```
 """
-function slice_offset(
-    slice::Value; offset=nothing::Union{Nothing,IR.Type}, dim, location=Location()
-)
+function slice_offset(slice::Value; offset=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
-    operands = Value[slice,]
+    operands = Value[slice, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(offset) && push!(results, offset)
-
-    return IR.create_operation(
-        "sparse_tensor.slice.offset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.slice.offset", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1387,25 +1197,19 @@ with `enable-runtime-library=false`).
 
 ```
 """
-function slice_stride(
-    slice::Value; stride=nothing::Union{Nothing,IR.Type}, dim, location=Location()
-)
+function slice_stride(slice::Value; stride=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
-    operands = Value[slice,]
+    operands = Value[slice, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(stride) && push!(results, stride)
-
-    return IR.create_operation(
-        "sparse_tensor.slice.stride",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.slice.stride", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1429,21 +1233,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1531,28 +1331,18 @@ the output, while missing values are filled with 1):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1588,31 +1378,18 @@ TODO: the current implementation does not yet support non-identity mappings.
 // %c_len = 6 (3x2)
 ```
 """
-function unpack(
-    tensor::Value,
-    out_values::Value,
-    out_levels::Vector{Value};
-    ret_values::IR.Type,
-    ret_levels::Vector{IR.Type},
-    val_len::IR.Type,
-    lvl_lens::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[ret_values, ret_levels..., val_len, lvl_lens...]
-    operands = Value[tensor, out_values, out_levels...]
+function unpack(tensor::Value, out_values::Value, out_levels::Vector{Value}; ret_values::IR.Type, ret_levels::Vector{IR.Type}, val_len::IR.Type, lvl_lens::Vector{IR.Type}, location=Location())
+    results = IR.Type[ret_values, ret_levels..., val_len, lvl_lens..., ]
+    operands = Value[tensor, out_values, out_levels..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1635,23 +1412,19 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing,Value}; location=Location())
+function yield(result=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/SparseTensor.jl
+++ b/src/Dialects/17/SparseTensor.jl
@@ -1,8 +1,8 @@
 module sparse_tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `binary`
@@ -110,36 +110,20 @@ because we never use its values, only its sparse structure:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function binary(
-    x::Value,
-    y::Value;
-    output::IR.Type,
-    left_identity=nothing,
-    right_identity=nothing,
-    overlapRegion::Region,
-    leftRegion::Region,
-    rightRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x, y]
-    owned_regions = Region[overlapRegion, leftRegion, rightRegion]
+function binary(x::Value, y::Value; output::IR.Type, left_identity=nothing, right_identity=nothing, overlapRegion::Region, leftRegion::Region, rightRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, y, ]
+    owned_regions = Region[overlapRegion, leftRegion, rightRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(left_identity) &&
-        push!(attributes, namedattribute("left_identity", left_identity))
-    !isnothing(right_identity) &&
-        push!(attributes, namedattribute("right_identity", right_identity))
-
-    return IR.create_operation(
-        "sparse_tensor.binary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(left_identity) && push!(attributes, namedattribute("left_identity", left_identity))
+    !isnothing(right_identity) && push!(attributes, namedattribute("right_identity", right_identity))
+    
+    IR.create_operation(
+        "sparse_tensor.binary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,32 +151,19 @@ done \"in place\", and referencing the old SSA value is undefined behavior.
   : memref<?xf64>, memref<?xi1>, memref<?xindex>, tensor<4x4xf64, #CSR>
 ```
 """
-function compress(
-    values::Value,
-    filled::Value,
-    added::Value,
-    count::Value,
-    tensor::Value,
-    lvlCoords::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function compress(values::Value, filled::Value, added::Value, count::Value, tensor::Value, lvlCoords::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[values, filled, added, count, tensor, lvlCoords...]
+    operands = Value[values, filled, added, count, tensor, lvlCoords..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -216,21 +187,17 @@ can be dynamically-sized.
 ```
 """
 function concatenate(inputs::Vector{Value}; result::IR.Type, dimension, location=Location())
-    results = IR.Type[result,]
-    operands = Value[inputs...,]
+    results = IR.Type[result, ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension),]
-
-    return IR.create_operation(
-        "sparse_tensor.concatenate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("dimension", dimension), ]
+    
+    IR.create_operation(
+        "sparse_tensor.concatenate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -274,21 +241,17 @@ Examples:
 ```
 """
 function convert(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.convert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.convert", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -326,29 +289,18 @@ side-effecting context that sets and resets the expanded arrays.
   : tensor<4x4xf64, #CSR> to memref<?xf64>, memref<?xi1>, memref<?xindex>
 ```
 """
-function expand(
-    tensor::Value;
-    values::IR.Type,
-    filled::IR.Type,
-    added::IR.Type,
-    count::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[values, filled, added, count]
-    operands = Value[tensor,]
+function expand(tensor::Value; values::IR.Type, filled::IR.Type, added::IR.Type, count::IR.Type, location=Location())
+    results = IR.Type[values, filled, added, count, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.expand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.expand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -426,30 +378,19 @@ sparse_tensor.foreach in %0 {order=affine_map<(i,j)->(j,i)>}: tensor<2x3xf64> do
 
 ```
 """
-function foreach(
-    tensor::Value,
-    initArgs::Vector{Value};
-    results::Vector{IR.Type},
-    order=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[tensor, initArgs...]
-    owned_regions = Region[region,]
+function foreach(tensor::Value, initArgs::Vector{Value}; results_::Vector{IR.Type}, order=nothing, region::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[tensor, initArgs..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(order) && push!(attributes, namedattribute("order", order))
-
-    return IR.create_operation(
-        "sparse_tensor.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -465,30 +406,20 @@ Example of querying the size of the coordinates array for level 0:
      : !sparse_tensor.storage_specifier<#COO>
 ```
 """
-function storage_specifier_get(
-    specifier::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    level=nothing,
-    location=Location(),
-)
+function storage_specifier_get(specifier::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, level=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier,]
+    operands = Value[specifier, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(level) && push!(attributes, namedattribute("level", level))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.get",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.get", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -521,29 +452,19 @@ This operation is scheduled to be unified with the dense counterpart
 %result = sparse_tensor.insert %val into %tensor[%i,%j] : tensor<1024x1024xf64, #CSR>
 ```
 """
-function insert(
-    value::Value,
-    tensor::Value,
-    lvlCoords::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insert(value::Value, tensor::Value, lvlCoords::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[value, tensor, lvlCoords...]
+    operands = Value[value, tensor, lvlCoords..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -575,29 +496,20 @@ Examples:
 %1 = sparse_tensor.load %0 hasInserts : tensor<16x32xf32, #CSR>
 ```
 """
-function load(
-    tensor::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    hasInserts=nothing,
-    location=Location(),
-)
+function load(tensor::Value; result=nothing::Union{Nothing, IR.Type}, hasInserts=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(hasInserts) && push!(attributes, namedattribute("hasInserts", hasInserts))
-
-    return IR.create_operation(
-        "sparse_tensor.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.load", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -624,21 +536,17 @@ sparse_tensor.new %source : !Source to tensor<1024x1024xf64, #CSR>
 ```
 """
 function new(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.new",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.new", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -656,25 +564,19 @@ accurate nomenclature is used.
 %noe = sparse_tensor.number_of_entries %tensor : tensor<64x64xf64, #CSR>
 ```
 """
-function number_of_entries(
-    tensor::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function number_of_entries(tensor::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "sparse_tensor.number_of_entries",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.number_of_entries", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -699,20 +601,16 @@ sparse_tensor.out %t, %dest : tensor<1024x1024xf64, #CSR>, !Dest
 """
 function out(tensor::Value, dest::Value; location=Location())
     results = IR.Type[]
-    operands = Value[tensor, dest]
+    operands = Value[tensor, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.out",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.out", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -754,21 +652,17 @@ does not yet support them.
 ```
 """
 function pack(values::Value, levels::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[values, levels...]
+    results = IR.Type[result, ]
+    operands = Value[values, levels..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -816,18 +710,9 @@ through the old SSA value after this operation is undefined behavior.
    : xindex, memref<?xf64>, f64
 ```
 """
-function push_back(
-    curSize::Value,
-    inBuffer::Value,
-    value::Value,
-    n=nothing::Union{Nothing,Value};
-    outBuffer=nothing::Union{Nothing,IR.Type},
-    newSize=nothing::Union{Nothing,IR.Type},
-    inbounds=nothing,
-    location=Location(),
-)
+function push_back(curSize::Value, inBuffer::Value, value::Value, n=nothing::Union{Nothing, Value}; outBuffer=nothing::Union{Nothing, IR.Type}, newSize=nothing::Union{Nothing, IR.Type}, inbounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[curSize, inBuffer, value]
+    operands = Value[curSize, inBuffer, value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
@@ -835,16 +720,12 @@ function push_back(
     !isnothing(outBuffer) && push!(results, outBuffer)
     !isnothing(newSize) && push!(results, newSize)
     !isnothing(inbounds) && push!(attributes, namedattribute("inbounds", inbounds))
-
-    return IR.create_operation(
-        "sparse_tensor.push_back",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.push_back", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -890,30 +771,19 @@ Example of Matrix->Vector reduction using max(product(x_i), 100):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function reduce(
-    x::Value,
-    y::Value,
-    identity::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    region::Region,
-    location=Location(),
-)
+function reduce(x::Value, y::Value, identity::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x, y, identity]
-    owned_regions = Region[region,]
+    operands = Value[x, y, identity, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.reduce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.reduce", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -967,25 +837,19 @@ Example of selecting lower triangle of a matrix:
 } -> tensor<?x?xf64, #CSR>
 ```
 """
-function select(
-    x::Value; output=nothing::Union{Nothing,IR.Type}, region::Region, location=Location()
-)
+function select(x::Value; output=nothing::Union{Nothing, IR.Type}, region::Region, location=Location())
     results = IR.Type[]
-    operands = Value[x,]
-    owned_regions = Region[region,]
+    operands = Value[x, ]
+    owned_regions = Region[region, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "sparse_tensor.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.select", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1002,31 +866,20 @@ Example of updating the sizes of the coordinates array for level 0:
    : !sparse_tensor.storage_specifier<#COO>
 ```
 """
-function storage_specifier_set(
-    specifier::Value,
-    value::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    specifierKind,
-    level=nothing,
-    location=Location(),
-)
+function storage_specifier_set(specifier::Value, value::Value; result=nothing::Union{Nothing, IR.Type}, specifierKind, level=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[specifier, value]
+    operands = Value[specifier, value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind),]
+    attributes = NamedAttribute[namedattribute("specifierKind", specifierKind), ]
     !isnothing(result) && push!(results, result)
     !isnothing(level) && push!(attributes, namedattribute("level", level))
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.set",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.set", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1058,32 +911,20 @@ sparse_tensor.sort hybrid_quick_sort %n, %xy jointly %y1
   : memref<?xi64> jointly memref<?xf32>
 ```
 """
-function sort_coo(
-    n::Value,
-    xy::Value,
-    ys::Vector{Value};
-    nx=nothing,
-    ny=nothing,
-    algorithm,
-    location=Location(),
-)
+function sort_coo(n::Value, xy::Value, ys::Vector{Value}; nx=nothing, ny=nothing, algorithm, location=Location())
     results = IR.Type[]
-    operands = Value[n, xy, ys...]
+    operands = Value[n, xy, ys..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("algorithm", algorithm),]
+    attributes = NamedAttribute[namedattribute("algorithm", algorithm), ]
     !isnothing(nx) && push!(attributes, namedattribute("nx", nx))
     !isnothing(ny) && push!(attributes, namedattribute("ny", ny))
-
-    return IR.create_operation(
-        "sparse_tensor.sort_coo",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.sort_coo", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1128,25 +969,19 @@ sparse_tensor.sort hybrid_quick_sort %n, %x1, %x2 jointly y1, %y2
   : memref<?xindex>, memref<?xindex> jointly memref<?xindex>, memref<?xf32>
 ```
 """
-function sort(
-    n::Value, xs::Vector{Value}, ys::Vector{Value}; algorithm, location=Location()
-)
+function sort(n::Value, xs::Vector{Value}, ys::Vector{Value}; algorithm, location=Location())
     results = IR.Type[]
-    operands = Value[n, xs..., ys...]
+    operands = Value[n, xs..., ys..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("algorithm", algorithm),]
-    push!(attributes, operandsegmentsizes([1, length(xs), length(ys)]))
-
-    return IR.create_operation(
-        "sparse_tensor.sort",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("algorithm", algorithm), ]
+    push!(attributes, operandsegmentsizes([1, length(xs), length(ys), ]))
+    
+    IR.create_operation(
+        "sparse_tensor.sort", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1177,25 +1012,19 @@ is subject to change in the future.
        !sparse_tensor.storage_specifier<#CSR_SLICE>
 ```
 """
-function storage_specifier_init(
-    source=nothing::Union{Nothing,Value}; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
+function storage_specifier_init(source=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(source) && push!(operands, source)
-
-    return IR.create_operation(
-        "sparse_tensor.storage_specifier.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.storage_specifier.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1225,21 +1054,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function coordinates_buffer(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.coordinates_buffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.coordinates_buffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1264,21 +1089,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function coordinates(tensor::Value; result::IR.Type, level, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("level", level),]
-
-    return IR.create_operation(
-        "sparse_tensor.coordinates",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("level", level), ]
+    
+    IR.create_operation(
+        "sparse_tensor.coordinates", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1303,21 +1124,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function positions(tensor::Value; result::IR.Type, level, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("level", level),]
-
-    return IR.create_operation(
-        "sparse_tensor.positions",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("level", level), ]
+    
+    IR.create_operation(
+        "sparse_tensor.positions", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1342,25 +1159,19 @@ with `enable-runtime-library=false`).
 // %2 = %v2
 ```
 """
-function slice_offset(
-    slice::Value; offset=nothing::Union{Nothing,IR.Type}, dim, location=Location()
-)
+function slice_offset(slice::Value; offset=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
-    operands = Value[slice,]
+    operands = Value[slice, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(offset) && push!(results, offset)
-
-    return IR.create_operation(
-        "sparse_tensor.slice.offset",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.slice.offset", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1386,25 +1197,19 @@ with `enable-runtime-library=false`).
 
 ```
 """
-function slice_stride(
-    slice::Value; stride=nothing::Union{Nothing,IR.Type}, dim, location=Location()
-)
+function slice_stride(slice::Value; stride=nothing::Union{Nothing, IR.Type}, dim, location=Location())
     results = IR.Type[]
-    operands = Value[slice,]
+    operands = Value[slice, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dim", dim),]
+    attributes = NamedAttribute[namedattribute("dim", dim), ]
     !isnothing(stride) && push!(results, stride)
-
-    return IR.create_operation(
-        "sparse_tensor.slice.stride",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.slice.stride", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1428,21 +1233,17 @@ Writing into the result of this operation is undefined behavior.
 ```
 """
 function values(tensor::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[tensor,]
+    results = IR.Type[result, ]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.values",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.values", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1530,28 +1331,18 @@ the output, while missing values are filled with 1):
 } -> tensor<?xf64, #SparseVector>
 ```
 """
-function unary(
-    x::Value;
-    output::IR.Type,
-    presentRegion::Region,
-    absentRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[x,]
-    owned_regions = Region[presentRegion, absentRegion]
+function unary(x::Value; output::IR.Type, presentRegion::Region, absentRegion::Region, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[x, ]
+    owned_regions = Region[presentRegion, absentRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unary",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unary", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1587,31 +1378,18 @@ TODO: the current implementation does not yet support non-identity mappings.
 // %c_len = 6 (3x2)
 ```
 """
-function unpack(
-    tensor::Value,
-    out_values::Value,
-    out_levels::Vector{Value};
-    ret_values::IR.Type,
-    ret_levels::Vector{IR.Type},
-    val_len::IR.Type,
-    lvl_lens::Vector{IR.Type},
-    location=Location(),
-)
-    results = IR.Type[ret_values, ret_levels..., val_len, lvl_lens...]
-    operands = Value[tensor, out_values, out_levels...]
+function unpack(tensor::Value, out_values::Value, out_levels::Vector{Value}; ret_values::IR.Type, ret_levels::Vector{IR.Type}, val_len::IR.Type, lvl_lens::Vector{IR.Type}, location=Location())
+    results = IR.Type[ret_values, ret_levels..., val_len, lvl_lens..., ]
+    operands = Value[tensor, out_values, out_levels..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "sparse_tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1634,23 +1412,19 @@ Yields a value from within a `binary`, `unary`, `reduce`,
 }
 ```
 """
-function yield(result=nothing::Union{Nothing,Value}; location=Location())
+function yield(result=nothing::Union{Nothing, Value}; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(operands, result)
-
-    return IR.create_operation(
-        "sparse_tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "sparse_tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Tensor.jl
+++ b/src/Dialects/17/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `bitcast`
@@ -19,21 +19,17 @@ should match.
 ```
 """
 function bitcast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -61,21 +57,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -105,21 +97,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,25 +136,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,21 +169,17 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[dynamicSizes...,]
+    results = IR.Type[result, ]
+    operands = Value[dynamicSizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -231,21 +209,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -264,28 +238,18 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -349,40 +313,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -405,21 +348,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -520,30 +459,19 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(
-    source::Value,
-    indices::Value;
-    result::IR.Type,
-    gather_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, indices]
+function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -569,24 +497,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -609,29 +531,18 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(
-    scalar::Value,
-    dest::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -689,42 +600,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -767,43 +655,21 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(
-    source::Value,
-    dest::Value,
-    padding_value=nothing::Union{Nothing,Value};
-    inner_tiles::Vector{Value},
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
-    )
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    push!(attributes, operandsegmentsizes([1, 1, (padding_value==nothing) ? 0 : 1length(inner_tiles), ]))
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.pack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -879,36 +745,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -972,40 +822,19 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1021,23 +850,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1076,21 +901,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1194,31 +1015,19 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(
-    source::Value,
-    dest::Value,
-    indices::Value;
-    result::IR.Type,
-    scatter_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, indices]
+function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1248,21 +1057,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1290,37 +1095,19 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(
-    source::Value,
-    dest::Value,
-    inner_tiles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1333,20 +1120,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Tensor.jl
+++ b/src/Dialects/17/Tensor.jl
@@ -1,8 +1,8 @@
 module tensor
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `bitcast`
@@ -19,17 +19,21 @@ should match.
 ```
 """
 function bitcast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -57,17 +61,21 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[source, ]
+    results = IR.Type[dest,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -97,17 +105,21 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "tensor.collapse_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "tensor.collapse_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -136,19 +148,25 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function dim(
+    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[source, index, ]
+    operands = Value[source, index]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "tensor.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -169,17 +187,21 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamicSizes..., ]
+    results = IR.Type[result,]
+    operands = Value[dynamicSizes...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.empty", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.empty",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -209,17 +231,21 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[src, ]
+    results = IR.Type[result,]
+    operands = Value[src,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
-    
-    IR.create_operation(
-        "tensor.expand_shape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
+
+    return IR.create_operation(
+        "tensor.expand_shape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -238,18 +264,28 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[tensor, indices..., ]
+function extract(
+    tensor::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[tensor, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.extract", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "tensor.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -313,19 +349,40 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, offsets..., sizes..., strides..., ]
+function extract_slice(
+    source::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result::IR.Type,
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.extract_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.extract_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -348,17 +405,21 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[elements..., ]
+    results = IR.Type[result,]
+    operands = Value[elements...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.from_elements", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.from_elements",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -459,19 +520,30 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, indices, ]
+function gather(
+    source::Value,
+    indices::Value;
+    result::IR.Type,
+    gather_dims,
+    unique=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, indices]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-    
-    IR.create_operation(
-        "tensor.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -497,18 +569,24 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[dynamicExtents..., ]
-    owned_regions = Region[body, ]
+function generate(
+    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[dynamicExtents...,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.generate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.generate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -531,18 +609,29 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[scalar, dest, indices..., ]
+function insert(
+    scalar::Value,
+    dest::Value,
+    indices::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[scalar, dest, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.insert", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "tensor.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -600,19 +689,42 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, offsets..., sizes..., strides..., ]
+function insert_slice(
+    source::Value,
+    dest::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[source, dest, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.insert_slice", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
+    )
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "tensor.insert_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -655,21 +767,43 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, inner_tiles..., ]
+function pack(
+    source::Value,
+    dest::Value,
+    padding_value=nothing::Union{Nothing,Value};
+    inner_tiles::Vector{Value},
+    result=nothing::Union{Nothing,IR.Type},
+    outer_dims_perm=nothing,
+    inner_dims_pos,
+    static_inner_tiles,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[source, dest, inner_tiles...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    attributes = NamedAttribute[
+        namedattribute("inner_dims_pos", inner_dims_pos),
+        namedattribute("static_inner_tiles", static_inner_tiles),
+    ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(attributes, operandsegmentsizes([1, 1, (padding_value==nothing) ? 0 : 1length(inner_tiles), ]))
-    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-    
-    IR.create_operation(
-        "tensor.pack", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
+    )
+    !isnothing(result) && push!(results, result)
+    !isnothing(outer_dims_perm) &&
+        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+
+    return IR.create_operation(
+        "tensor.pack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -745,20 +879,36 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, low..., high..., ]
-    owned_regions = Region[region, ]
+function pad(
+    source::Value,
+    low::Vector{Value},
+    high::Vector{Value};
+    result::IR.Type,
+    static_low,
+    static_high,
+    nofold=nothing,
+    region::Region,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, low..., high...]
+    owned_regions = Region[region,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
+    attributes = NamedAttribute[
+        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
+    ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-    
-    IR.create_operation(
-        "tensor.pad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -822,19 +972,40 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
+function parallel_insert_slice(
+    source::Value,
+    dest::Value,
+    offsets::Vector{Value},
+    sizes::Vector{Value},
+    strides::Vector{Value};
+    static_offsets,
+    static_sizes,
+    static_strides,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides..., ]
+    operands = Value[source, dest, offsets..., sizes..., strides...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
-    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
-    
-    IR.create_operation(
-        "tensor.parallel_insert_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("static_offsets", static_offsets),
+        namedattribute("static_sizes", static_sizes),
+        namedattribute("static_strides", static_strides),
+    ]
+    push!(
+        attributes,
+        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
+    )
+
+    return IR.create_operation(
+        "tensor.parallel_insert_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -850,19 +1021,23 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor, ]
+    operands = Value[tensor,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "tensor.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -901,17 +1076,21 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, shape, ]
+    results = IR.Type[result,]
+    operands = Value[source, shape]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1015,19 +1194,31 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, indices, ]
+function scatter(
+    source::Value,
+    dest::Value,
+    indices::Value;
+    result::IR.Type,
+    scatter_dims,
+    unique=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[source, dest, indices]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-    
-    IR.create_operation(
-        "tensor.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1057,17 +1248,21 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate, ]
-    operands = Value[input, ]
+    results = IR.Type[aggregate,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.splat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.splat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1095,19 +1290,37 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, dest, inner_tiles..., ]
+function unpack(
+    source::Value,
+    dest::Value,
+    inner_tiles::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    outer_dims_perm=nothing,
+    inner_dims_pos,
+    static_inner_tiles,
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[source, dest, inner_tiles...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
-    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-    
-    IR.create_operation(
-        "tensor.unpack", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    attributes = NamedAttribute[
+        namedattribute("inner_dims_pos", inner_dims_pos),
+        namedattribute("static_inner_tiles", static_inner_tiles),
+    ]
+    !isnothing(result) && push!(results, result)
+    !isnothing(outer_dims_perm) &&
+        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+
+    return IR.create_operation(
+        "tensor.unpack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1120,16 +1333,20 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value, ]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tensor.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tensor.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Tensor.jl
+++ b/src/Dialects/17/Tensor.jl
@@ -1,9 +1,8 @@
 module tensor
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `bitcast`
@@ -20,21 +19,17 @@ should match.
 ```
 """
 function bitcast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -62,21 +57,17 @@ converting to a mismatching constant dimension.
 ```
 """
 function cast(source::Value; dest::IR.Type, location=Location())
-    results = IR.Type[dest,]
-    operands = Value[source,]
+    results = IR.Type[dest, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -106,21 +97,17 @@ Examples:
 ```
 """
 function collapse_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.collapse_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.collapse_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,25 +136,19 @@ The specified tensor type is that of the first operand.
 %y = \"tensor.dim\"(%A, %c1) : (memref<4x?xf32>, index) -> index
 ```
 """
-function dim(
-    source::Value, index::Value; result=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function dim(source::Value, index::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, index]
+    operands = Value[source, index, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.dim", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -188,21 +169,17 @@ Note: This op can be lowered to a `bufferization.alloc_tensor`, at which
 point it turns into an explicit buffer allocation.
 """
 function empty(dynamicSizes::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[dynamicSizes...,]
+    results = IR.Type[result, ]
+    operands = Value[dynamicSizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -232,21 +209,17 @@ Examples:
 ```
 """
 function expand_shape(src::Value; result::IR.Type, reassociation, location=Location())
-    results = IR.Type[result,]
-    operands = Value[src,]
+    results = IR.Type[result, ]
+    operands = Value[src, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("reassociation", reassociation),]
-
-    return IR.create_operation(
-        "tensor.expand_shape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("reassociation", reassociation), ]
+    
+    IR.create_operation(
+        "tensor.expand_shape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -265,28 +238,18 @@ the rank of the accessed value. All indices should all be of `index` type.
 %5 = tensor.extract %rt[%1, %2] : tensor<?x?xi32>
 ```
 """
-function extract(
-    tensor::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[tensor, indices...]
+function extract(tensor::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[tensor, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.extract", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -350,40 +313,19 @@ dims, to map the rank-reduced type to the source type by dropping ones:
   tensor<8x16x4xf32> to tensor<1x?xf32>
 ```
 """
-function extract_slice(
-    source::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result::IR.Type,
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, offsets..., sizes..., strides...]
+function extract_slice(source::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -406,21 +348,17 @@ will result in a tensor
  [%d, %e, %f]]
 """
 function from_elements(elements::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[elements...,]
+    results = IR.Type[result, ]
+    operands = Value[elements..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.from_elements",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.from_elements", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -521,30 +459,19 @@ op:
       (memref<4x4xf32>, memref<?x 1xindex>) -> memref<? x memref<4x1xf32>>
 ```
 """
-function gather(
-    source::Value,
-    indices::Value;
-    result::IR.Type,
-    gather_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, indices]
+function gather(source::Value, indices::Value; result::IR.Type, gather_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims),]
+    attributes = NamedAttribute[namedattribute("gather_dims", gather_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -570,24 +497,18 @@ a \"parallel map\" operation.
   } : tensor<?x3x?f32>
 ```
 """
-function generate(
-    dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[dynamicExtents...,]
-    owned_regions = Region[body,]
+function generate(dynamicExtents::Vector{Value}; result::IR.Type, body::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[dynamicExtents..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.generate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.generate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -610,29 +531,18 @@ indices should be of `index` type.
 %5 = tensor.insert %rt into %dest[%1, %2] : tensor<?x?xi32>
 ```
 """
-function insert(
-    scalar::Value,
-    dest::Value,
-    indices::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[scalar, dest, indices...]
+function insert(scalar::Value, dest::Value, indices::Vector{Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[scalar, dest, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "tensor.insert", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -690,42 +600,19 @@ Unlike ExtractSliceOp however, there is no need for a specific inference.
   tensor<1x?xf32> into tensor<8x16x4xf32>
 ```
 """
-function insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+function insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; result::IR.Type, static_offsets, static_sizes, static_strides, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "tensor.insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.insert_slice", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -768,43 +655,21 @@ Example NC_to_NCnc with padding:
   inner_tiles = [8, 2] into %arg1 : tensor<13x15xf32> -> tensor<2x8x8x2xf32>
 ```
 """
-function pack(
-    source::Value,
-    dest::Value,
-    padding_value=nothing::Union{Nothing,Value};
-    inner_tiles::Vector{Value},
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function pack(source::Value, dest::Value, padding_value=nothing::Union{Nothing, Value}; inner_tiles::Vector{Value}, result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
     !isnothing(padding_value) && push!(operands, padding_value)
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, (padding_value == nothing) ? 0 : 1length(inner_tiles)]),
-    )
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    push!(attributes, operandsegmentsizes([1, 1, (padding_value==nothing) ? 0 : 1length(inner_tiles), ]))
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.pack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -880,36 +745,20 @@ Example 4:
   } : tensor<2x3xf32> to tensor<2x3xf32>
 ```
 """
-function pad(
-    source::Value,
-    low::Vector{Value},
-    high::Vector{Value};
-    result::IR.Type,
-    static_low,
-    static_high,
-    nofold=nothing,
-    region::Region,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, low..., high...]
-    owned_regions = Region[region,]
+function pad(source::Value, low::Vector{Value}, high::Vector{Value}; result::IR.Type, static_low, static_high, nofold=nothing, region::Region, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, low..., high..., ]
+    owned_regions = Region[region, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_low", static_low), namedattribute("static_high", static_high)
-    ]
-    push!(attributes, operandsegmentsizes([1, length(low), length(high)]))
+    attributes = NamedAttribute[namedattribute("static_low", static_low), namedattribute("static_high", static_high), ]
+    push!(attributes, operandsegmentsizes([1, length(low), length(high), ]))
     !isnothing(nofold) && push!(attributes, namedattribute("nofold", nofold))
-
-    return IR.create_operation(
-        "tensor.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -973,40 +822,19 @@ rank-reducing behavior of tensor.insert_slice and tensor.extract_slice.
 The same verification discussion and mechanisms apply as for ExtractSliceOp.
 Unlike ExtractSliceOp however, there is no need for a specific inference.
 """
-function parallel_insert_slice(
-    source::Value,
-    dest::Value,
-    offsets::Vector{Value},
-    sizes::Vector{Value},
-    strides::Vector{Value};
-    static_offsets,
-    static_sizes,
-    static_strides,
-    location=Location(),
-)
+function parallel_insert_slice(source::Value, dest::Value, offsets::Vector{Value}, sizes::Vector{Value}, strides::Vector{Value}; static_offsets, static_sizes, static_strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest, offsets..., sizes..., strides...]
+    operands = Value[source, dest, offsets..., sizes..., strides..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("static_offsets", static_offsets),
-        namedattribute("static_sizes", static_sizes),
-        namedattribute("static_strides", static_strides),
-    ]
-    push!(
-        attributes,
-        operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides)]),
-    )
-
-    return IR.create_operation(
-        "tensor.parallel_insert_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("static_offsets", static_offsets), namedattribute("static_sizes", static_sizes), namedattribute("static_strides", static_strides), ]
+    push!(attributes, operandsegmentsizes([1, 1, length(offsets), length(sizes), length(strides), ]))
+    
+    IR.create_operation(
+        "tensor.parallel_insert_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1022,23 +850,19 @@ The `tensor.rank` operation takes a tensor operand and returns its rank.
 %1 = tensor.rank %arg1 : tensor<?x?xf32>
 ```
 """
-function rank(tensor::Value; result_0=nothing::Union{Nothing,IR.Type}, location=Location())
+function rank(tensor::Value; result_0=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[tensor,]
+    operands = Value[tensor, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "tensor.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.rank", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1077,21 +901,17 @@ Result type is unranked.
 ```
 """
 function reshape(source::Value, shape::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source, shape]
+    results = IR.Type[result, ]
+    operands = Value[source, shape, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1195,31 +1015,19 @@ op:
     some_side_effecting_op_writing_into %v, ...: memref<? x memref<4xf32>>
 ```
 """
-function scatter(
-    source::Value,
-    dest::Value,
-    indices::Value;
-    result::IR.Type,
-    scatter_dims,
-    unique=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[source, dest, indices]
+function scatter(source::Value, dest::Value, indices::Value; result::IR.Type, scatter_dims, unique=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, indices, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims),]
+    attributes = NamedAttribute[namedattribute("scatter_dims", scatter_dims), ]
     !isnothing(unique) && push!(attributes, namedattribute("unique", unique))
-
-    return IR.create_operation(
-        "tensor.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1249,21 +1057,17 @@ TODO: This operation is easy to extend to broadcast to dynamically shaped
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1291,37 +1095,19 @@ Example CK to KCck:
   inner_tiles = [8, 32] into %dest : tensor<8x16x8x32xf32> -> tensor<128x256xf32>
 ```
 """
-function unpack(
-    source::Value,
-    dest::Value,
-    inner_tiles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    outer_dims_perm=nothing,
-    inner_dims_pos,
-    static_inner_tiles,
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[source, dest, inner_tiles...]
+function unpack(source::Value, dest::Value, inner_tiles::Vector{Value}; result::IR.Type, outer_dims_perm=nothing, inner_dims_pos, static_inner_tiles, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[source, dest, inner_tiles..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("inner_dims_pos", inner_dims_pos),
-        namedattribute("static_inner_tiles", static_inner_tiles),
-    ]
-    !isnothing(result) && push!(results, result)
-    !isnothing(outer_dims_perm) &&
-        push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
-
-    return IR.create_operation(
-        "tensor.unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    attributes = NamedAttribute[namedattribute("inner_dims_pos", inner_dims_pos), namedattribute("static_inner_tiles", static_inner_tiles), ]
+    !isnothing(outer_dims_perm) && push!(attributes, namedattribute("outer_dims_perm", outer_dims_perm))
+    
+    IR.create_operation(
+        "tensor.unpack", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -1334,20 +1120,16 @@ is used to create dynamically sized tensors
 """
 function yield(value::Value; location=Location())
     results = IR.Type[]
-    operands = Value[value,]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tensor.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tensor.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Tosa.jl
+++ b/src/Dialects/17/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `abs`
@@ -10,17 +10,21 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.abs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.abs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -31,17 +35,21 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.add", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.add",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -55,18 +63,29 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[value, multiplier, shift, ]
+function apply_scale(
+    value::Value,
+    multiplier::Value,
+    shift::Value;
+    output::IR.Type,
+    double_round,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[value, multiplier, shift]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
-    
-    IR.create_operation(
-        "tosa.apply_scale", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round),]
+
+    return IR.create_operation(
+        "tosa.apply_scale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -77,17 +96,21 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.argmax", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.argmax",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -97,18 +120,24 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function arithmetic_right_shift(
+    input1::Value, input2::Value; output::IR.Type, round, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round), ]
-    
-    IR.create_operation(
-        "tosa.arithmetic_right_shift", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("round", round),]
+
+    return IR.create_operation(
+        "tosa.arithmetic_right_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -119,19 +148,38 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, acc_type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function avg_pool2d(
+    input::Value;
+    output::IR.Type,
+    kernel,
+    stride,
+    pad,
+    acc_type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), namedattribute("acc_type", acc_type), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.avg_pool2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("kernel", kernel),
+        namedattribute("stride", stride),
+        namedattribute("pad", pad),
+        namedattribute("acc_type", acc_type),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.avg_pool2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -142,17 +190,21 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -162,17 +214,21 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -183,17 +239,21 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -204,17 +264,21 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.bitwise_xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.bitwise_xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -245,17 +309,21 @@ Performs a set of permissible cast operations
 | float 64 to float 32     | float64 | float32 |
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -265,17 +333,21 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.ceil", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.ceil",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -288,18 +360,29 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function clamp(
+    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
-    
-    IR.create_operation(
-        "tosa.clamp", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("min_int", min_int),
+        namedattribute("max_int", max_int),
+        namedattribute("min_fp", min_fp),
+        namedattribute("max_fp", max_fp),
+    ]
+
+    return IR.create_operation(
+        "tosa.clamp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -309,17 +392,21 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.clz", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.clz",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -329,19 +416,25 @@ end
 Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
-function concat(input1::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function concat(
+    input1::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input1..., ]
+    operands = Value[input1...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.concat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.concat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -351,19 +444,23 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
+    attributes = NamedAttribute[namedattribute("value", value),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.const", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.const",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -373,19 +470,38 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function conv2d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -394,19 +510,38 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function conv3d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.conv3d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.conv3d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -432,18 +567,33 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[inputs..., ]
+function custom(
+    inputs::Vector{Value};
+    outputs::Vector{IR.Type},
+    identifier,
+    config,
+    implementation_attrs,
+    location=Location(),
+)
+    results = IR.Type[outputs...,]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
-    
-    IR.create_operation(
-        "tosa.custom", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("identifier", identifier),
+        namedattribute("config", config),
+        namedattribute("implementation_attrs", implementation_attrs),
+    ]
+
+    return IR.create_operation(
+        "tosa.custom",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -453,19 +603,38 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function depthwise_conv2d(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    pad,
+    stride,
+    dilation,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.depthwise_conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("pad", pad),
+        namedattribute("stride", stride),
+        namedattribute("dilation", dilation),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.depthwise_conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -476,17 +645,21 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.div", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.div",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -495,19 +668,28 @@ end
 
 Elementwise comparison operation
 """
-function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
+function equal(
+    input1::Value,
+    input2::Value;
+    output=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[input1, input2, ]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -520,17 +702,21 @@ with the following definition.  The erf_table has 513 entries each of
 16-bit/8-bit precision and covering the input range -4.0 to +4.0 in steps of 1/64.
 """
 function erf(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.erf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.erf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -540,17 +726,21 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.exp", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.exp",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -563,18 +753,29 @@ input_real and input_imag tensors. The resulting values in the output are
 split into the output_real and output_imag tensors. No normalization is
 applied on either the forward or inverse versions of the operation.
 """
-function fft2d(input_real::Value, input_imag::Value; output_real::IR.Type, output_imag::IR.Type, inverse, location=Location())
-    results = IR.Type[output_real, output_imag, ]
-    operands = Value[input_real, input_imag, ]
+function fft2d(
+    input_real::Value,
+    input_imag::Value;
+    output_real::IR.Type,
+    output_imag::IR.Type,
+    inverse,
+    location=Location(),
+)
+    results = IR.Type[output_real, output_imag]
+    operands = Value[input_real, input_imag]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inverse", inverse), ]
-    
-    IR.create_operation(
-        "tosa.fft2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("inverse", inverse),]
+
+    return IR.create_operation(
+        "tosa.fft2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -584,17 +785,21 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.floor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.floor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -603,19 +808,31 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, weight, bias, ]
+function fully_connected(
+    input::Value,
+    weight::Value,
+    bias::Value;
+    output::IR.Type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, weight, bias]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.fully_connected", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.fully_connected",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -626,17 +843,21 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[values, indices, ]
+    results = IR.Type[output,]
+    operands = Value[values, indices]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -646,17 +867,21 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.greater_equal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.greater_equal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -666,17 +891,21 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.greater", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.greater",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -687,17 +916,21 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.identity", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.identity",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -707,18 +940,29 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
-    results = IR.Type[output..., ]
-    operands = Value[cond, inputs..., ]
-    owned_regions = Region[then_branch, else_branch, ]
+function cond_if(
+    cond::Value,
+    inputs::Vector{Value};
+    output::Vector{IR.Type},
+    then_branch::Region,
+    else_branch::Region,
+    location=Location(),
+)
+    results = IR.Type[output...,]
+    operands = Value[cond, inputs...]
+    owned_regions = Region[then_branch, else_branch]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.cond_if", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.cond_if",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -728,17 +972,21 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.log", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.log",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -749,17 +997,21 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_and", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_and",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -769,18 +1021,24 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function logical_left_shift(
+    input1::Value, input2::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_left_shift", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_left_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -790,17 +1048,21 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_not", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_not",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -811,17 +1073,21 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_or", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_or",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -831,18 +1097,24 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+function logical_right_shift(
+    input1::Value, input2::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_right_shift", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_right_shift",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -853,17 +1125,21 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.logical_xor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.logical_xor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -874,19 +1150,26 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[c, ]
-    operands = Value[a, b, ]
+function matmul(
+    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
+)
+    results = IR.Type[c,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.matmul", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.matmul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -899,17 +1182,25 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
-    
-    IR.create_operation(
-        "tosa.max_pool2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("kernel", kernel),
+        namedattribute("stride", stride),
+        namedattribute("pad", pad),
+    ]
+
+    return IR.create_operation(
+        "tosa.max_pool2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -920,17 +1211,21 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.maximum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.maximum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -941,17 +1236,21 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.minimum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.minimum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -963,17 +1262,21 @@ Axis of size 1 will be broadcast, as necessary.
 i8/i16 input type can be promoted to i32 result type.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift), ]
-    
-    IR.create_operation(
-        "tosa.mul", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift),]
+
+    return IR.create_operation(
+        "tosa.mul",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -982,19 +1285,26 @@ end
 
 Elementwise negation operation
 """
-function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+function negate(
+    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.negate", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.negate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1019,20 +1329,32 @@ Example 2:
 \"tosa.pad\"(%arg0, %0)  : (tensor<1x2xf32>, tensor<2x2xi32>)  -> (tensor<?x9xf32>)
 ```
 """
-function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, padding, ]
+function pad(
+    input1::Value,
+    padding::Value,
+    pad_const=nothing::Union{Nothing,Value};
+    output::IR.Type,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input1, padding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.pad", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1043,17 +1365,21 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[z,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.pow", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.pow",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1067,18 +1393,24 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
-    results = IR.Type[output_real, output_imag, ]
-    operands = Value[input, ]
+function rfft2d(
+    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
+)
+    results = IR.Type[output_real, output_imag]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.rfft2d", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.rfft2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1089,17 +1421,21 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.reciprocal", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reciprocal",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1108,19 +1444,25 @@ end
 
 Reduce a tensor along the given axis with a logical AND operation
 """
-function reduce_all(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function reduce_all(
+    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reduce_all", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reduce_all",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1129,19 +1471,25 @@ end
 
 Reduce a tensor along the given axis with a logical OR operation
 """
-function reduce_any(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function reduce_any(
+    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reduce_any", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reduce_any",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1150,19 +1498,25 @@ end
 
 Reduce a tensor along the given axis with a maximum operation
 """
-function reduce_max(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function reduce_max(
+    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reduce_max", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reduce_max",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1171,19 +1525,25 @@ end
 
 Reduce a tensor along the given axis with a minimum operation
 """
-function reduce_min(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function reduce_min(
+    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reduce_min", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reduce_min",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1192,19 +1552,25 @@ end
 
 Reduce a tensor along the given axis by computing the product of the axis.
 """
-function reduce_prod(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function reduce_prod(
+    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reduce_prod", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reduce_prod",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1213,19 +1579,25 @@ end
 
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
-function reduce_sum(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
+function reduce_sum(
+    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input, ]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    attributes = NamedAttribute[namedattribute("axis", axis),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reduce_sum", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reduce_sum",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1249,18 +1621,41 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function rescale(
+    input::Value;
+    output::IR.Type,
+    input_zp,
+    output_zp,
+    multiplier,
+    shift,
+    scale32,
+    double_round,
+    per_channel,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
-    
-    IR.create_operation(
-        "tosa.rescale", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("input_zp", input_zp),
+        namedattribute("output_zp", output_zp),
+        namedattribute("multiplier", multiplier),
+        namedattribute("shift", shift),
+        namedattribute("scale32", scale32),
+        namedattribute("double_round", double_round),
+        namedattribute("per_channel", per_channel),
+    ]
+
+    return IR.create_operation(
+        "tosa.rescale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1271,19 +1666,25 @@ Returns a tensor with the same type/values as the input, with a new shape
 specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
-function reshape(input1::Value; output=nothing::Union{Nothing, IR.Type}, new_shape, location=Location())
+function reshape(
+    input1::Value; output=nothing::Union{Nothing,IR.Type}, new_shape, location=Location()
+)
     results = IR.Type[]
-    operands = Value[input1, ]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
     !isnothing(output) && push!(results, output)
-    
-    IR.create_operation(
-        "tosa.reshape", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1297,18 +1698,29 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+function resize(
+    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
-    
-    IR.create_operation(
-        "tosa.resize", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("scale", scale),
+        namedattribute("offset", offset),
+        namedattribute("border", border),
+        namedattribute("mode", mode),
+    ]
+
+    return IR.create_operation(
+        "tosa.resize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1320,17 +1732,21 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis), ]
-    
-    IR.create_operation(
-        "tosa.reverse", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis),]
+
+    return IR.create_operation(
+        "tosa.reverse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1341,17 +1757,21 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1361,18 +1781,24 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
-    results = IR.Type[values_out, ]
-    operands = Value[values_in, indices, input, ]
+function scatter(
+    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
+)
+    results = IR.Type[values_out,]
+    operands = Value[values_in, indices, input]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1381,18 +1807,24 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[pred, on_true, on_false, ]
+function select(
+    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
+)
+    results = IR.Type[output,]
+    operands = Value[pred, on_true, on_false]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.select", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1406,17 +1838,21 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.sigmoid", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.sigmoid",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1428,17 +1864,23 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
-    
-    IR.create_operation(
-        "tosa.slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("start", start), namedattribute("size", size)
+    ]
+
+    return IR.create_operation(
+        "tosa.slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1449,17 +1891,21 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, input2, ]
+    results = IR.Type[output,]
+    operands = Value[input1, input2]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.sub", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.sub",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1482,17 +1928,21 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, table, ]
+    results = IR.Type[output,]
+    operands = Value[input, table]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.table", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.table",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1505,17 +1955,21 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.tanh", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.tanh",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1525,17 +1979,21 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, ]
+    results = IR.Type[output,]
+    operands = Value[input1,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
-    
-    IR.create_operation(
-        "tosa.tile", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples),]
+
+    return IR.create_operation(
+        "tosa.tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1545,19 +2003,38 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, filter, bias, ]
+function transpose_conv2d(
+    input::Value,
+    filter::Value,
+    bias::Value;
+    output::IR.Type,
+    out_pad,
+    stride,
+    out_shape,
+    quantization_info=nothing,
+    location=Location(),
+)
+    results = IR.Type[output,]
+    operands = Value[input, filter, bias]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
-    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
-    
-    IR.create_operation(
-        "tosa.transpose_conv2d", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("out_pad", out_pad),
+        namedattribute("stride", stride),
+        namedattribute("out_shape", out_shape),
+    ]
+    !isnothing(quantization_info) &&
+        push!(attributes, namedattribute("quantization_info", quantization_info))
+
+    return IR.create_operation(
+        "tosa.transpose_conv2d",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1567,17 +2044,21 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input1, perms, ]
+    results = IR.Type[output,]
+    operands = Value[input1, perms]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1589,18 +2070,28 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
-    results = IR.Type[output..., ]
-    operands = Value[inputs..., ]
-    owned_regions = Region[cond, body, ]
+function while_loop(
+    inputs::Vector{Value};
+    output::Vector{IR.Type},
+    cond::Region,
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[output...,]
+    operands = Value[inputs...,]
+    owned_regions = Region[cond, body]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.while_loop", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.while_loop",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1613,16 +2104,20 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs..., ]
+    operands = Value[inputs...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "tosa.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "tosa.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Tosa.jl
+++ b/src/Dialects/17/Tosa.jl
@@ -1,9 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `abs`
@@ -11,21 +10,17 @@ import ...API
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -36,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -64,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -97,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -121,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -149,38 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    acc_type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, acc_type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-        namedattribute("acc_type", acc_type),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), namedattribute("acc_type", acc_type), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -191,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -215,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -240,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -265,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -310,21 +245,17 @@ Performs a set of permissible cast operations
 | float 64 to float 32     | float64 | float32 |
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -334,21 +265,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -361,29 +288,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -393,21 +309,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -417,25 +329,19 @@ end
 Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
-function concat(
-    input1::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function concat(input1::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input1...,]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -445,23 +351,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -471,38 +373,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -511,38 +394,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -568,33 +432,18 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    identifier,
-    config,
-    implementation_attrs,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("identifier", identifier),
-        namedattribute("config", config),
-        namedattribute("implementation_attrs", implementation_attrs),
-    ]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -604,38 +453,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -646,21 +476,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -669,28 +495,19 @@ end
 
 Elementwise comparison operation
 """
-function equal(
-    input1::Value,
-    input2::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1, input2]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -703,21 +520,17 @@ with the following definition.  The erf_table has 513 entries each of
 16-bit/8-bit precision and covering the input range -4.0 to +4.0 in steps of 1/64.
 """
 function erf(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.erf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -727,21 +540,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -754,29 +563,18 @@ input_real and input_imag tensors. The resulting values in the output are
 split into the output_real and output_imag tensors. No normalization is
 applied on either the forward or inverse versions of the operation.
 """
-function fft2d(
-    input_real::Value,
-    input_imag::Value;
-    output_real::IR.Type,
-    output_imag::IR.Type,
-    inverse,
-    location=Location(),
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input_real, input_imag]
+function fft2d(input_real::Value, input_imag::Value; output_real::IR.Type, output_imag::IR.Type, inverse, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input_real, input_imag, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inverse", inverse),]
-
-    return IR.create_operation(
-        "tosa.fft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("inverse", inverse), ]
+    
+    IR.create_operation(
+        "tosa.fft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -786,21 +584,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -809,31 +603,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -844,21 +626,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -868,21 +646,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -892,21 +666,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -917,21 +687,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -941,29 +707,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -973,21 +728,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -998,21 +749,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1022,24 +769,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1049,21 +790,17 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1074,21 +811,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1098,24 +831,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1126,21 +853,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1151,26 +874,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1183,25 +899,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1212,21 +920,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1237,21 +941,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1263,21 +963,17 @@ Axis of size 1 will be broadcast, as necessary.
 i8/i16 input type can be promoted to i32 result type.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1286,26 +982,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1330,32 +1019,20 @@ Example 2:
 \"tosa.pad\"(%arg0, %0)  : (tensor<1x2xf32>, tensor<2x2xi32>)  -> (tensor<?x9xf32>)
 ```
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1366,21 +1043,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1394,24 +1067,18 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(
-    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input,]
+function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rfft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rfft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1422,21 +1089,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1445,25 +1108,19 @@ end
 
 Reduce a tensor along the given axis with a logical AND operation
 """
-function reduce_all(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_all(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1472,25 +1129,19 @@ end
 
 Reduce a tensor along the given axis with a logical OR operation
 """
-function reduce_any(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_any(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1499,25 +1150,19 @@ end
 
 Reduce a tensor along the given axis with a maximum operation
 """
-function reduce_max(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_max(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1526,25 +1171,19 @@ end
 
 Reduce a tensor along the given axis with a minimum operation
 """
-function reduce_min(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_min(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1553,25 +1192,19 @@ end
 
 Reduce a tensor along the given axis by computing the product of the axis.
 """
-function reduce_prod(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_prod(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1580,25 +1213,19 @@ end
 
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
-function reduce_sum(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_sum(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1622,41 +1249,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1667,25 +1271,19 @@ Returns a tensor with the same type/values as the input, with a new shape
 specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
-function reshape(
-    input1::Value; output=nothing::Union{Nothing,IR.Type}, new_shape, location=Location()
-)
+function reshape(input1::Value; output=nothing::Union{Nothing, IR.Type}, new_shape, location=Location())
     results = IR.Type[]
-    operands = Value[input1,]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1699,29 +1297,18 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(
-    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("scale", scale),
-        namedattribute("offset", offset),
-        namedattribute("border", border),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1733,21 +1320,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1758,21 +1341,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1782,24 +1361,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1808,24 +1381,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1839,21 +1406,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1865,23 +1428,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1892,21 +1449,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1929,21 +1482,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1956,21 +1505,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1980,21 +1525,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2004,38 +1545,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2045,21 +1567,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2071,28 +1589,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2105,20 +1613,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Tosa.jl
+++ b/src/Dialects/17/Tosa.jl
@@ -1,8 +1,8 @@
 module tosa
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `abs`
@@ -10,21 +10,17 @@ import ..Dialects: namedattribute, operandsegmentsizes
 Elementwise absolute value operation
 """
 function abs(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.abs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.abs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -35,21 +31,17 @@ Elementwise addition of input1 and input2. Axis of size 1 will be broadcast,
 as necessary.
 """
 function add(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.add",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.add", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -63,29 +55,18 @@ The commonplace implementation is to use i64 operations to avoid integer
 overflow with target specific implementations can use native operations to
 avoid wider than necessary types.
 """
-function apply_scale(
-    value::Value,
-    multiplier::Value,
-    shift::Value;
-    output::IR.Type,
-    double_round,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[value, multiplier, shift]
+function apply_scale(value::Value, multiplier::Value, shift::Value; output::IR.Type, double_round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[value, multiplier, shift, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("double_round", double_round),]
-
-    return IR.create_operation(
-        "tosa.apply_scale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("double_round", double_round), ]
+    
+    IR.create_operation(
+        "tosa.apply_scale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -96,21 +77,17 @@ This returns the index with the largest value across the given axis of the
 input tensor.
 """
 function argmax(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.argmax",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.argmax", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -120,24 +97,18 @@ end
 Elementwise arithmetic right shift of input1 by the amount specified in
 input2. Axis of size 1 will be broadcast, as necessary.
 """
-function arithmetic_right_shift(
-    input1::Value, input2::Value; output::IR.Type, round, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function arithmetic_right_shift(input1::Value, input2::Value; output::IR.Type, round, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("round", round),]
-
-    return IR.create_operation(
-        "tosa.arithmetic_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("round", round), ]
+    
+    IR.create_operation(
+        "tosa.arithmetic_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -148,38 +119,19 @@ This performs an average pooling over the given input tensor. A sliding
 window of size given by <kernel size> is passed over the input tensor, with
 the mean value being placed in the output tensor.
 """
-function avg_pool2d(
-    input::Value;
-    output::IR.Type,
-    kernel,
-    stride,
-    pad,
-    acc_type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function avg_pool2d(input::Value; output::IR.Type, kernel, stride, pad, acc_type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-        namedattribute("acc_type", acc_type),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.avg_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), namedattribute("acc_type", acc_type), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.avg_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -190,21 +142,17 @@ Elementwise bitwise AND of input1 and input2. Axis of size 1
 will be broadcast as necessary.
 """
 function bitwise_and(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -214,21 +162,17 @@ end
 Elementwise bitwise NOT of input tensor.
 """
 function bitwise_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -239,21 +183,17 @@ Elementwise bitwise OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_or(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -264,21 +204,17 @@ Elementwise bitwise XOR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function bitwise_xor(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.bitwise_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.bitwise_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -309,21 +245,17 @@ Performs a set of permissible cast operations
 | float 64 to float 32     | float64 | float32 |
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -333,21 +265,17 @@ end
 Elementwise ceiling operation
 """
 function ceil(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.ceil",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.ceil", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -360,29 +288,18 @@ input type.
 No zero point subtraction is done to the values, thus to clamp to the zero
 point value, the zero point itself should be supplied as the minimum value.
 """
-function clamp(
-    input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function clamp(input::Value; output::IR.Type, min_int, max_int, min_fp, max_fp, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("min_int", min_int),
-        namedattribute("max_int", max_int),
-        namedattribute("min_fp", min_fp),
-        namedattribute("max_fp", max_fp),
-    ]
-
-    return IR.create_operation(
-        "tosa.clamp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("min_int", min_int), namedattribute("max_int", max_int), namedattribute("min_fp", min_fp), namedattribute("max_fp", max_fp), ]
+    
+    IR.create_operation(
+        "tosa.clamp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -392,21 +309,17 @@ end
 Elementwise count leading zeros operation
 """
 function clz(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.clz",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.clz", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,25 +329,19 @@ end
 Concatenate a variadic amount of tensors along a given axis. No data
 conversion happens during a concat operation.
 """
-function concat(
-    input1::Vector{Value}; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function concat(input1::Vector{Value}; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input1...,]
+    operands = Value[input1..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.concat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.concat", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -444,23 +351,19 @@ end
 A node containing constant data for use as the input to an operation. May
 hold data in any of the supported data formats.
 """
-function const_(; output=nothing::Union{Nothing,IR.Type}, value, location=Location())
+function const_(; output=nothing::Union{Nothing, IR.Type}, value, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
+    attributes = NamedAttribute[namedattribute("value", value), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.const",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.const", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -470,38 +373,19 @@ end
 Performs a 2D convolution over the given tensor input, using the weight
 tensor.
 """
-function conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -510,38 +394,19 @@ end
 
 Performs a 3D convolution over the given input tensor.
 """
-function conv3d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function conv3d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.conv3d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.conv3d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -567,33 +432,18 @@ set of attributes to the custom operator.
 `outputs is the list of tensors returned by the operator. The number of operators
 is backend specific.
 """
-function custom(
-    inputs::Vector{Value};
-    outputs::Vector{IR.Type},
-    identifier,
-    config,
-    implementation_attrs,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[inputs...,]
+function custom(inputs::Vector{Value}; outputs::Vector{IR.Type}, identifier, config, implementation_attrs, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("identifier", identifier),
-        namedattribute("config", config),
-        namedattribute("implementation_attrs", implementation_attrs),
-    ]
-
-    return IR.create_operation(
-        "tosa.custom",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("identifier", identifier), namedattribute("config", config), namedattribute("implementation_attrs", implementation_attrs), ]
+    
+    IR.create_operation(
+        "tosa.custom", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -603,38 +453,19 @@ end
 Performs 2D convolutions separately over each channel of the given tensor
 input, using the weight tensor.
 """
-function depthwise_conv2d(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    pad,
-    stride,
-    dilation,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function depthwise_conv2d(input::Value, weight::Value, bias::Value; output::IR.Type, pad, stride, dilation, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("pad", pad),
-        namedattribute("stride", stride),
-        namedattribute("dilation", dilation),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.depthwise_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pad", pad), namedattribute("stride", stride), namedattribute("dilation", dilation), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.depthwise_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -645,21 +476,17 @@ Elementwise integer divide operator of input1 by input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function div(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.div",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.div", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -668,28 +495,19 @@ end
 
 Elementwise comparison operation
 """
-function equal(
-    input1::Value,
-    input2::Value;
-    output=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function equal(input1::Value, input2::Value; output=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[input1, input2]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.equal", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -702,21 +520,17 @@ with the following definition.  The erf_table has 513 entries each of
 16-bit/8-bit precision and covering the input range -4.0 to +4.0 in steps of 1/64.
 """
 function erf(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.erf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.erf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -726,21 +540,17 @@ end
 Elementwise e to the x operation
 """
 function exp(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.exp",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.exp", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -753,29 +563,18 @@ input_real and input_imag tensors. The resulting values in the output are
 split into the output_real and output_imag tensors. No normalization is
 applied on either the forward or inverse versions of the operation.
 """
-function fft2d(
-    input_real::Value,
-    input_imag::Value;
-    output_real::IR.Type,
-    output_imag::IR.Type,
-    inverse,
-    location=Location(),
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input_real, input_imag]
+function fft2d(input_real::Value, input_imag::Value; output_real::IR.Type, output_imag::IR.Type, inverse, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input_real, input_imag, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("inverse", inverse),]
-
-    return IR.create_operation(
-        "tosa.fft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("inverse", inverse), ]
+    
+    IR.create_operation(
+        "tosa.fft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -785,21 +584,17 @@ end
 Elementwise floor operation
 """
 function floor(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.floor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.floor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -808,31 +603,19 @@ end
 
 Performs a fully connected network.
 """
-function fully_connected(
-    input::Value,
-    weight::Value,
-    bias::Value;
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, weight, bias]
+function fully_connected(input::Value, weight::Value, bias::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, weight, bias, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.fully_connected",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.fully_connected", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -843,21 +626,17 @@ Generate a tensor for which each element in the output is a slice of the
 values tensor based on the value of indices.
 """
 function gather(values::Value, indices::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[values, indices]
+    results = IR.Type[output, ]
+    operands = Value[values, indices, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -867,21 +646,17 @@ end
 Elementwise comparison operation
 """
 function greater_equal(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater_equal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater_equal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -891,21 +666,17 @@ end
 Elementwise greater than comparison operation
 """
 function greater(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.greater",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.greater", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -916,21 +687,17 @@ Returns a tensor with the same shape, size, type
 and content as the input.
 """
 function identity(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.identity",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.identity", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -940,29 +707,18 @@ end
 Evaluates a Boolean condition and then takes one of two distinct execution
 paths. This implements the semantic If-then-else structure.
 """
-function cond_if(
-    cond::Value,
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    then_branch::Region,
-    else_branch::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[cond, inputs...]
-    owned_regions = Region[then_branch, else_branch]
+function cond_if(cond::Value, inputs::Vector{Value}; output::Vector{IR.Type}, then_branch::Region, else_branch::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[cond, inputs..., ]
+    owned_regions = Region[then_branch, else_branch, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.cond_if",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.cond_if", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -972,21 +728,17 @@ end
 Elementwise natural logarithm operation
 """
 function log(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.log",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.log", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -997,21 +749,17 @@ Elementwise logical AND of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
 function logical_and(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_and",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_and", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1021,24 +769,18 @@ end
 Elementwise left shift of input1 and input2. Axis of size 1 will be
 broadcast, as necessary.
 """
-function logical_left_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_left_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_left_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_left_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1048,21 +790,17 @@ end
 Elementwise logical NOT of input.
 """
 function logical_not(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_not",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_not", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1073,21 +811,17 @@ Elementwise logical OR of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_or(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_or",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_or", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1097,24 +831,18 @@ end
 Elementwise logical right shift of input1 by the amount specified in input2.
 Axis of size 1 will be broadcast, as necessary.
 """
-function logical_right_shift(
-    input1::Value, input2::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+function logical_right_shift(input1::Value, input2::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_right_shift",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_right_shift", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1125,21 +853,17 @@ Elementwise logical XOR of input1 and input2.  Axis of size 1 will be
 broadcast as necessary.
 """
 function logical_xor(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.logical_xor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.logical_xor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1150,26 +874,19 @@ Performs a two dimensional matrix multiplication. This allows both inputs to
 be activations, rather than reserving weights as an attribute in the
 FULLY_CONNECTED operator.
 """
-function matmul(
-    a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[c,]
-    operands = Value[a, b]
+function matmul(a::Value, b::Value; c::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[c, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.matmul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.matmul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1182,25 +899,17 @@ maximum value being placed in the
 output tensor.
 """
 function max_pool2d(input::Value; output::IR.Type, kernel, stride, pad, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kernel", kernel),
-        namedattribute("stride", stride),
-        namedattribute("pad", pad),
-    ]
-
-    return IR.create_operation(
-        "tosa.max_pool2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("kernel", kernel), namedattribute("stride", stride), namedattribute("pad", pad), ]
+    
+    IR.create_operation(
+        "tosa.max_pool2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1211,21 +920,17 @@ Elementwise max of input1 and input2. Axis of size 1 will be broadcast, as
 necessary.
 """
 function maximum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.maximum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.maximum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1236,21 +941,17 @@ Elementwise minimum of input1 and input2. Axis of size 1
 will be broadcast, as necessary.
 """
 function minimum(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.minimum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.minimum", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1262,21 +963,17 @@ Axis of size 1 will be broadcast, as necessary.
 i8/i16 input type can be promoted to i32 result type.
 """
 function mul(input1::Value, input2::Value; output::IR.Type, shift, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("shift", shift),]
-
-    return IR.create_operation(
-        "tosa.mul",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("shift", shift), ]
+    
+    IR.create_operation(
+        "tosa.mul", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1285,26 +982,19 @@ end
 
 Elementwise negation operation
 """
-function negate(
-    input1::Value; output::IR.Type, quantization_info=nothing, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input1,]
+function negate(input1::Value; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.negate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.negate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1329,32 +1019,20 @@ Example 2:
 \"tosa.pad\"(%arg0, %0)  : (tensor<1x2xf32>, tensor<2x2xi32>)  -> (tensor<?x9xf32>)
 ```
 """
-function pad(
-    input1::Value,
-    padding::Value,
-    pad_const=nothing::Union{Nothing,Value};
-    output::IR.Type,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input1, padding]
+function pad(input1::Value, padding::Value, pad_const=nothing::Union{Nothing, Value}; output::IR.Type, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input1, padding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(pad_const) && push!(operands, pad_const)
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1365,21 +1043,17 @@ Elementwise input1 raised to the power of input2.
 Axis of size 1 will be broadcast, as necessary.
 """
 function pow(input1::Value, input2::Value; z::IR.Type, location=Location())
-    results = IR.Type[z,]
-    operands = Value[input1, input2]
+    results = IR.Type[z, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.pow",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.pow", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1393,24 +1067,18 @@ tensor arguments. RFFT2D takes advantage of Hermitian symmetry to only
 calculate the first half of the final output axis. Imaginary values with
 locations (0,0), (0,W/2), (H/2,0) and (H/2,W/2) are zero.
 """
-function rfft2d(
-    input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location()
-)
-    results = IR.Type[output_real, output_imag]
-    operands = Value[input,]
+function rfft2d(input::Value; output_real::IR.Type, output_imag::IR.Type, location=Location())
+    results = IR.Type[output_real, output_imag, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rfft2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rfft2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1421,21 +1089,17 @@ Elementwise reciprocal operation. For integer operation, a TABLE should be
 used with the appropriate ranges.
 """
 function reciprocal(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.reciprocal",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reciprocal", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1444,25 +1108,19 @@ end
 
 Reduce a tensor along the given axis with a logical AND operation
 """
-function reduce_all(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_all(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_all",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_all", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1471,25 +1129,19 @@ end
 
 Reduce a tensor along the given axis with a logical OR operation
 """
-function reduce_any(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_any(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_any",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_any", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1498,25 +1150,19 @@ end
 
 Reduce a tensor along the given axis with a maximum operation
 """
-function reduce_max(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_max(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_max",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_max", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1525,25 +1171,19 @@ end
 
 Reduce a tensor along the given axis with a minimum operation
 """
-function reduce_min(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_min(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_min",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_min", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1552,25 +1192,19 @@ end
 
 Reduce a tensor along the given axis by computing the product of the axis.
 """
-function reduce_prod(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_prod(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_prod",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_prod", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1579,25 +1213,19 @@ end
 
 Reduce a tensor along the given axis by computing the sum of the axis.
 """
-function reduce_sum(
-    input::Value; output=nothing::Union{Nothing,IR.Type}, axis, location=Location()
-)
+function reduce_sum(input::Value; output=nothing::Union{Nothing, IR.Type}, axis, location=Location())
     results = IR.Type[]
-    operands = Value[input,]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reduce_sum",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reduce_sum", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1621,41 +1249,18 @@ signed 48 to 32         int48   int32
 unsigned 8 to signed 8  uint8   int8
 signed 8 to unsigned 8  int8    uint8
 """
-function rescale(
-    input::Value;
-    output::IR.Type,
-    input_zp,
-    output_zp,
-    multiplier,
-    shift,
-    scale32,
-    double_round,
-    per_channel,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function rescale(input::Value; output::IR.Type, input_zp, output_zp, multiplier, shift, scale32, double_round, per_channel, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("input_zp", input_zp),
-        namedattribute("output_zp", output_zp),
-        namedattribute("multiplier", multiplier),
-        namedattribute("shift", shift),
-        namedattribute("scale32", scale32),
-        namedattribute("double_round", double_round),
-        namedattribute("per_channel", per_channel),
-    ]
-
-    return IR.create_operation(
-        "tosa.rescale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("input_zp", input_zp), namedattribute("output_zp", output_zp), namedattribute("multiplier", multiplier), namedattribute("shift", shift), namedattribute("scale32", scale32), namedattribute("double_round", double_round), namedattribute("per_channel", per_channel), ]
+    
+    IR.create_operation(
+        "tosa.rescale", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1666,25 +1271,19 @@ Returns a tensor with the same type/values as the input, with a new shape
 specified by the shape argument. Reshape may operate on tensors of any rank.
 No data conversion happens during a reshape operation.
 """
-function reshape(
-    input1::Value; output=nothing::Union{Nothing,IR.Type}, new_shape, location=Location()
-)
+function reshape(input1::Value; output=nothing::Union{Nothing, IR.Type}, new_shape, location=Location())
     results = IR.Type[]
-    operands = Value[input1,]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("new_shape", new_shape),]
+    attributes = NamedAttribute[namedattribute("new_shape", new_shape), ]
     !isnothing(output) && push!(results, output)
-
-    return IR.create_operation(
-        "tosa.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1698,29 +1297,18 @@ output dimensions can be derived from the input dimensions by inverting the
 scale. And the [order_y, border_x] values adjust the output size to allow
 fractional sampling beyond integer input position (IH-1,IW-1).
 """
-function resize(
-    input::Value; output::IR.Type, scale, offset, border, mode, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[input,]
+function resize(input::Value; output::IR.Type, scale, offset, border, mode, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("scale", scale),
-        namedattribute("offset", offset),
-        namedattribute("border", border),
-        namedattribute("mode", mode),
-    ]
-
-    return IR.create_operation(
-        "tosa.resize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("scale", scale), namedattribute("offset", offset), namedattribute("border", border), namedattribute("mode", mode), ]
+    
+    IR.create_operation(
+        "tosa.resize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1732,21 +1320,17 @@ reversed along the given axis. No data conversion happens during a reverse
 operation.
 """
 function reverse(input::Value; output::IR.Type, axis, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("axis", axis),]
-
-    return IR.create_operation(
-        "tosa.reverse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("axis", axis), ]
+    
+    IR.create_operation(
+        "tosa.reverse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1757,21 +1341,17 @@ Elementwise reciprocal square root operation. For integer operation, a TABLE
 should be used with the appropriate ranges.
 """
 function rsqrt(input1::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1781,24 +1361,18 @@ end
 The values_out tensor is set to the values_in tensor with data modified as follows:
 data from the input tensor is inserted at the positions specified by the indices tensor.
 """
-function scatter(
-    values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location()
-)
-    results = IR.Type[values_out,]
-    operands = Value[values_in, indices, input]
+function scatter(values_in::Value, indices::Value, input::Value; values_out::IR.Type, location=Location())
+    results = IR.Type[values_out, ]
+    operands = Value[values_in, indices, input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1807,24 +1381,18 @@ end
 
 Elementwise select of the output based on a condition.
 """
-function select(
-    pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location()
-)
-    results = IR.Type[output,]
-    operands = Value[pred, on_true, on_false]
+function select(pred::Value, on_true::Value, on_false::Value; output::IR.Type, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[pred, on_true, on_false, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1838,21 +1406,17 @@ with the following definition.  The sigmoid table has 513 entries each of
 in steps of 1/16.
 """
 function sigmoid(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sigmoid",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sigmoid", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1864,23 +1428,17 @@ start coordinates, and extending for size elements in each direction.  No
 data conversion happens during a slice operation.
 """
 function slice(input::Value; output::IR.Type, start, size, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("start", start), namedattribute("size", size)
-    ]
-
-    return IR.create_operation(
-        "tosa.slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("start", start), namedattribute("size", size), ]
+    
+    IR.create_operation(
+        "tosa.slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1891,21 +1449,17 @@ Elementwise subtraction of input1 and input2. Axis of size 1 will be
 broadcast as necessary.
 """
 function sub(input1::Value, input2::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, input2]
+    results = IR.Type[output, ]
+    operands = Value[input1, input2, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.sub",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.sub", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1928,21 +1482,17 @@ The TABLE operator is expected to be used as follows:
   RESCALE with a right shift of 15
 """
 function table(input::Value, table::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input, table]
+    results = IR.Type[output, ]
+    operands = Value[input, table, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.table",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.table", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1955,21 +1505,17 @@ with the following definition.  The tanh_table has 513 entries each of
 16-bit precision and covering the input range -8.0 to +8.0 in steps of 1/32.
 """
 function tanh(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.tanh",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.tanh", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1979,21 +1525,17 @@ end
 Replicates input 0 multiplies times along each dimension.
 """
 function tile(input1::Value; output::IR.Type, multiples, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1,]
+    results = IR.Type[output, ]
+    operands = Value[input1, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("multiples", multiples),]
-
-    return IR.create_operation(
-        "tosa.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("multiples", multiples), ]
+    
+    IR.create_operation(
+        "tosa.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2003,38 +1545,19 @@ end
 Performs a 2D transposed convolution over the given tensor input, using the
 weights tensor.
 """
-function transpose_conv2d(
-    input::Value,
-    filter::Value,
-    bias::Value;
-    output::IR.Type,
-    out_pad,
-    stride,
-    out_shape,
-    quantization_info=nothing,
-    location=Location(),
-)
-    results = IR.Type[output,]
-    operands = Value[input, filter, bias]
+function transpose_conv2d(input::Value, filter::Value, bias::Value; output::IR.Type, out_pad, stride, out_shape, quantization_info=nothing, location=Location())
+    results = IR.Type[output, ]
+    operands = Value[input, filter, bias, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("out_pad", out_pad),
-        namedattribute("stride", stride),
-        namedattribute("out_shape", out_shape),
-    ]
-    !isnothing(quantization_info) &&
-        push!(attributes, namedattribute("quantization_info", quantization_info))
-
-    return IR.create_operation(
-        "tosa.transpose_conv2d",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("out_pad", out_pad), namedattribute("stride", stride), namedattribute("out_shape", out_shape), ]
+    !isnothing(quantization_info) && push!(attributes, namedattribute("quantization_info", quantization_info))
+    
+    IR.create_operation(
+        "tosa.transpose_conv2d", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2044,21 +1567,17 @@ end
 Permutes the dimensions based on perm.
 """
 function transpose(input1::Value, perms::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input1, perms]
+    results = IR.Type[output, ]
+    operands = Value[input1, perms, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2070,28 +1589,18 @@ exits to another control point. This action is performed repeatedly after
 updating and re-evaluating the Boolean condition every iteration. This
 implements the semantic foreach or while iterative loop structure.
 """
-function while_loop(
-    inputs::Vector{Value};
-    output::Vector{IR.Type},
-    cond::Region,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[output...,]
-    operands = Value[inputs...,]
-    owned_regions = Region[cond, body]
+function while_loop(inputs::Vector{Value}; output::Vector{IR.Type}, cond::Region, body::Region, location=Location())
+    results = IR.Type[output..., ]
+    operands = Value[inputs..., ]
+    owned_regions = Region[cond, body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.while_loop",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.while_loop", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2104,20 +1613,16 @@ but produces no results of its own.
 """
 function yield(inputs::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[inputs...,]
+    operands = Value[inputs..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "tosa.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "tosa.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Transform.jl
+++ b/src/Dialects/17/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -33,24 +33,37 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
+function affine_simplify_bounded_affine_ops(
+    target::Value,
+    bounded_values::Vector{Value};
+    lower_bounds,
+    upper_bounds,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, bounded_values..., ]
+    operands = Value[target, bounded_values...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
-    
-    IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("lower_bounds", lower_bounds),
+        namedattribute("upper_bounds", upper_bounds),
+    ]
+
+    return IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `bufferization_buffer_loop_hoisting`
@@ -63,16 +76,20 @@ This transform reads the `target` handle and modifies the payload.
 """
 function bufferization_buffer_loop_hoisting(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.bufferization.buffer_loop_hoisting", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.bufferization.buffer_loop_hoisting",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -121,16 +138,20 @@ not produce any handle.
 """
 function bufferization_eliminate_empty_tensors(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.bufferization.eliminate_empty_tensors", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.bufferization.eliminate_empty_tensors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -145,18 +166,24 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function bufferization_empty_tensor_to_alloc_tensor(
+    target::Value; transformed::IR.Type, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -184,32 +211,61 @@ otherwise, said ops would be considered non-bufferizable.
 This operation consumes the `target` handle and produces the `transformed`
 handle.
 """
-function bufferization_one_shot_bufferize(target::Value; transformed::IR.Type, function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, test_analysis_only=nothing, print_conflicts=nothing, memcpy_op=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function bufferization_one_shot_bufferize(
+    target::Value;
+    transformed::IR.Type,
+    function_boundary_type_conversion=nothing,
+    allow_return_allocs=nothing,
+    allow_unknown_ops=nothing,
+    bufferize_function_boundaries=nothing,
+    create_deallocs=nothing,
+    test_analysis_only=nothing,
+    print_conflicts=nothing,
+    memcpy_op=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
-    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
-    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    !isnothing(function_boundary_type_conversion) && push!(
+        attributes,
+        namedattribute(
+            "function_boundary_type_conversion", function_boundary_type_conversion
+        ),
+    )
+    !isnothing(allow_return_allocs) &&
+        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) &&
+        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(
+        attributes,
+        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
+    )
+    !isnothing(create_deallocs) &&
+        push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(test_analysis_only) &&
+        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) &&
+        push!(attributes, namedattribute("print_conflicts", print_conflicts))
     !isnothing(memcpy_op) && push!(attributes, namedattribute("memcpy_op", memcpy_op))
-    
-    IR.create_operation(
-        "transform.bufferization.one_shot_bufferize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.bufferization.one_shot_bufferize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_patterns_gpu_eliminate_barriers`
@@ -244,12 +300,16 @@ function apply_patterns_gpu_eliminate_barriers(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.gpu.eliminate_barriers", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.gpu.eliminate_barriers",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -291,20 +351,31 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_forall_to_blocks(target::Value; result::IR.Type, grid_dims=nothing, generate_gpu_launch=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+function gpu_map_forall_to_blocks(
+    target::Value;
+    result::IR.Type,
+    grid_dims=nothing,
+    generate_gpu_launch=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(grid_dims) && push!(attributes, namedattribute("grid_dims", grid_dims))
-    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-    
-    IR.create_operation(
-        "transform.gpu.map_forall_to_blocks", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(generate_gpu_launch) &&
+        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+
+    return IR.create_operation(
+        "transform.gpu.map_forall_to_blocks",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -399,27 +470,39 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_forall_to_threads(target::Value; result::IR.Type, block_dims=nothing, warp_dims=nothing, sync_after_distribute=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+function gpu_map_nested_forall_to_threads(
+    target::Value;
+    result::IR.Type,
+    block_dims=nothing,
+    warp_dims=nothing,
+    sync_after_distribute=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(block_dims) && push!(attributes, namedattribute("block_dims", block_dims))
     !isnothing(warp_dims) && push!(attributes, namedattribute("warp_dims", warp_dims))
-    !isnothing(sync_after_distribute) && push!(attributes, namedattribute("sync_after_distribute", sync_after_distribute))
-    
-    IR.create_operation(
-        "transform.gpu.map_nested_forall_to_threads", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(sync_after_distribute) &&
+        push!(attributes, namedattribute("sync_after_distribute", sync_after_distribute))
+
+    return IR.create_operation(
+        "transform.gpu.map_nested_forall_to_threads",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `match_structured_body`
@@ -452,21 +535,32 @@ Succeeds if the operation body satisfies the specified criteria, produces a
 silenceable failure otherwise. Produces a definite failure if the operand is
 not associated with a single payload op.
 """
-function match_structured_body(operand_handle::Value; reduction_position=nothing, passthrough=nothing, contraction=nothing, location=Location())
+function match_structured_body(
+    operand_handle::Value;
+    reduction_position=nothing,
+    passthrough=nothing,
+    contraction=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_handle, ]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(reduction_position) && push!(attributes, namedattribute("reduction_position", reduction_position))
+    !isnothing(reduction_position) &&
+        push!(attributes, namedattribute("reduction_position", reduction_position))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(contraction) && push!(attributes, namedattribute("contraction", contraction))
-    
-    IR.create_operation(
-        "transform.match.structured.body", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.body",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -498,18 +592,29 @@ to have been already checked for being a single structured op.
 Succeeds if the operation has the contraction-like dimensions, produces a
 silenceable failure otherwise.
 """
-function match_structured_classify_contraction_dims(operand_handle::Value; batch::IR.Type, m::IR.Type, n::IR.Type, k::IR.Type, location=Location())
-    results = IR.Type[batch, m, n, k, ]
-    operands = Value[operand_handle, ]
+function match_structured_classify_contraction_dims(
+    operand_handle::Value;
+    batch::IR.Type,
+    m::IR.Type,
+    n::IR.Type,
+    k::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[batch, m, n, k]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.match.structured.classify_contraction_dims", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.classify_contraction_dims",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -562,23 +667,36 @@ Succeeds if the specified dimensions satisfy the specified criteria,
 produces a silenceable failure otherwise. Produces a definite failure if
 the operand is not associated with a single payload op.
 """
-function match_structured_dim(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_dim_list, is_inverted=nothing, is_all=nothing, parallel=nothing, reduction=nothing, location=Location())
+function match_structured_dim(
+    operand_handle::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    raw_dim_list,
+    is_inverted=nothing,
+    is_all=nothing,
+    parallel=nothing,
+    reduction=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_handle, ]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_dim_list", raw_dim_list), ]
+    attributes = NamedAttribute[namedattribute("raw_dim_list", raw_dim_list),]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(parallel) && push!(attributes, namedattribute("parallel", parallel))
     !isnothing(reduction) && push!(attributes, namedattribute("reduction", reduction))
-    
-    IR.create_operation(
-        "transform.match.structured.dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -597,18 +715,24 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one payload value of
 `ShapedType`. Produces a silenceable failure otherwise.
 """
-function match_structured_elemental_bitwidth(operand_handle::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand_handle, ]
+function match_structured_elemental_bitwidth(
+    operand_handle::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.match.structured.elemental_bitwidth", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.elemental_bitwidth",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -673,23 +797,37 @@ failure otherwise. Additionally, when the result is an operation handle,
 produces a silenceable failure if the init(outs) specification defines
 more than one init(outs) or if the operand is not an operation result.
 """
-function match_structured_init(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_position_list, is_inverted=nothing, is_all=nothing, permutation=nothing, projected_permutation=nothing, location=Location())
+function match_structured_init(
+    operand_handle::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    raw_position_list,
+    is_inverted=nothing,
+    is_all=nothing,
+    permutation=nothing,
+    projected_permutation=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_handle, ]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list), ]
+    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list),]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(permutation) && push!(attributes, namedattribute("permutation", permutation))
-    !isnothing(projected_permutation) && push!(attributes, namedattribute("projected_permutation", projected_permutation))
-    
-    IR.create_operation(
-        "transform.match.structured.init", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(projected_permutation) &&
+        push!(attributes, namedattribute("projected_permutation", projected_permutation))
+
+    return IR.create_operation(
+        "transform.match.structured.init",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -755,23 +893,37 @@ otherwise. Additionally, when the result is an operation handle, produces a
 silenceable failure if the input specification defines more than one input
 or if the operand is not an operation result.
 """
-function match_structured_input(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_position_list, is_inverted=nothing, is_all=nothing, permutation=nothing, projected_permutation=nothing, location=Location())
+function match_structured_input(
+    operand_handle::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    raw_position_list,
+    is_inverted=nothing,
+    is_all=nothing,
+    permutation=nothing,
+    projected_permutation=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[operand_handle, ]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list), ]
+    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list),]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(permutation) && push!(attributes, namedattribute("permutation", permutation))
-    !isnothing(projected_permutation) && push!(attributes, namedattribute("projected_permutation", projected_permutation))
-    
-    IR.create_operation(
-        "transform.match.structured.input", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(projected_permutation) &&
+        push!(attributes, namedattribute("projected_permutation", projected_permutation))
+
+    return IR.create_operation(
+        "transform.match.structured.input",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -793,18 +945,24 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
-function match_structured_num_inits(operand_handle::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand_handle, ]
+function match_structured_num_inits(
+    operand_handle::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.match.structured.num_inits", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.num_inits",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -826,18 +984,24 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
-function match_structured_num_inputs(operand_handle::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand_handle, ]
+function match_structured_num_inputs(
+    operand_handle::Value; result::IR.Type, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.match.structured.num_inputs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.num_inputs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -878,19 +1042,31 @@ in \"suppress\" mode as long as the operand handle is associated with exactly
 one payload operation. It produces a definite failure when the handle is
 not associated with exactly one payload operation.
 """
-function match_structured(current::Value; outputs::Vector{IR.Type}, failure_propagation_mode=nothing, body_region::Region, location=Location())
-    results = IR.Type[outputs..., ]
-    operands = Value[current, ]
-    owned_regions = Region[body_region, ]
+function match_structured(
+    current::Value;
+    outputs::Vector{IR.Type},
+    failure_propagation_mode=nothing,
+    body_region::Region,
+    location=Location(),
+)
+    results = IR.Type[outputs...,]
+    operands = Value[current,]
+    owned_regions = Region[body_region,]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(failure_propagation_mode) && push!(attributes, namedattribute("failure_propagation_mode", failure_propagation_mode))
-    
-    IR.create_operation(
-        "transform.match.structured", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(failure_propagation_mode) && push!(
+        attributes, namedattribute("failure_propagation_mode", failure_propagation_mode)
+    )
+
+    return IR.create_operation(
+        "transform.match.structured",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -913,17 +1089,21 @@ Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
 function match_structured_rank(operand_handle::Value; rank::IR.Type, location=Location())
-    results = IR.Type[rank, ]
-    operands = Value[operand_handle, ]
+    results = IR.Type[rank,]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.match.structured.rank", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.rank",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -959,20 +1139,31 @@ to have been already checked for being a single structured op.
 Succeeds if the position is in bounds and if the user operation could be
 found when requested. Produces a silenceable failure otherwise.
 """
-function match_structured_result(operand_handle::Value; result::IR.Type, position, any=nothing, single=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[operand_handle, ]
+function match_structured_result(
+    operand_handle::Value;
+    result::IR.Type,
+    position,
+    any=nothing,
+    single=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(any) && push!(attributes, namedattribute("any", any))
     !isnothing(single) && push!(attributes, namedattribute("single", single))
-    
-    IR.create_operation(
-        "transform.match.structured.result", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -984,22 +1175,26 @@ parent op. Always succeeds.
 """
 function match_structured_yield(handles::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[handles..., ]
+    operands = Value[handles...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.match.structured.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.match.structured.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_patterns_linalg_erase_unnecessary_inputs`
@@ -1013,12 +1208,16 @@ function apply_patterns_linalg_erase_unnecessary_inputs(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.linalg.erase_unnecessary_inputs", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.linalg.erase_unnecessary_inputs",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1034,12 +1233,16 @@ function apply_patterns_linalg_fold_unit_extent_dims_via_reshapes(; location=Loc
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1055,12 +1258,16 @@ function apply_patterns_linalg_fold_unit_extent_dims_via_slices(; location=Locat
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1075,12 +1282,16 @@ function apply_patterns_linalg_tiling_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.linalg.tiling_canonicalization", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.linalg.tiling_canonicalization",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1145,22 +1356,39 @@ op are bufferized to a new memory allocation, but not the op itself.
 This operation consumes the `target` handle and produces the
 `allocated_buffer` and `new_ops` handles. It always succeeds.
 """
-function structured_bufferize_to_allocation(target::Value; allocated_buffer::IR.Type, new_ops::IR.Type, memory_space=nothing, memcpy_op=nothing, alloc_op=nothing, bufferize_destination_only=nothing, location=Location())
-    results = IR.Type[allocated_buffer, new_ops, ]
-    operands = Value[target, ]
+function structured_bufferize_to_allocation(
+    target::Value;
+    allocated_buffer::IR.Type,
+    new_ops::IR.Type,
+    memory_space=nothing,
+    memcpy_op=nothing,
+    alloc_op=nothing,
+    bufferize_destination_only=nothing,
+    location=Location(),
+)
+    results = IR.Type[allocated_buffer, new_ops]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
+    !isnothing(memory_space) &&
+        push!(attributes, namedattribute("memory_space", memory_space))
     !isnothing(memcpy_op) && push!(attributes, namedattribute("memcpy_op", memcpy_op))
     !isnothing(alloc_op) && push!(attributes, namedattribute("alloc_op", alloc_op))
-    !isnothing(bufferize_destination_only) && push!(attributes, namedattribute("bufferize_destination_only", bufferize_destination_only))
-    
-    IR.create_operation(
-        "transform.structured.bufferize_to_allocation", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(bufferize_destination_only) && push!(
+        attributes,
+        namedattribute("bufferize_destination_only", bufferize_destination_only),
+    )
+
+    return IR.create_operation(
+        "transform.structured.bufferize_to_allocation",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1212,18 +1440,24 @@ Returns two handles:
 Returns a definite failure if target is not isolated from above.
 Returns a silenceable failure if the pattern application failed.
 """
-function structured_convert_conv2d_to_img2col(target::Value; img2col_tensor::IR.Type, transformed::IR.Type, location=Location())
-    results = IR.Type[img2col_tensor, transformed, ]
-    operands = Value[target, ]
+function structured_convert_conv2d_to_img2col(
+    target::Value; img2col_tensor::IR.Type, transformed::IR.Type, location=Location()
+)
+    results = IR.Type[img2col_tensor, transformed]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.convert_conv2d_to_img2col", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.convert_conv2d_to_img2col",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1232,18 +1466,24 @@ end
 
 TODO
 """
-function structured_decompose_interface(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_decompose_interface(
+    target::Value; transformed::IR.Type, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.decompose_interface", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.decompose_interface",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1263,17 +1503,21 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.decompose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.decompose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1333,16 +1577,20 @@ not produce any handle.
 """
 function structured_eliminate_empty_tensors(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.eliminate_empty_tensors", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.eliminate_empty_tensors",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1381,18 +1629,28 @@ op are rejected by this operation.
 This operation consumes the producer handle.
 This operation only reads the containing op handle.
 """
-function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, new_containing_op::IR.Type, location=Location())
-    results = IR.Type[fused_op, new_containing_op, ]
-    operands = Value[producer_op, containing_op, ]
+function structured_fuse_into_containing_op(
+    producer_op::Value,
+    containing_op::Value;
+    fused_op::IR.Type,
+    new_containing_op::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[fused_op, new_containing_op]
+    operands = Value[producer_op, containing_op]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.fuse_into_containing_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.fuse_into_containing_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1402,20 +1660,32 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
-    results = IR.Type[transformed, loops..., ]
-    operands = Value[target, ]
+function structured_fuse(
+    target::Value;
+    transformed::IR.Type,
+    loops::Vector{IR.Type},
+    tile_sizes=nothing,
+    tile_interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed, loops...]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
-    
-    IR.create_operation(
-        "transform.structured.fuse", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(tile_interchange) &&
+        push!(attributes, namedattribute("tile_interchange", tile_interchange))
+
+    return IR.create_operation(
+        "transform.structured.fuse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1435,17 +1705,21 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.generalize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.generalize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1467,19 +1741,29 @@ If any non-tensor.pad is passed, the transform emits a silenceable failure.
 The return handle points to only the subset of successfully created packing
 loop nests, which can be empty.
 """
-function structured_hoist_pad_build_packing_loop_nest(target::Value, loop::Value; packing_loop::IR.Type, transpose=nothing, location=Location())
-    results = IR.Type[packing_loop, ]
-    operands = Value[target, loop, ]
+function structured_hoist_pad_build_packing_loop_nest(
+    target::Value,
+    loop::Value;
+    packing_loop::IR.Type,
+    transpose=nothing,
+    location=Location(),
+)
+    results = IR.Type[packing_loop,]
+    operands = Value[target, loop]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-    
-    IR.create_operation(
-        "transform.structured.hoist_pad.build_packing_loop_nest", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.hoist_pad.build_packing_loop_nest",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1504,19 +1788,25 @@ transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully hoisted 
 tensor.pad operations, which can be empty.
 """
-function structured_hoist_pad(target::Value; transformed::IR.Type, num_loops, transpose=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_hoist_pad(
+    target::Value; transformed::IR.Type, num_loops, transpose=nothing, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-    
-    IR.create_operation(
-        "transform.structured.hoist_pad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.hoist_pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1545,16 +1835,20 @@ The operation always succeeds and returns nothing.
 """
 function structured_hoist_redundant_tensor_subsets(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.hoist_redundant_tensor_subsets", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.hoist_redundant_tensor_subsets",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1578,18 +1872,24 @@ TODO: obsolete and should be retired.
 The operation always succeeds and returns a handle to the transformed
 function op.
 """
-function structured_hoist_redundant_vector_transfers(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_hoist_redundant_vector_transfers(
+    target::Value; transformed::IR.Type, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.hoist_redundant_vector_transfers", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.hoist_redundant_vector_transfers",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1608,18 +1908,24 @@ op (i.e. do not create an additional linalg.copy op).
 The operation always succeeds and returns a handle to the relevant 
 linalg.copy op.
 """
-function structured_insert_slice_to_copy(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_insert_slice_to_copy(
+    target::Value; transformed::IR.Type, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.insert_slice_to_copy", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.insert_slice_to_copy",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1639,19 +1945,26 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_interchange(
+    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-    
-    IR.create_operation(
-        "transform.structured.interchange", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(iterator_interchange) &&
+        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+
+    return IR.create_operation(
+        "transform.structured.interchange",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1669,18 +1982,28 @@ If all the operations referred to by the `target` are rewritten, the
 transform succeeds.
 Return handles to the newly produced pad, expand_shape and transpose ops.
 """
-function structured_lower_pack(target::Value; pad_op::IR.Type, expand_shape_op::IR.Type, transpose_op::IR.Type, location=Location())
-    results = IR.Type[pad_op, expand_shape_op, transpose_op, ]
-    operands = Value[target, ]
+function structured_lower_pack(
+    target::Value;
+    pad_op::IR.Type,
+    expand_shape_op::IR.Type,
+    transpose_op::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[pad_op, expand_shape_op, transpose_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.lower_pack", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.lower_pack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1699,18 +2022,29 @@ If all the operations referred to by the `target` are rewritten, the
 transform succeeds.
 Return handles to the newly produced empty, transpose, collapse_shape and extract_slice ops.
 """
-function structured_lower_unpack(target::Value; empty_op::IR.Type, transpose_op::IR.Type, collapse_shape_op::IR.Type, extract_slice_op::IR.Type, location=Location())
-    results = IR.Type[empty_op, transpose_op, collapse_shape_op, extract_slice_op, ]
-    operands = Value[target, ]
+function structured_lower_unpack(
+    target::Value;
+    empty_op::IR.Type,
+    transpose_op::IR.Type,
+    collapse_shape_op::IR.Type,
+    extract_slice_op::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[empty_op, transpose_op, collapse_shape_op, extract_slice_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.lower_unpack", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.lower_unpack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1737,18 +2071,32 @@ linalg.copy / tensor.pad) among the targeted op. Otherwise, the operation
 always succeeds and returns a handle to the relevant tiled linalg.copy /
 tensor.pad op and the enclosing scf.forall op.
 """
-function structured_gpu_map_copy_to_threads(target::Value; forall_op::IR.Type, tiled_op::IR.Type, total_num_threads, desired_bit_alignment, location=Location())
-    results = IR.Type[forall_op, tiled_op, ]
-    operands = Value[target, ]
+function structured_gpu_map_copy_to_threads(
+    target::Value;
+    forall_op::IR.Type,
+    tiled_op::IR.Type,
+    total_num_threads,
+    desired_bit_alignment,
+    location=Location(),
+)
+    results = IR.Type[forall_op, tiled_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("total_num_threads", total_num_threads), namedattribute("desired_bit_alignment", desired_bit_alignment), ]
-    
-    IR.create_operation(
-        "transform.structured.gpu.map_copy_to_threads", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("total_num_threads", total_num_threads),
+        namedattribute("desired_bit_alignment", desired_bit_alignment),
+    ]
+
+    return IR.create_operation(
+        "transform.structured.gpu.map_copy_to_threads",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1775,21 +2123,35 @@ values) do not satisfy the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; vectorize_nd_extract=nothing, scalable_sizes=nothing, static_vector_sizes=nothing, location=Location())
+function structured_masked_vectorize(
+    target::Value,
+    vector_sizes::Vector{Value};
+    vectorize_nd_extract=nothing,
+    scalable_sizes=nothing,
+    static_vector_sizes=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[target, vector_sizes..., ]
+    operands = Value[target, vector_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(scalable_sizes) && push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
-    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-    
-    IR.create_operation(
-        "transform.structured.masked_vectorize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(vectorize_nd_extract) &&
+        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(scalable_sizes) &&
+        push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
+    !isnothing(static_vector_sizes) &&
+        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+
+    return IR.create_operation(
+        "transform.structured.masked_vectorize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1823,22 +2185,35 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
-    results = IR.Type[results_, ]
-    operands = Value[target, ]
+function structured_match(
+    target::Value;
+    results::IR.Type,
+    ops=nothing,
+    interface=nothing,
+    op_attrs=nothing,
+    filter_result_type=nothing,
+    location=Location(),
+)
+    results = IR.Type[results,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
-    
-    IR.create_operation(
-        "transform.structured.match", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(filter_result_type) &&
+        push!(attributes, namedattribute("filter_result_type", filter_result_type))
+
+    return IR.create_operation(
+        "transform.structured.match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1898,19 +2273,34 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
-    results = IR.Type[low_size, high_size, split_point, ]
-    operands = Value[target, ]
+function structured_multitile_sizes(
+    target::Value;
+    low_size::IR.Type,
+    high_size::IR.Type,
+    split_point::IR.Type,
+    dimension,
+    target_size,
+    divisor=nothing,
+    location=Location(),
+)
+    results = IR.Type[low_size, high_size, split_point]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
+    attributes = NamedAttribute[
+        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
+    ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-    
-    IR.create_operation(
-        "transform.structured.multitile_sizes", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.multitile_sizes",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1971,21 +2361,43 @@ This operation ignores non-Linalg ops and drops them in the return.
 It returns the list of packed Linalg ops or the original op when all available
 packing strategies failed to apply.
 """
-function structured_pack_greedily(target::Value, matmul_packed_sizes::Vector{Value}; packed_op::IR.Type, static_matmul_packed_sizes=nothing, matmul_padded_sizes_next_multiple_of=nothing, matmul_inner_dims_order=nothing, location=Location())
-    results = IR.Type[packed_op, ]
-    operands = Value[target, matmul_packed_sizes..., ]
+function structured_pack_greedily(
+    target::Value,
+    matmul_packed_sizes::Vector{Value};
+    packed_op::IR.Type,
+    static_matmul_packed_sizes=nothing,
+    matmul_padded_sizes_next_multiple_of=nothing,
+    matmul_inner_dims_order=nothing,
+    location=Location(),
+)
+    results = IR.Type[packed_op,]
+    operands = Value[target, matmul_packed_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_matmul_packed_sizes) && push!(attributes, namedattribute("static_matmul_packed_sizes", static_matmul_packed_sizes))
-    !isnothing(matmul_padded_sizes_next_multiple_of) && push!(attributes, namedattribute("matmul_padded_sizes_next_multiple_of", matmul_padded_sizes_next_multiple_of))
-    !isnothing(matmul_inner_dims_order) && push!(attributes, namedattribute("matmul_inner_dims_order", matmul_inner_dims_order))
-    
-    IR.create_operation(
-        "transform.structured.pack_greedily", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(static_matmul_packed_sizes) && push!(
+        attributes,
+        namedattribute("static_matmul_packed_sizes", static_matmul_packed_sizes),
+    )
+    !isnothing(matmul_padded_sizes_next_multiple_of) && push!(
+        attributes,
+        namedattribute(
+            "matmul_padded_sizes_next_multiple_of", matmul_padded_sizes_next_multiple_of
+        ),
+    )
+    !isnothing(matmul_inner_dims_order) && push!(
+        attributes, namedattribute("matmul_inner_dims_order", matmul_inner_dims_order)
+    )
+
+    return IR.create_operation(
+        "transform.structured.pack_greedily",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2050,19 +2462,30 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
-    results = IR.Type[packed_op, ]
-    operands = Value[target, packed_sizes..., ]
+function structured_pack(
+    target::Value,
+    packed_sizes::Vector{Value};
+    packed_op::IR.Type,
+    static_packed_sizes=nothing,
+    location=Location(),
+)
+    results = IR.Type[packed_op,]
+    operands = Value[target, packed_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-    
-    IR.create_operation(
-        "transform.structured.pack", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(static_packed_sizes) &&
+        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+
+    return IR.create_operation(
+        "transform.structured.pack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2104,20 +2527,33 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
-    results = IR.Type[packed_op, pack_op, un_pack_op, ]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
+function structured_pack_transpose(
+    target_pack_or_un_pack_op::Value,
+    target_linalg_op::Value;
+    packed_op::IR.Type,
+    pack_op::IR.Type,
+    un_pack_op::IR.Type,
+    outer_perm=nothing,
+    inner_perm=nothing,
+    location=Location(),
+)
+    results = IR.Type[packed_op, pack_op, un_pack_op]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-    
-    IR.create_operation(
-        "transform.structured.pack_transpose", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.pack_transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2139,24 +2575,44 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(target::Value; padded::IR.Type, pad::IR.Type, padding_values=nothing, padding_dimensions=nothing, pad_to_multiple_of=nothing, pack_paddings=nothing, transpose_paddings=nothing, copy_back=nothing, location=Location())
-    results = IR.Type[padded, pad, ]
-    operands = Value[target, ]
+function structured_pad(
+    target::Value;
+    padded::IR.Type,
+    pad::IR.Type,
+    padding_values=nothing,
+    padding_dimensions=nothing,
+    pad_to_multiple_of=nothing,
+    pack_paddings=nothing,
+    transpose_paddings=nothing,
+    copy_back=nothing,
+    location=Location(),
+)
+    results = IR.Type[padded, pad]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pad_to_multiple_of) && push!(attributes, namedattribute("pad_to_multiple_of", pad_to_multiple_of))
-    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    !isnothing(padding_values) &&
+        push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) &&
+        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pad_to_multiple_of) &&
+        push!(attributes, namedattribute("pad_to_multiple_of", pad_to_multiple_of))
+    !isnothing(pack_paddings) &&
+        push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(transpose_paddings) &&
+        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
     !isnothing(copy_back) && push!(attributes, namedattribute("copy_back", copy_back))
-    
-    IR.create_operation(
-        "transform.structured.pad", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.pad",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2179,24 +2635,43 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, mapping=nothing, alignment=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_promote(
+    target::Value;
+    transformed::IR.Type,
+    operands_to_promote=nothing,
+    use_full_tile_buffers=nothing,
+    use_full_tiles_by_default=nothing,
+    use_alloca=nothing,
+    mapping=nothing,
+    alignment=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
+    !isnothing(operands_to_promote) &&
+        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) &&
+        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(
+        attributes,
+        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
+    )
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-    
-    IR.create_operation(
-        "transform.structured.promote", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.promote",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2213,18 +2688,24 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
-    results = IR.Type[replacement, ]
-    operands = Value[target, ]
-    owned_regions = Region[bodyRegion, ]
+function structured_replace(
+    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
+)
+    results = IR.Type[replacement,]
+    operands = Value[target,]
+    owned_regions = Region[bodyRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.replace", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.replace",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2251,18 +2732,24 @@ The return handle points to a subset of successfully produced operations:
   - `tensor.from_elements` case, the returned handle points to the last 
     `tensor.insert`.
 """
-function structured_rewrite_in_destination_passing_style(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_rewrite_in_destination_passing_style(
+    target::Value; transformed::IR.Type, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.rewrite_in_destination_passing_style", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.rewrite_in_destination_passing_style",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2291,17 +2778,21 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.structured.scalarize", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.scalarize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2326,19 +2817,34 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
-    results = IR.Type[first, second, ]
-    operands = Value[target, ]
+function structured_split(
+    target::Value,
+    dynamic_split_point=nothing::Union{Nothing,Value};
+    first::IR.Type,
+    second::IR.Type,
+    dimension,
+    static_split_point,
+    location=Location(),
+)
+    results = IR.Type[first, second]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
+    attributes = NamedAttribute[
+        namedattribute("dimension", dimension),
+        namedattribute("static_split_point", static_split_point),
+    ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-    
-    IR.create_operation(
-        "transform.structured.split", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.split",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2478,23 +2984,43 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_split_reduction(
+    target::Value;
+    init_or_alloc_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    split_factor=nothing,
+    insert_split_dimension=nothing,
+    inner_parallel=nothing,
+    use_scaling_algorithm=nothing,
+    use_alloc=nothing,
+    location=Location(),
+)
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) &&
+        push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) &&
+        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) &&
+        push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) &&
+        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-    
-    IR.create_operation(
-        "transform.structured.split_reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.split_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2537,21 +3063,36 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, scalable_sizes=nothing, location=Location())
-    results = IR.Type[tiled_linalg_op, loops..., ]
-    operands = Value[target, dynamic_sizes..., ]
+function structured_tile(
+    target::Value,
+    dynamic_sizes::Vector{Value};
+    tiled_linalg_op::IR.Type,
+    loops::Vector{IR.Type},
+    static_sizes=nothing,
+    interchange=nothing,
+    scalable_sizes=nothing,
+    location=Location(),
+)
+    results = IR.Type[tiled_linalg_op, loops...]
+    operands = Value[target, dynamic_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) &&
+        push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    !isnothing(scalable_sizes) && push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
-    
-    IR.create_operation(
-        "transform.structured.tile", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(scalable_sizes) &&
+        push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
+
+    return IR.create_operation(
+        "transform.structured.tile",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2622,21 +3163,35 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_forall(target::Value; forall_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
-    results = IR.Type[forall_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_tile_reduction_using_forall(
+    target::Value;
+    forall_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    num_threads=nothing,
+    tile_sizes=nothing,
+    mapping=nothing,
+    location=Location(),
+)
+    results = IR.Type[forall_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-    
-    IR.create_operation(
-        "transform.structured.tile_reduction_using_forall", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_reduction_using_forall",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2710,19 +3265,31 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
-    operands = Value[target, ]
+function structured_tile_reduction_using_scf(
+    target::Value;
+    for_op::IR.Type,
+    fill_op::IR.Type,
+    split_linalg_op::IR.Type,
+    combining_linalg_op::IR.Type,
+    tile_sizes=nothing,
+    location=Location(),
+)
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    
-    IR.create_operation(
-        "transform.structured.tile_reduction_using_scf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_reduction_using_scf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2783,24 +3350,56 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_forall_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_forall_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, forall_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
-    results = IR.Type[forall_op, tiled_op, ]
-    operands = Value[target, num_threads..., tile_sizes..., ]
+function structured_tile_to_forall_op(
+    target::Value,
+    num_threads::Vector{Value},
+    tile_sizes::Vector{Value},
+    packed_num_threads=nothing::Union{Nothing,Value};
+    packed_tile_sizes=nothing::Union{Nothing,Value},
+    forall_op::IR.Type,
+    tiled_op::IR.Type,
+    static_num_threads=nothing,
+    static_tile_sizes=nothing,
+    mapping=nothing,
+    location=Location(),
+)
+    results = IR.Type[forall_op, tiled_op]
+    operands = Value[target, num_threads..., tile_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), (packed_num_threads==nothing) ? 0 : 1(packed_tile_sizes==nothing) ? 0 : 1]))
-    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(
+        attributes,
+        operandsegmentsizes([
+            1,
+            length(num_threads),
+            length(tile_sizes),
+            if (packed_num_threads == nothing)
+                0
+            elseif 1(packed_tile_sizes == nothing)
+                0
+            else
+                1
+            end,
+        ]),
+    )
+    !isnothing(static_num_threads) &&
+        push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) &&
+        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-    
-    IR.create_operation(
-        "transform.structured.tile_to_forall_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_to_forall_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2843,20 +3442,33 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
-    results = IR.Type[tiled_linalg_op, loops..., ]
-    operands = Value[target, dynamic_sizes..., ]
+function structured_tile_to_scf_for(
+    target::Value,
+    dynamic_sizes::Vector{Value};
+    tiled_linalg_op::IR.Type,
+    loops::Vector{IR.Type},
+    static_sizes=nothing,
+    interchange=nothing,
+    location=Location(),
+)
+    results = IR.Type[tiled_linalg_op, loops...]
+    operands = Value[target, dynamic_sizes...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) &&
+        push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    
-    IR.create_operation(
-        "transform.structured.tile_to_scf_for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.structured.tile_to_scf_for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2897,28 +3509,54 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function structured_vectorize(
+    target::Value;
+    transformed::IR.Type,
+    vectorize_padding=nothing,
+    vectorize_nd_extract=nothing,
+    disable_multi_reduction_to_contract_patterns=nothing,
+    disable_transfer_permutation_map_lowering_patterns=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
-    
-    IR.create_operation(
-        "transform.structured.vectorize", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(vectorize_padding) &&
+        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) &&
+        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
+        attributes,
+        namedattribute(
+            "disable_multi_reduction_to_contract_patterns",
+            disable_multi_reduction_to_contract_patterns,
+        ),
+    )
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
+        attributes,
+        namedattribute(
+            "disable_transfer_permutation_map_lowering_patterns",
+            disable_transfer_permutation_map_lowering_patterns,
+        ),
+    )
+
+    return IR.create_operation(
+        "transform.structured.vectorize",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_patterns_memref_expand_ops`
@@ -2937,12 +3575,16 @@ function apply_patterns_memref_expand_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.memref.expand_ops", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.memref.expand_ops",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2958,12 +3600,16 @@ function apply_patterns_memref_expand_strided_metadata(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.memref.expand_strided_metadata", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.memref.expand_strided_metadata",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2991,12 +3637,16 @@ function apply_patterns_memref_extract_address_computations(; location=Location(
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.memref.extract_address_computations", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.memref.extract_address_computations",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3014,12 +3664,16 @@ function apply_patterns_memref_fold_memref_alias_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.memref.fold_memref_alias_ops", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.memref.fold_memref_alias_ops",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3036,12 +3690,16 @@ function apply_patterns_memref_resolve_ranked_shaped_type_result_dims(; location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.memref.resolve_ranked_shaped_type_result_dims", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.memref.resolve_ranked_shaped_type_result_dims",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3070,18 +3728,24 @@ Otherwise, the returned handle points to a subset of the produced ops:
 
 This transform op consumes the target handle and produces a result handle.
 """
-function memref_make_loop_independent(target::Value; transformed::IR.Type, num_loops, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function memref_make_loop_independent(
+    target::Value; transformed::IR.Type, num_loops, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
-    
-    IR.create_operation(
-        "transform.memref.make_loop_independent", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
+
+    return IR.create_operation(
+        "transform.memref.make_loop_independent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3102,25 +3766,32 @@ iterations.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(target::Value; transformed::IR.Type, factor, skip_analysis=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function memref_multibuffer(
+    target::Value; transformed::IR.Type, factor, skip_analysis=nothing, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor), ]
-    !isnothing(skip_analysis) && push!(attributes, namedattribute("skip_analysis", skip_analysis))
-    
-    IR.create_operation(
-        "transform.memref.multibuffer", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor),]
+    !isnothing(skip_analysis) &&
+        push!(attributes, namedattribute("skip_analysis", skip_analysis))
+
+    return IR.create_operation(
+        "transform.memref.multibuffer",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `nvgpu_create_async_groups`
@@ -3141,19 +3812,25 @@ This op consumes the `target` handle and produces the `result` handle, which
 is mapped to the same payload operations as the `target` handle. The op
 modifies the payload.
 """
-function nvgpu_create_async_groups(target::Value; result::IR.Type, bypass_l1=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+function nvgpu_create_async_groups(
+    target::Value; result::IR.Type, bypass_l1=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(bypass_l1) && push!(attributes, namedattribute("bypass_l1", bypass_l1))
-    
-    IR.create_operation(
-        "transform.nvgpu.create_async_groups", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.nvgpu.create_async_groups",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3191,20 +3868,34 @@ TODO: the shared memory part and behavior specific to NVGPU should be
 made orthogonal to pipelining so that `transform.loop.pipeline` becomes
 usable here.
 """
-function nvgpu_pipeline_shared_memory_copies(for_op::Value; result::IR.Type, depth, peel_epilogue=nothing, failure_propagation_mode=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[for_op, ]
+function nvgpu_pipeline_shared_memory_copies(
+    for_op::Value;
+    result::IR.Type,
+    depth,
+    peel_epilogue=nothing,
+    failure_propagation_mode=nothing,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[for_op,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("depth", depth), ]
-    !isnothing(peel_epilogue) && push!(attributes, namedattribute("peel_epilogue", peel_epilogue))
-    !isnothing(failure_propagation_mode) && push!(attributes, namedattribute("failure_propagation_mode", failure_propagation_mode))
-    
-    IR.create_operation(
-        "transform.nvgpu.pipeline_shared_memory_copies", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("depth", depth),]
+    !isnothing(peel_epilogue) &&
+        push!(attributes, namedattribute("peel_epilogue", peel_epilogue))
+    !isnothing(failure_propagation_mode) && push!(
+        attributes, namedattribute("failure_propagation_mode", failure_propagation_mode)
+    )
+
+    return IR.create_operation(
+        "transform.nvgpu.pipeline_shared_memory_copies",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3219,22 +3910,26 @@ unchanged.
 """
 function nvgpu_rewrite_matmul_as_mma_sync(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.nvgpu.rewrite_matmul_as_mma_sync", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.nvgpu.rewrite_matmul_as_mma_sync",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_patterns_scf_for_loop_canonicalization`
@@ -3249,12 +3944,16 @@ function apply_patterns_scf_for_loop_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.scf.for_loop_canonicalization", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.scf.for_loop_canonicalization",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3268,20 +3967,26 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
-    results = IR.Type[parent, ]
-    operands = Value[target, ]
+function loop_get_parent_for(
+    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
+)
+    results = IR.Type[parent,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-    
-    IR.create_operation(
-        "transform.loop.get_parent_for", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.loop.get_parent_for",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3297,17 +4002,21 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.loop.coalesce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.loop.coalesce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3331,18 +4040,24 @@ handle.
 
 Produces a definite failure if outlining failed for any of the targets.
 """
-function loop_outline(target::Value; function_::IR.Type, call::IR.Type, func_name, location=Location())
-    results = IR.Type[function_, call, ]
-    operands = Value[target, ]
+function loop_outline(
+    target::Value; function_::IR.Type, call::IR.Type, func_name, location=Location()
+)
+    results = IR.Type[function_, call]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
-    
-    IR.create_operation(
-        "transform.loop.outline", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name),]
+
+    return IR.create_operation(
+        "transform.loop.outline",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3370,19 +4085,31 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function loop_peel(
+    target::Value;
+    transformed::IR.Type,
+    fail_if_already_divisible=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
-    
-    IR.create_operation(
-        "transform.loop.peel", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fail_if_already_divisible) && push!(
+        attributes,
+        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
+    )
+
+    return IR.create_operation(
+        "transform.loop.peel",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3409,20 +4136,32 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function loop_pipeline(
+    target::Value;
+    transformed::IR.Type,
+    iteration_interval=nothing,
+    read_latency=nothing,
+    location=Location(),
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
-    
-    IR.create_operation(
-        "transform.loop.pipeline", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(iteration_interval) &&
+        push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) &&
+        push!(attributes, namedattribute("read_latency", read_latency))
+
+    return IR.create_operation(
+        "transform.loop.pipeline",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3441,16 +4180,20 @@ modifies the payload.
 """
 function loop_promote_if_one_iteration(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.loop.promote_if_one_iteration", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.loop.promote_if_one_iteration",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3473,16 +4216,20 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor), ]
-    
-    IR.create_operation(
-        "transform.loop.unroll", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor),]
+
+    return IR.create_operation(
+        "transform.loop.unroll",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3507,25 +4254,32 @@ The transform only consumes its operand and does not produce any result.
 The transform definitely fails if `take_else_branch` is specified and the
 `else` region is empty.
 """
-function scf_take_assumed_branch(target::Value; take_else_branch=nothing, location=Location())
+function scf_take_assumed_branch(
+    target::Value; take_else_branch=nothing, location=Location()
+)
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(take_else_branch) && push!(attributes, namedattribute("take_else_branch", take_else_branch))
-    
-    IR.create_operation(
-        "transform.scf.take_assumed_branch", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(take_else_branch) &&
+        push!(attributes, namedattribute("take_else_branch", take_else_branch))
+
+    return IR.create_operation(
+        "transform.scf.take_assumed_branch",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion`
@@ -3534,18 +4288,24 @@ Indicates that redundant tensor.insert_slice rank reductions should be
 dropped. E.g., cases where a tensor.extract_slice rank reduction immediately
 follows an inverse tensor.insert_slice rank expansion.
 """
-function apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion(; location=Location())
+function apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion(;
+    location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.drop_redundant_insert_slice_rank_expansion", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.drop_redundant_insert_slice_rank_expansion",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3561,12 +4321,16 @@ function apply_patterns_tensor_fold_into_pack_and_unpack(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.fold_into_pack_and_unpack", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.fold_into_pack_and_unpack",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3579,19 +4343,26 @@ folded into tensor.empty.
 If `fold_single_use_only` is set to \"true\", only tensor.empty that have a
 single use are folded.
 """
-function apply_patterns_tensor_fold_tensor_empty(; fold_single_use_only=nothing, location=Location())
+function apply_patterns_tensor_fold_tensor_empty(;
+    fold_single_use_only=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fold_single_use_only) && push!(attributes, namedattribute("fold_single_use_only", fold_single_use_only))
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_empty", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(fold_single_use_only) &&
+        push!(attributes, namedattribute("fold_single_use_only", fold_single_use_only))
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_empty",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3602,18 +4373,24 @@ Indicates that tensor.extract_slice -> vector.transfer_read and
 vector.transfer_write -> tensor.insert_slice op chains should be folded into
 vector tranfer read and write ops
 """
-function apply_patterns_tensor_fold_tensor_subset_ops_into_vector_transfers(; location=Location())
+function apply_patterns_tensor_fold_tensor_subset_ops_into_vector_transfers(;
+    location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_subset_ops_into_vector_transfers", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_subset_ops_into_vector_transfers",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3629,12 +4406,16 @@ function apply_patterns_tensor_fold_tensor_subset_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_subset_ops", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_subset_ops",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3651,12 +4432,16 @@ function apply_patterns_tensor_merge_consecutive_insert_extract_slice(; location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.merge_consecutive_insert_extract_slice", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.merge_consecutive_insert_extract_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3673,12 +4458,16 @@ function apply_patterns_tensor_reassociative_reshape_folding(; location=Location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.reassociative_reshape_folding", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.reassociative_reshape_folding",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3694,12 +4483,16 @@ function apply_patterns_tensor_rewrite_as_constant(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.tensor.rewrite_as_constant", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.tensor.rewrite_as_constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3731,24 +4524,30 @@ Otherwise, the returned handle points to a subset of the produced ops:
 
 This transform op consumes the target handle and produces a result handle.
 """
-function tensor_make_loop_independent(target::Value; transformed::IR.Type, num_loops, location=Location())
-    results = IR.Type[transformed, ]
-    operands = Value[target, ]
+function tensor_make_loop_independent(
+    target::Value; transformed::IR.Type, num_loops, location=Location()
+)
+    results = IR.Type[transformed,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
-    
-    IR.create_operation(
-        "transform.tensor.make_loop_independent", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
+
+    return IR.create_operation(
+        "transform.tensor.make_loop_independent",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `alternatives`
@@ -3811,19 +4610,28 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
-    results = IR.Type[results_..., ]
+function alternatives(
+    scope=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    alternatives::Vector{Region},
+    location=Location(),
+)
+    results = IR.Type[results...,]
     operands = Value[]
-    owned_regions = Region[alternatives..., ]
+    owned_regions = Region[alternatives...,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-    
-    IR.create_operation(
-        "transform.alternatives", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.alternatives",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3839,19 +4647,25 @@ the order within the handles.
 Fails silently if the length of the parameter payload does not match the length of
 the target payload. Does not consume the provided handles.
 """
-function annotate(target::Value, param=nothing::Union{Nothing, Value}; name, location=Location())
+function annotate(
+    target::Value, param=nothing::Union{Nothing,Value}; name, location=Location()
+)
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name), ]
+    attributes = NamedAttribute[namedattribute("name", name),]
     !isnothing(param) && push!(operands, param)
-    
-    IR.create_operation(
-        "transform.annotate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.annotate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3867,12 +4681,16 @@ function apply_patterns_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.canonicalization", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.canonicalization",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3890,16 +4708,20 @@ mapped to the same operation multiple times.
 """
 function apply_cse(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_cse", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_cse",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3918,16 +4740,20 @@ this transform may silently remove payload ops from handles.
 """
 function apply_dce(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_dce", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_dce",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3945,16 +4771,20 @@ This transform reads the target handle and modifies the payload.
 """
 function apply_licm(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_licm", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_licm",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -3988,19 +4818,25 @@ This transform also fails silently if the pattern application did not
 converge within the default number of iterations/rewrites of the greedy
 pattern rewrite driver.
 """
-function apply_patterns(target::Value; apply_cse=nothing, patterns::Region, location=Location())
+function apply_patterns(
+    target::Value; apply_cse=nothing, patterns::Region, location=Location()
+)
     results = IR.Type[]
-    operands = Value[target, ]
-    owned_regions = Region[patterns, ]
+    operands = Value[target,]
+    owned_regions = Region[patterns,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(apply_cse) && push!(attributes, namedattribute("apply_cse", apply_cse))
-    
-    IR.create_operation(
-        "transform.apply_patterns", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4019,19 +4855,25 @@ that they operate on, so the target op is guaranteed to still exist. The
 target handle is invalidated because a pass may arbitrarily modify the body
 of targeted ops.
 """
-function apply_registered_pass(target::Value; result::IR.Type, pass_name, options=nothing, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+function apply_registered_pass(
+    target::Value; result::IR.Type, pass_name, options=nothing, location=Location()
+)
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pass_name", pass_name), ]
+    attributes = NamedAttribute[namedattribute("pass_name", pass_name),]
     !isnothing(options) && push!(attributes, namedattribute("options", options))
-    
-    IR.create_operation(
-        "transform.apply_registered_pass", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_registered_pass",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4040,17 +4882,21 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output, ]
-    operands = Value[input, ]
+    results = IR.Type[output,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4106,18 +4952,26 @@ the resulting handle is associated with an empty payload. The operation
 produces a definite failure if any of the applied matchers or actions
 produced a definite failure.
 """
-function foreach_match(root::Value; updated::IR.Type, matchers, actions, location=Location())
-    results = IR.Type[updated, ]
-    operands = Value[root, ]
+function foreach_match(
+    root::Value; updated::IR.Type, matchers, actions, location=Location()
+)
+    results = IR.Type[updated,]
+    operands = Value[root,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("matchers", matchers), namedattribute("actions", actions), ]
-    
-    IR.create_operation(
-        "transform.foreach_match", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("matchers", matchers), namedattribute("actions", actions)
+    ]
+
+    return IR.create_operation(
+        "transform.foreach_match",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4143,18 +4997,22 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[target, ]
-    owned_regions = Region[body, ]
+function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results...,]
+    operands = Value[target,]
+    owned_regions = Region[body,]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.foreach", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.foreach",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4169,18 +5027,24 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
-    results = IR.Type[consumers, ]
-    operands = Value[target, ]
+function get_consumers_of_result(
+    target::Value; consumers::IR.Type, result_number, location=Location()
+)
+    results = IR.Type[consumers,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
-    
-    IR.create_operation(
-        "transform.get_consumers_of_result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number),]
+
+    return IR.create_operation(
+        "transform.get_consumers_of_result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4193,17 +5057,21 @@ the targeted value.
 This transform fails silently if the targeted value is a block argument.
 """
 function get_defining_op(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.get_defining_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.get_defining_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4229,21 +5097,33 @@ on the further transformation applied to the handle produced here.
 If any of the given Payload IR ops has no such suitable parent, the
 transformation fails silently.
 """
-function get_parent_op(target::Value; parent::IR.Type, isolated_from_above=nothing, op_name=nothing, deduplicate=nothing, location=Location())
-    results = IR.Type[parent, ]
-    operands = Value[target, ]
+function get_parent_op(
+    target::Value;
+    parent::IR.Type,
+    isolated_from_above=nothing,
+    op_name=nothing,
+    deduplicate=nothing,
+    location=Location(),
+)
+    results = IR.Type[parent,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(isolated_from_above) && push!(attributes, namedattribute("isolated_from_above", isolated_from_above))
+    !isnothing(isolated_from_above) &&
+        push!(attributes, namedattribute("isolated_from_above", isolated_from_above))
     !isnothing(op_name) && push!(attributes, namedattribute("op_name", op_name))
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-    
-    IR.create_operation(
-        "transform.get_parent_op", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.get_parent_op",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4257,18 +5137,24 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
-    results = IR.Type[producer, ]
-    operands = Value[target, ]
+function get_producer_of_operand(
+    target::Value; producer::IR.Type, operand_number, location=Location()
+)
+    results = IR.Type[producer,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
-    
-    IR.create_operation(
-        "transform.get_producer_of_operand", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
+
+    return IR.create_operation(
+        "transform.get_producer_of_operand",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4282,17 +5168,21 @@ This transform fails silently if the targeted operation does not have enough
 results. It reads the target handle and produces the result handle.
 """
 function get_result(target::Value; result::IR.Type, result_number, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
-    
-    IR.create_operation(
-        "transform.get_result", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number),]
+
+    return IR.create_operation(
+        "transform.get_result",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4305,18 +5195,22 @@ type(s) of the value(s) associated with the operand handle.
 This transform never fails.
 """
 function get_type(value::Value; type_param::IR.Type, elemental=nothing, location=Location())
-    results = IR.Type[type_param, ]
-    operands = Value[value, ]
+    results = IR.Type[type_param,]
+    operands = Value[value,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(elemental) && push!(attributes, namedattribute("elemental", elemental))
-    
-    IR.create_operation(
-        "transform.get_type", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.get_type",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4340,18 +5234,31 @@ immediately regardless of the mode. The objects associated with the results
 of this operation are the same as those associated with the operands of the
 `transform.yield` in the referenced named sequence.
 """
-function include_(operands_::Vector{Value}; results_::Vector{IR.Type}, target, failure_propagation_mode, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[operands_..., ]
+function include_(
+    operands::Vector{Value};
+    results::Vector{IR.Type},
+    target,
+    failure_propagation_mode,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("target", target), namedattribute("failure_propagation_mode", failure_propagation_mode), ]
-    
-    IR.create_operation(
-        "transform.include", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("target", target),
+        namedattribute("failure_propagation_mode", failure_propagation_mode),
+    ]
+
+    return IR.create_operation(
+        "transform.include",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4366,16 +5273,20 @@ produces a definite failure.
 """
 function match_operation_name(operand_handle::Value; op_names, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle, ]
+    operands = Value[operand_handle,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op_names", op_names), ]
-    
-    IR.create_operation(
-        "transform.match.operation_name", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("op_names", op_names),]
+
+    return IR.create_operation(
+        "transform.match.operation_name",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4389,16 +5300,20 @@ Produces a silenceable failure otherwise.
 """
 function match_param_cmpi(param::Value, reference::Value; predicate, location=Location())
     results = IR.Type[]
-    operands = Value[param, reference, ]
+    operands = Value[param, reference]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
-    
-    IR.create_operation(
-        "transform.match.param.cmpi", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate),]
+
+    return IR.create_operation(
+        "transform.match.param.cmpi",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4414,20 +5329,29 @@ first, then all Payload IR associated with the second handle and so on. If
 parameter more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
+function merge_handles(
+    handles::Vector{Value};
+    result=nothing::Union{Nothing,IR.Type},
+    deduplicate=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[handles..., ]
+    operands = Value[handles...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-    
-    IR.create_operation(
-        "transform.merge_handles", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.merge_handles",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -4458,21 +5382,36 @@ trait and have the `transform.with_named_sequence` attribute attached.
 Named sequences may include other named sequences via `transform.include`,
 but recursion is *not* allowed.
 """
-function named_sequence(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
+function named_sequence(;
+    sym_name,
+    function_type,
+    sym_visibility=nothing,
+    arg_attrs=nothing,
+    res_attrs=nothing,
+    body::Region,
+    location=Location(),
+)
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body, ]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
-    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[
+        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
+    ]
+    !isnothing(sym_visibility) &&
+        push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-    
-    IR.create_operation(
-        "transform.named_sequence", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.named_sequence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4485,17 +5424,21 @@ but the general association check may fail if the parameter type does not
 accept the given kind of attribute as valid.
 """
 function param_constant(; param::IR.Type, value, location=Location())
-    results = IR.Type[param, ]
+    results = IR.Type[param,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value), ]
-    
-    IR.create_operation(
-        "transform.param.constant", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("value", value),]
+
+    return IR.create_operation(
+        "transform.param.constant",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4508,7 +5451,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -4516,12 +5459,16 @@ function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Loc
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-    
-    IR.create_operation(
-        "transform.print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4550,18 +5497,24 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
-    results = IR.Type[replicated..., ]
-    operands = Value[pattern, handles..., ]
+function replicate(
+    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
+)
+    results = IR.Type[replicated...,]
+    operands = Value[pattern, handles...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.replicate", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.replicate",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4579,17 +5532,21 @@ This transform op reads the `target` handle and produces the `result`
 handle. It reads the payload, but does not modify it.
 """
 function select(target::Value; result::IR.Type, op_name, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[target, ]
+    results = IR.Type[result,]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op_name", op_name), ]
-    
-    IR.create_operation(
-        "transform.select", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("op_name", op_name),]
+
+    return IR.create_operation(
+        "transform.select",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4644,20 +5601,35 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(root=nothing::Union{Nothing, Value}; extra_bindings::Vector{Value}, results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[extra_bindings..., ]
-    owned_regions = Region[body, ]
+function sequence(
+    root=nothing::Union{Nothing,Value};
+    extra_bindings::Vector{Value},
+    results::Vector{IR.Type},
+    failure_propagation_mode,
+    body::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[extra_bindings...,]
+    owned_regions = Region[body,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
+    attributes = NamedAttribute[namedattribute(
+        "failure_propagation_mode", failure_propagation_mode
+    ),]
     !isnothing(root) && push!(operands, root)
-    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(extra_bindings), ]))
-    
-    IR.create_operation(
-        "transform.sequence", location;
-        operands, owned_regions, successors, attributes,
+    push!(
+        attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(extra_bindings)])
+    )
+
+    return IR.create_operation(
+        "transform.sequence",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4685,21 +5657,39 @@ the remaining result handles are not mapped to any op. It also succeeds if
 `handle` is empty and `pass_through_empty_handle` is set to \"true\",
 regardless of `fail_on_payload_too_small`.
 """
-function split_handle(handle::Value; results_::Vector{IR.Type}, pass_through_empty_handle=nothing, fail_on_payload_too_small=nothing, overflow_result=nothing, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[handle, ]
+function split_handle(
+    handle::Value;
+    results::Vector{IR.Type},
+    pass_through_empty_handle=nothing,
+    fail_on_payload_too_small=nothing,
+    overflow_result=nothing,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[handle,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(pass_through_empty_handle) && push!(attributes, namedattribute("pass_through_empty_handle", pass_through_empty_handle))
-    !isnothing(fail_on_payload_too_small) && push!(attributes, namedattribute("fail_on_payload_too_small", fail_on_payload_too_small))
-    !isnothing(overflow_result) && push!(attributes, namedattribute("overflow_result", overflow_result))
-    
-    IR.create_operation(
-        "transform.split_handle", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(pass_through_empty_handle) && push!(
+        attributes,
+        namedattribute("pass_through_empty_handle", pass_through_empty_handle),
+    )
+    !isnothing(fail_on_payload_too_small) && push!(
+        attributes,
+        namedattribute("fail_on_payload_too_small", fail_on_payload_too_small),
+    )
+    !isnothing(overflow_result) &&
+        push!(attributes, namedattribute("overflow_result", overflow_result))
+
+    return IR.create_operation(
+        "transform.split_handle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4718,16 +5708,20 @@ This transform reads the target handle.
 """
 function verify(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target, ]
+    operands = Value[target,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.verify", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.verify",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4738,24 +5732,28 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `apply_patterns_vector_cast_away_vector_leading_one_dim`
@@ -4773,12 +5771,16 @@ function apply_patterns_vector_cast_away_vector_leading_one_dim(; location=Locat
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.cast_away_vector_leading_one_dim", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.cast_away_vector_leading_one_dim",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4797,12 +5799,16 @@ function apply_patterns_vector_lower_broadcast(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4815,19 +5821,26 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_contraction(; lowering_strategy=nothing, location=Location())
+function apply_patterns_vector_lower_contraction(;
+    lowering_strategy=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_contraction", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(lowering_strategy) &&
+        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_contraction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4843,12 +5856,16 @@ function apply_patterns_vector_lower_gather(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4867,12 +5884,16 @@ function apply_patterns_vector_lower_masked_transfers(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_masked_transfers", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_masked_transfers",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4891,12 +5912,16 @@ function apply_patterns_vector_lower_masks(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_masks", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_masks",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4909,19 +5934,26 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_multi_reduction(; lowering_strategy=nothing, location=Location())
+function apply_patterns_vector_lower_multi_reduction(;
+    lowering_strategy=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_multi_reduction", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(lowering_strategy) &&
+        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_multi_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4940,12 +5972,16 @@ function apply_patterns_vector_lower_outerproduct(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_outerproduct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_outerproduct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4961,12 +5997,16 @@ function apply_patterns_vector_lower_scan(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_scan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_scan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -4985,12 +6025,16 @@ function apply_patterns_vector_lower_shape_cast(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_shape_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_shape_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5003,19 +6047,26 @@ vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_transfer(; max_transfer_rank=nothing, location=Location())
+function apply_patterns_vector_lower_transfer(;
+    max_transfer_rank=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(max_transfer_rank) && push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_transfer", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(max_transfer_rank) &&
+        push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_transfer",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5028,20 +6079,28 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_transpose(; lowering_strategy=nothing, avx2_lowering_strategy=nothing, location=Location())
+function apply_patterns_vector_lower_transpose(;
+    lowering_strategy=nothing, avx2_lowering_strategy=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-    !isnothing(avx2_lowering_strategy) && push!(attributes, namedattribute("avx2_lowering_strategy", avx2_lowering_strategy))
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.lower_transpose", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(lowering_strategy) &&
+        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    !isnothing(avx2_lowering_strategy) &&
+        push!(attributes, namedattribute("avx2_lowering_strategy", avx2_lowering_strategy))
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.lower_transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5060,12 +6119,16 @@ function apply_patterns_vector_materialize_masks(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.materialize_masks", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.materialize_masks",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5086,12 +6149,16 @@ function apply_patterns_vector_rank_reducing_subview_patterns(; location=Locatio
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.rank_reducing_subview_patterns", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.rank_reducing_subview_patterns",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5104,19 +6171,27 @@ partial parts.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_split_transfer_full_partial(; split_transfer_strategy=nothing, location=Location())
+function apply_patterns_vector_split_transfer_full_partial(;
+    split_transfer_strategy=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_transfer_strategy) && push!(attributes, namedattribute("split_transfer_strategy", split_transfer_strategy))
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.split_transfer_full_partial", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(split_transfer_strategy) && push!(
+        attributes, namedattribute("split_transfer_strategy", split_transfer_strategy)
+    )
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.split_transfer_full_partial",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5142,12 +6217,16 @@ function apply_patterns_vector_transfer_permutation_patterns(; location=Location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.transfer_permutation_patterns", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.transfer_permutation_patterns",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -5160,20 +6239,27 @@ loops over finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_transfer_to_scf(; max_transfer_rank=nothing, full_unroll=nothing, location=Location())
+function apply_patterns_vector_transfer_to_scf(;
+    max_transfer_rank=nothing, full_unroll=nothing, location=Location()
+)
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(max_transfer_rank) && push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
+    !isnothing(max_transfer_rank) &&
+        push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
     !isnothing(full_unroll) && push!(attributes, namedattribute("full_unroll", full_unroll))
-    
-    IR.create_operation(
-        "transform.apply_patterns.vector.transfer_to_scf", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "transform.apply_patterns.vector.transfer_to_scf",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Transform.jl
+++ b/src/Dialects/17/Transform.jl
@@ -1,9 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -34,38 +33,24 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(
-    target::Value,
-    bounded_values::Vector{Value};
-    lower_bounds,
-    upper_bounds,
-    location=Location(),
-)
+function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
     results = IR.Type[]
-    operands = Value[target, bounded_values...]
+    operands = Value[target, bounded_values..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lower_bounds", lower_bounds),
-        namedattribute("upper_bounds", upper_bounds),
-    ]
-
-    return IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
+    
+    IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `bufferization_buffer_loop_hoisting`
@@ -78,20 +63,16 @@ This transform reads the `target` handle and modifies the payload.
 """
 function bufferization_buffer_loop_hoisting(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.buffer_loop_hoisting",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.buffer_loop_hoisting", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -140,20 +121,16 @@ not produce any handle.
 """
 function bufferization_eliminate_empty_tensors(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.eliminate_empty_tensors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.eliminate_empty_tensors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,24 +145,18 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -213,62 +184,32 @@ otherwise, said ops would be considered non-bufferizable.
 This operation consumes the `target` handle and produces the `transformed`
 handle.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    transformed::IR.Type,
-    function_boundary_type_conversion=nothing,
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    memcpy_op=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_one_shot_bufferize(target::Value; transformed::IR.Type, function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, test_analysis_only=nothing, print_conflicts=nothing, memcpy_op=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(
-        attributes,
-        namedattribute(
-            "function_boundary_type_conversion", function_boundary_type_conversion
-        ),
-    )
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
     !isnothing(memcpy_op) && push!(attributes, namedattribute("memcpy_op", memcpy_op))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_patterns_gpu_eliminate_barriers`
@@ -303,16 +244,12 @@ function apply_patterns_gpu_eliminate_barriers(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.gpu.eliminate_barriers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.gpu.eliminate_barriers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,31 +291,20 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_forall_to_blocks(
-    target::Value;
-    result::IR.Type,
-    grid_dims=nothing,
-    generate_gpu_launch=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_forall_to_blocks(target::Value; result::IR.Type, grid_dims=nothing, generate_gpu_launch=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(grid_dims) && push!(attributes, namedattribute("grid_dims", grid_dims))
-    !isnothing(generate_gpu_launch) &&
-        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-
-    return IR.create_operation(
-        "transform.gpu.map_forall_to_blocks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+    
+    IR.create_operation(
+        "transform.gpu.map_forall_to_blocks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -473,40 +399,27 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_forall_to_threads(
-    target::Value;
-    result::IR.Type,
-    block_dims=nothing,
-    warp_dims=nothing,
-    sync_after_distribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_nested_forall_to_threads(target::Value; result::IR.Type, block_dims=nothing, warp_dims=nothing, sync_after_distribute=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(block_dims) && push!(attributes, namedattribute("block_dims", block_dims))
     !isnothing(warp_dims) && push!(attributes, namedattribute("warp_dims", warp_dims))
-    !isnothing(sync_after_distribute) &&
-        push!(attributes, namedattribute("sync_after_distribute", sync_after_distribute))
-
-    return IR.create_operation(
-        "transform.gpu.map_nested_forall_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sync_after_distribute) && push!(attributes, namedattribute("sync_after_distribute", sync_after_distribute))
+    
+    IR.create_operation(
+        "transform.gpu.map_nested_forall_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `match_structured_body`
@@ -539,32 +452,21 @@ Succeeds if the operation body satisfies the specified criteria, produces a
 silenceable failure otherwise. Produces a definite failure if the operand is
 not associated with a single payload op.
 """
-function match_structured_body(
-    operand_handle::Value;
-    reduction_position=nothing,
-    passthrough=nothing,
-    contraction=nothing,
-    location=Location(),
-)
+function match_structured_body(operand_handle::Value; reduction_position=nothing, passthrough=nothing, contraction=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(reduction_position) &&
-        push!(attributes, namedattribute("reduction_position", reduction_position))
+    !isnothing(reduction_position) && push!(attributes, namedattribute("reduction_position", reduction_position))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(contraction) && push!(attributes, namedattribute("contraction", contraction))
-
-    return IR.create_operation(
-        "transform.match.structured.body",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.body", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -596,29 +498,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operation has the contraction-like dimensions, produces a
 silenceable failure otherwise.
 """
-function match_structured_classify_contraction_dims(
-    operand_handle::Value;
-    batch::IR.Type,
-    m::IR.Type,
-    n::IR.Type,
-    k::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[batch, m, n, k]
-    operands = Value[operand_handle,]
+function match_structured_classify_contraction_dims(operand_handle::Value; batch::IR.Type, m::IR.Type, n::IR.Type, k::IR.Type, location=Location())
+    results = IR.Type[batch, m, n, k, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.classify_contraction_dims",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.classify_contraction_dims", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -671,36 +562,23 @@ Succeeds if the specified dimensions satisfy the specified criteria,
 produces a silenceable failure otherwise. Produces a definite failure if
 the operand is not associated with a single payload op.
 """
-function match_structured_dim(
-    operand_handle::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    raw_dim_list,
-    is_inverted=nothing,
-    is_all=nothing,
-    parallel=nothing,
-    reduction=nothing,
-    location=Location(),
-)
+function match_structured_dim(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_dim_list, is_inverted=nothing, is_all=nothing, parallel=nothing, reduction=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_dim_list", raw_dim_list),]
+    attributes = NamedAttribute[namedattribute("raw_dim_list", raw_dim_list), ]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(parallel) && push!(attributes, namedattribute("parallel", parallel))
     !isnothing(reduction) && push!(attributes, namedattribute("reduction", reduction))
-
-    return IR.create_operation(
-        "transform.match.structured.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -719,24 +597,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one payload value of
 `ShapedType`. Produces a silenceable failure otherwise.
 """
-function match_structured_elemental_bitwidth(
-    operand_handle::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_elemental_bitwidth(operand_handle::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.elemental_bitwidth",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.elemental_bitwidth", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -801,37 +673,23 @@ failure otherwise. Additionally, when the result is an operation handle,
 produces a silenceable failure if the init(outs) specification defines
 more than one init(outs) or if the operand is not an operation result.
 """
-function match_structured_init(
-    operand_handle::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    raw_position_list,
-    is_inverted=nothing,
-    is_all=nothing,
-    permutation=nothing,
-    projected_permutation=nothing,
-    location=Location(),
-)
+function match_structured_init(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_position_list, is_inverted=nothing, is_all=nothing, permutation=nothing, projected_permutation=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list),]
+    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list), ]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(permutation) && push!(attributes, namedattribute("permutation", permutation))
-    !isnothing(projected_permutation) &&
-        push!(attributes, namedattribute("projected_permutation", projected_permutation))
-
-    return IR.create_operation(
-        "transform.match.structured.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(projected_permutation) && push!(attributes, namedattribute("projected_permutation", projected_permutation))
+    
+    IR.create_operation(
+        "transform.match.structured.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -897,37 +755,23 @@ otherwise. Additionally, when the result is an operation handle, produces a
 silenceable failure if the input specification defines more than one input
 or if the operand is not an operation result.
 """
-function match_structured_input(
-    operand_handle::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    raw_position_list,
-    is_inverted=nothing,
-    is_all=nothing,
-    permutation=nothing,
-    projected_permutation=nothing,
-    location=Location(),
-)
+function match_structured_input(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_position_list, is_inverted=nothing, is_all=nothing, permutation=nothing, projected_permutation=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list),]
+    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list), ]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(permutation) && push!(attributes, namedattribute("permutation", permutation))
-    !isnothing(projected_permutation) &&
-        push!(attributes, namedattribute("projected_permutation", projected_permutation))
-
-    return IR.create_operation(
-        "transform.match.structured.input",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(projected_permutation) && push!(attributes, namedattribute("projected_permutation", projected_permutation))
+    
+    IR.create_operation(
+        "transform.match.structured.input", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -949,24 +793,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
-function match_structured_num_inits(
-    operand_handle::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_num_inits(operand_handle::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.num_inits",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.num_inits", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -988,24 +826,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
-function match_structured_num_inputs(
-    operand_handle::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_num_inputs(operand_handle::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.num_inputs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.num_inputs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1046,31 +878,19 @@ in \"suppress\" mode as long as the operand handle is associated with exactly
 one payload operation. It produces a definite failure when the handle is
 not associated with exactly one payload operation.
 """
-function match_structured(
-    current::Value;
-    outputs::Vector{IR.Type},
-    failure_propagation_mode=nothing,
-    body_region::Region,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[current,]
-    owned_regions = Region[body_region,]
+function match_structured(current::Value; outputs::Vector{IR.Type}, failure_propagation_mode=nothing, body_region::Region, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[current, ]
+    owned_regions = Region[body_region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(failure_propagation_mode) && push!(
-        attributes, namedattribute("failure_propagation_mode", failure_propagation_mode)
-    )
-
-    return IR.create_operation(
-        "transform.match.structured",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(failure_propagation_mode) && push!(attributes, namedattribute("failure_propagation_mode", failure_propagation_mode))
+    
+    IR.create_operation(
+        "transform.match.structured", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1093,21 +913,17 @@ Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
 function match_structured_rank(operand_handle::Value; rank::IR.Type, location=Location())
-    results = IR.Type[rank,]
-    operands = Value[operand_handle,]
+    results = IR.Type[rank, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.rank", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1143,31 +959,20 @@ to have been already checked for being a single structured op.
 Succeeds if the position is in bounds and if the user operation could be
 found when requested. Produces a silenceable failure otherwise.
 """
-function match_structured_result(
-    operand_handle::Value;
-    result::IR.Type,
-    position,
-    any=nothing,
-    single=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_result(operand_handle::Value; result::IR.Type, position, any=nothing, single=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(any) && push!(attributes, namedattribute("any", any))
     !isnothing(single) && push!(attributes, namedattribute("single", single))
-
-    return IR.create_operation(
-        "transform.match.structured.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1179,27 +984,22 @@ parent op. Always succeeds.
 """
 function match_structured_yield(handles::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_patterns_linalg_erase_unnecessary_inputs`
@@ -1213,16 +1013,12 @@ function apply_patterns_linalg_erase_unnecessary_inputs(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.erase_unnecessary_inputs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.erase_unnecessary_inputs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1238,16 +1034,12 @@ function apply_patterns_linalg_fold_unit_extent_dims_via_reshapes(; location=Loc
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1263,16 +1055,12 @@ function apply_patterns_linalg_fold_unit_extent_dims_via_slices(; location=Locat
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1287,16 +1075,12 @@ function apply_patterns_linalg_tiling_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.tiling_canonicalization",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.tiling_canonicalization", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1361,39 +1145,22 @@ op are bufferized to a new memory allocation, but not the op itself.
 This operation consumes the `target` handle and produces the
 `allocated_buffer` and `new_ops` handles. It always succeeds.
 """
-function structured_bufferize_to_allocation(
-    target::Value;
-    allocated_buffer::IR.Type,
-    new_ops::IR.Type,
-    memory_space=nothing,
-    memcpy_op=nothing,
-    alloc_op=nothing,
-    bufferize_destination_only=nothing,
-    location=Location(),
-)
-    results = IR.Type[allocated_buffer, new_ops]
-    operands = Value[target,]
+function structured_bufferize_to_allocation(target::Value; allocated_buffer::IR.Type, new_ops::IR.Type, memory_space=nothing, memcpy_op=nothing, alloc_op=nothing, bufferize_destination_only=nothing, location=Location())
+    results = IR.Type[allocated_buffer, new_ops, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
     !isnothing(memcpy_op) && push!(attributes, namedattribute("memcpy_op", memcpy_op))
     !isnothing(alloc_op) && push!(attributes, namedattribute("alloc_op", alloc_op))
-    !isnothing(bufferize_destination_only) && push!(
-        attributes,
-        namedattribute("bufferize_destination_only", bufferize_destination_only),
-    )
-
-    return IR.create_operation(
-        "transform.structured.bufferize_to_allocation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(bufferize_destination_only) && push!(attributes, namedattribute("bufferize_destination_only", bufferize_destination_only))
+    
+    IR.create_operation(
+        "transform.structured.bufferize_to_allocation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1445,24 +1212,18 @@ Returns two handles:
 Returns a definite failure if target is not isolated from above.
 Returns a silenceable failure if the pattern application failed.
 """
-function structured_convert_conv2d_to_img2col(
-    target::Value; img2col_tensor::IR.Type, transformed::IR.Type, location=Location()
-)
-    results = IR.Type[img2col_tensor, transformed]
-    operands = Value[target,]
+function structured_convert_conv2d_to_img2col(target::Value; img2col_tensor::IR.Type, transformed::IR.Type, location=Location())
+    results = IR.Type[img2col_tensor, transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.convert_conv2d_to_img2col",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.convert_conv2d_to_img2col", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1471,24 +1232,18 @@ end
 
 TODO
 """
-function structured_decompose_interface(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_decompose_interface(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose_interface",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose_interface", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1508,21 +1263,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1582,20 +1333,16 @@ not produce any handle.
 """
 function structured_eliminate_empty_tensors(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.eliminate_empty_tensors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.eliminate_empty_tensors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1634,28 +1381,18 @@ op are rejected by this operation.
 This operation consumes the producer handle.
 This operation only reads the containing op handle.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value,
-    containing_op::Value;
-    fused_op::IR.Type,
-    new_containing_op::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[fused_op, new_containing_op]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, new_containing_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, new_containing_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1665,32 +1402,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1710,21 +1435,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1746,29 +1467,19 @@ If any non-tensor.pad is passed, the transform emits a silenceable failure.
 The return handle points to only the subset of successfully created packing
 loop nests, which can be empty.
 """
-function structured_hoist_pad_build_packing_loop_nest(
-    target::Value,
-    loop::Value;
-    packing_loop::IR.Type,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[packing_loop,]
-    operands = Value[target, loop]
+function structured_hoist_pad_build_packing_loop_nest(target::Value, loop::Value; packing_loop::IR.Type, transpose=nothing, location=Location())
+    results = IR.Type[packing_loop, ]
+    operands = Value[target, loop, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "transform.structured.hoist_pad.build_packing_loop_nest",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_pad.build_packing_loop_nest", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1793,25 +1504,19 @@ transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully hoisted 
 tensor.pad operations, which can be empty.
 """
-function structured_hoist_pad(
-    target::Value; transformed::IR.Type, num_loops, transpose=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_hoist_pad(target::Value; transformed::IR.Type, num_loops, transpose=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "transform.structured.hoist_pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1840,20 +1545,16 @@ The operation always succeeds and returns nothing.
 """
 function structured_hoist_redundant_tensor_subsets(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.hoist_redundant_tensor_subsets",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_redundant_tensor_subsets", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1877,24 +1578,18 @@ TODO: obsolete and should be retired.
 The operation always succeeds and returns a handle to the transformed
 function op.
 """
-function structured_hoist_redundant_vector_transfers(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_hoist_redundant_vector_transfers(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.hoist_redundant_vector_transfers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_redundant_vector_transfers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1913,24 +1608,18 @@ op (i.e. do not create an additional linalg.copy op).
 The operation always succeeds and returns a handle to the relevant 
 linalg.copy op.
 """
-function structured_insert_slice_to_copy(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_insert_slice_to_copy(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.insert_slice_to_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.insert_slice_to_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1950,26 +1639,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1987,28 +1669,18 @@ If all the operations referred to by the `target` are rewritten, the
 transform succeeds.
 Return handles to the newly produced pad, expand_shape and transpose ops.
 """
-function structured_lower_pack(
-    target::Value;
-    pad_op::IR.Type,
-    expand_shape_op::IR.Type,
-    transpose_op::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[pad_op, expand_shape_op, transpose_op]
-    operands = Value[target,]
+function structured_lower_pack(target::Value; pad_op::IR.Type, expand_shape_op::IR.Type, transpose_op::IR.Type, location=Location())
+    results = IR.Type[pad_op, expand_shape_op, transpose_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.lower_pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.lower_pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2027,29 +1699,18 @@ If all the operations referred to by the `target` are rewritten, the
 transform succeeds.
 Return handles to the newly produced empty, transpose, collapse_shape and extract_slice ops.
 """
-function structured_lower_unpack(
-    target::Value;
-    empty_op::IR.Type,
-    transpose_op::IR.Type,
-    collapse_shape_op::IR.Type,
-    extract_slice_op::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[empty_op, transpose_op, collapse_shape_op, extract_slice_op]
-    operands = Value[target,]
+function structured_lower_unpack(target::Value; empty_op::IR.Type, transpose_op::IR.Type, collapse_shape_op::IR.Type, extract_slice_op::IR.Type, location=Location())
+    results = IR.Type[empty_op, transpose_op, collapse_shape_op, extract_slice_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.lower_unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.lower_unpack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2076,32 +1737,18 @@ linalg.copy / tensor.pad) among the targeted op. Otherwise, the operation
 always succeeds and returns a handle to the relevant tiled linalg.copy /
 tensor.pad op and the enclosing scf.forall op.
 """
-function structured_gpu_map_copy_to_threads(
-    target::Value;
-    forall_op::IR.Type,
-    tiled_op::IR.Type,
-    total_num_threads,
-    desired_bit_alignment,
-    location=Location(),
-)
-    results = IR.Type[forall_op, tiled_op]
-    operands = Value[target,]
+function structured_gpu_map_copy_to_threads(target::Value; forall_op::IR.Type, tiled_op::IR.Type, total_num_threads, desired_bit_alignment, location=Location())
+    results = IR.Type[forall_op, tiled_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("total_num_threads", total_num_threads),
-        namedattribute("desired_bit_alignment", desired_bit_alignment),
-    ]
-
-    return IR.create_operation(
-        "transform.structured.gpu.map_copy_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("total_num_threads", total_num_threads), namedattribute("desired_bit_alignment", desired_bit_alignment), ]
+    
+    IR.create_operation(
+        "transform.structured.gpu.map_copy_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2128,35 +1775,21 @@ values) do not satisfy the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(
-    target::Value,
-    vector_sizes::Vector{Value};
-    vectorize_nd_extract=nothing,
-    scalable_sizes=nothing,
-    static_vector_sizes=nothing,
-    location=Location(),
-)
+function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; vectorize_nd_extract=nothing, scalable_sizes=nothing, static_vector_sizes=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, vector_sizes...]
+    operands = Value[target, vector_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(scalable_sizes) &&
-        push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
-    !isnothing(static_vector_sizes) &&
-        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-
-    return IR.create_operation(
-        "transform.structured.masked_vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(scalable_sizes) && push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
+    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+    
+    IR.create_operation(
+        "transform.structured.masked_vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2190,35 +1823,22 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    op_attrs=nothing,
-    filter_result_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) &&
-        push!(attributes, namedattribute("filter_result_type", filter_result_type))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2278,34 +1898,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2366,43 +1971,21 @@ This operation ignores non-Linalg ops and drops them in the return.
 It returns the list of packed Linalg ops or the original op when all available
 packing strategies failed to apply.
 """
-function structured_pack_greedily(
-    target::Value,
-    matmul_packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_matmul_packed_sizes=nothing,
-    matmul_padded_sizes_next_multiple_of=nothing,
-    matmul_inner_dims_order=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, matmul_packed_sizes...]
+function structured_pack_greedily(target::Value, matmul_packed_sizes::Vector{Value}; packed_op::IR.Type, static_matmul_packed_sizes=nothing, matmul_padded_sizes_next_multiple_of=nothing, matmul_inner_dims_order=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, matmul_packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_matmul_packed_sizes) && push!(
-        attributes,
-        namedattribute("static_matmul_packed_sizes", static_matmul_packed_sizes),
-    )
-    !isnothing(matmul_padded_sizes_next_multiple_of) && push!(
-        attributes,
-        namedattribute(
-            "matmul_padded_sizes_next_multiple_of", matmul_padded_sizes_next_multiple_of
-        ),
-    )
-    !isnothing(matmul_inner_dims_order) && push!(
-        attributes, namedattribute("matmul_inner_dims_order", matmul_inner_dims_order)
-    )
-
-    return IR.create_operation(
-        "transform.structured.pack_greedily",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_matmul_packed_sizes) && push!(attributes, namedattribute("static_matmul_packed_sizes", static_matmul_packed_sizes))
+    !isnothing(matmul_padded_sizes_next_multiple_of) && push!(attributes, namedattribute("matmul_padded_sizes_next_multiple_of", matmul_padded_sizes_next_multiple_of))
+    !isnothing(matmul_inner_dims_order) && push!(attributes, namedattribute("matmul_inner_dims_order", matmul_inner_dims_order))
+    
+    IR.create_operation(
+        "transform.structured.pack_greedily", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2467,30 +2050,19 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(
-    target::Value,
-    packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_packed_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, packed_sizes...]
+function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) &&
-        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-
-    return IR.create_operation(
-        "transform.structured.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+    
+    IR.create_operation(
+        "transform.structured.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2532,33 +2104,20 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(
-    target_pack_or_un_pack_op::Value,
-    target_linalg_op::Value;
-    packed_op::IR.Type,
-    pack_op::IR.Type,
-    un_pack_op::IR.Type,
-    outer_perm=nothing,
-    inner_perm=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op, pack_op, un_pack_op]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
+function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
+    results = IR.Type[packed_op, pack_op, un_pack_op, ]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-
-    return IR.create_operation(
-        "transform.structured.pack_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pack_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2580,44 +2139,24 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    padded::IR.Type,
-    pad::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pad_to_multiple_of=nothing,
-    pack_paddings=nothing,
-    transpose_paddings=nothing,
-    copy_back=nothing,
-    location=Location(),
-)
-    results = IR.Type[padded, pad]
-    operands = Value[target,]
+function structured_pad(target::Value; padded::IR.Type, pad::IR.Type, padding_values=nothing, padding_dimensions=nothing, pad_to_multiple_of=nothing, pack_paddings=nothing, transpose_paddings=nothing, copy_back=nothing, location=Location())
+    results = IR.Type[padded, pad, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pad_to_multiple_of) &&
-        push!(attributes, namedattribute("pad_to_multiple_of", pad_to_multiple_of))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pad_to_multiple_of) && push!(attributes, namedattribute("pad_to_multiple_of", pad_to_multiple_of))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
     !isnothing(copy_back) && push!(attributes, namedattribute("copy_back", copy_back))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2640,43 +2179,24 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    mapping=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, mapping=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2693,24 +2213,18 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(
-    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
-)
-    results = IR.Type[replacement,]
-    operands = Value[target,]
-    owned_regions = Region[bodyRegion,]
+function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
+    results = IR.Type[replacement, ]
+    operands = Value[target, ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2737,24 +2251,18 @@ The return handle points to a subset of successfully produced operations:
   - `tensor.from_elements` case, the returned handle points to the last 
     `tensor.insert`.
 """
-function structured_rewrite_in_destination_passing_style(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_rewrite_in_destination_passing_style(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.rewrite_in_destination_passing_style",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.rewrite_in_destination_passing_style", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2783,21 +2291,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2822,34 +2326,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2989,43 +2478,23 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    inner_parallel=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) &&
-        push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3068,36 +2537,21 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    scalable_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, scalable_sizes=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    !isnothing(scalable_sizes) &&
-        push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(scalable_sizes) && push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3168,35 +2622,21 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_forall(
-    target::Value;
-    forall_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[forall_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_forall(target::Value; forall_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[forall_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_forall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_forall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3270,31 +2710,19 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(
-    target::Value;
-    for_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    tile_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3355,56 +2783,24 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_forall_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_forall_op(
-    target::Value,
-    num_threads::Vector{Value},
-    tile_sizes::Vector{Value},
-    packed_num_threads=nothing::Union{Nothing,Value};
-    packed_tile_sizes=nothing::Union{Nothing,Value},
-    forall_op::IR.Type,
-    tiled_op::IR.Type,
-    static_num_threads=nothing,
-    static_tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[forall_op, tiled_op]
-    operands = Value[target, num_threads..., tile_sizes...]
+function structured_tile_to_forall_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, forall_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[forall_op, tiled_op, ]
+    operands = Value[target, num_threads..., tile_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1,
-            length(num_threads),
-            length(tile_sizes),
-            if (packed_num_threads == nothing)
-                0
-            elseif 1(packed_tile_sizes == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(static_num_threads) &&
-        push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) &&
-        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), (packed_num_threads==nothing) ? 0 : 1(packed_tile_sizes==nothing) ? 0 : 1]))
+    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_forall_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_forall_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3447,33 +2843,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_scf_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_scf_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3514,55 +2897,28 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value;
-    transformed::IR.Type,
-    vectorize_padding=nothing,
-    vectorize_nd_extract=nothing,
-    disable_multi_reduction_to_contract_patterns=nothing,
-    disable_transfer_permutation_map_lowering_patterns=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_multi_reduction_to_contract_patterns",
-            disable_multi_reduction_to_contract_patterns,
-        ),
-    )
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_transfer_permutation_map_lowering_patterns",
-            disable_transfer_permutation_map_lowering_patterns,
-        ),
-    )
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_patterns_memref_expand_ops`
@@ -3581,16 +2937,12 @@ function apply_patterns_memref_expand_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.expand_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.expand_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3606,16 +2958,12 @@ function apply_patterns_memref_expand_strided_metadata(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.expand_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.expand_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3643,16 +2991,12 @@ function apply_patterns_memref_extract_address_computations(; location=Location(
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.extract_address_computations",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.extract_address_computations", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3670,16 +3014,12 @@ function apply_patterns_memref_fold_memref_alias_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.fold_memref_alias_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.fold_memref_alias_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3696,16 +3036,12 @@ function apply_patterns_memref_resolve_ranked_shaped_type_result_dims(; location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.resolve_ranked_shaped_type_result_dims",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.resolve_ranked_shaped_type_result_dims", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3734,24 +3070,18 @@ Otherwise, the returned handle points to a subset of the produced ops:
 
 This transform op consumes the target handle and produces a result handle.
 """
-function memref_make_loop_independent(
-    target::Value; transformed::IR.Type, num_loops, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_make_loop_independent(target::Value; transformed::IR.Type, num_loops, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
-
-    return IR.create_operation(
-        "transform.memref.make_loop_independent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
+    
+    IR.create_operation(
+        "transform.memref.make_loop_independent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3772,33 +3102,25 @@ iterations.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(
-    target::Value; transformed::IR.Type, factor, skip_analysis=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_multibuffer(target::Value; transformed::IR.Type, factor, skip_analysis=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-    !isnothing(skip_analysis) &&
-        push!(attributes, namedattribute("skip_analysis", skip_analysis))
-
-    return IR.create_operation(
-        "transform.memref.multibuffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    !isnothing(skip_analysis) && push!(attributes, namedattribute("skip_analysis", skip_analysis))
+    
+    IR.create_operation(
+        "transform.memref.multibuffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `nvgpu_create_async_groups`
@@ -3819,25 +3141,19 @@ This op consumes the `target` handle and produces the `result` handle, which
 is mapped to the same payload operations as the `target` handle. The op
 modifies the payload.
 """
-function nvgpu_create_async_groups(
-    target::Value; result::IR.Type, bypass_l1=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function nvgpu_create_async_groups(target::Value; result::IR.Type, bypass_l1=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(bypass_l1) && push!(attributes, namedattribute("bypass_l1", bypass_l1))
-
-    return IR.create_operation(
-        "transform.nvgpu.create_async_groups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.nvgpu.create_async_groups", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3875,34 +3191,20 @@ TODO: the shared memory part and behavior specific to NVGPU should be
 made orthogonal to pipelining so that `transform.loop.pipeline` becomes
 usable here.
 """
-function nvgpu_pipeline_shared_memory_copies(
-    for_op::Value;
-    result::IR.Type,
-    depth,
-    peel_epilogue=nothing,
-    failure_propagation_mode=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[for_op,]
+function nvgpu_pipeline_shared_memory_copies(for_op::Value; result::IR.Type, depth, peel_epilogue=nothing, failure_propagation_mode=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[for_op, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("depth", depth),]
-    !isnothing(peel_epilogue) &&
-        push!(attributes, namedattribute("peel_epilogue", peel_epilogue))
-    !isnothing(failure_propagation_mode) && push!(
-        attributes, namedattribute("failure_propagation_mode", failure_propagation_mode)
-    )
-
-    return IR.create_operation(
-        "transform.nvgpu.pipeline_shared_memory_copies",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("depth", depth), ]
+    !isnothing(peel_epilogue) && push!(attributes, namedattribute("peel_epilogue", peel_epilogue))
+    !isnothing(failure_propagation_mode) && push!(attributes, namedattribute("failure_propagation_mode", failure_propagation_mode))
+    
+    IR.create_operation(
+        "transform.nvgpu.pipeline_shared_memory_copies", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3917,27 +3219,22 @@ unchanged.
 """
 function nvgpu_rewrite_matmul_as_mma_sync(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.nvgpu.rewrite_matmul_as_mma_sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.nvgpu.rewrite_matmul_as_mma_sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_patterns_scf_for_loop_canonicalization`
@@ -3952,16 +3249,12 @@ function apply_patterns_scf_for_loop_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.scf.for_loop_canonicalization",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.scf.for_loop_canonicalization", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3975,26 +3268,20 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4010,21 +3297,17 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.coalesce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.coalesce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4048,24 +3331,18 @@ handle.
 
 Produces a definite failure if outlining failed for any of the targets.
 """
-function loop_outline(
-    target::Value; function_::IR.Type, call::IR.Type, func_name, location=Location()
-)
-    results = IR.Type[function_, call]
-    operands = Value[target,]
+function loop_outline(target::Value; function_::IR.Type, call::IR.Type, func_name, location=Location())
+    results = IR.Type[function_, call, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4093,31 +3370,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4144,32 +3409,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4188,20 +3441,16 @@ modifies the payload.
 """
 function loop_promote_if_one_iteration(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.promote_if_one_iteration",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.promote_if_one_iteration", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4224,20 +3473,16 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4262,33 +3507,25 @@ The transform only consumes its operand and does not produce any result.
 The transform definitely fails if `take_else_branch` is specified and the
 `else` region is empty.
 """
-function scf_take_assumed_branch(
-    target::Value; take_else_branch=nothing, location=Location()
-)
+function scf_take_assumed_branch(target::Value; take_else_branch=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(take_else_branch) &&
-        push!(attributes, namedattribute("take_else_branch", take_else_branch))
-
-    return IR.create_operation(
-        "transform.scf.take_assumed_branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(take_else_branch) && push!(attributes, namedattribute("take_else_branch", take_else_branch))
+    
+    IR.create_operation(
+        "transform.scf.take_assumed_branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion`
@@ -4297,24 +3534,18 @@ Indicates that redundant tensor.insert_slice rank reductions should be
 dropped. E.g., cases where a tensor.extract_slice rank reduction immediately
 follows an inverse tensor.insert_slice rank expansion.
 """
-function apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion(;
-    location=Location()
-)
+function apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion(; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.drop_redundant_insert_slice_rank_expansion",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.drop_redundant_insert_slice_rank_expansion", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4330,16 +3561,12 @@ function apply_patterns_tensor_fold_into_pack_and_unpack(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_into_pack_and_unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_into_pack_and_unpack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4352,26 +3579,19 @@ folded into tensor.empty.
 If `fold_single_use_only` is set to \"true\", only tensor.empty that have a
 single use are folded.
 """
-function apply_patterns_tensor_fold_tensor_empty(;
-    fold_single_use_only=nothing, location=Location()
-)
+function apply_patterns_tensor_fold_tensor_empty(; fold_single_use_only=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fold_single_use_only) &&
-        push!(attributes, namedattribute("fold_single_use_only", fold_single_use_only))
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fold_single_use_only) && push!(attributes, namedattribute("fold_single_use_only", fold_single_use_only))
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4382,24 +3602,18 @@ Indicates that tensor.extract_slice -> vector.transfer_read and
 vector.transfer_write -> tensor.insert_slice op chains should be folded into
 vector tranfer read and write ops
 """
-function apply_patterns_tensor_fold_tensor_subset_ops_into_vector_transfers(;
-    location=Location()
-)
+function apply_patterns_tensor_fold_tensor_subset_ops_into_vector_transfers(; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_subset_ops_into_vector_transfers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_subset_ops_into_vector_transfers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4415,16 +3629,12 @@ function apply_patterns_tensor_fold_tensor_subset_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_subset_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_subset_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4441,16 +3651,12 @@ function apply_patterns_tensor_merge_consecutive_insert_extract_slice(; location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.merge_consecutive_insert_extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.merge_consecutive_insert_extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4467,16 +3673,12 @@ function apply_patterns_tensor_reassociative_reshape_folding(; location=Location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.reassociative_reshape_folding",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.reassociative_reshape_folding", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4492,16 +3694,12 @@ function apply_patterns_tensor_rewrite_as_constant(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.rewrite_as_constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.rewrite_as_constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4533,31 +3731,24 @@ Otherwise, the returned handle points to a subset of the produced ops:
 
 This transform op consumes the target handle and produces a result handle.
 """
-function tensor_make_loop_independent(
-    target::Value; transformed::IR.Type, num_loops, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function tensor_make_loop_independent(target::Value; transformed::IR.Type, num_loops, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
-
-    return IR.create_operation(
-        "transform.tensor.make_loop_independent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
+    
+    IR.create_operation(
+        "transform.tensor.make_loop_independent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `alternatives`
@@ -4620,28 +3811,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4657,25 +3839,19 @@ the order within the handles.
 Fails silently if the length of the parameter payload does not match the length of
 the target payload. Does not consume the provided handles.
 """
-function annotate(
-    target::Value, param=nothing::Union{Nothing,Value}; name, location=Location()
-)
+function annotate(target::Value, param=nothing::Union{Nothing, Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
+    attributes = NamedAttribute[namedattribute("name", name), ]
     !isnothing(param) && push!(operands, param)
-
-    return IR.create_operation(
-        "transform.annotate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.annotate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4691,16 +3867,12 @@ function apply_patterns_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.canonicalization",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.canonicalization", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4718,20 +3890,16 @@ mapped to the same operation multiple times.
 """
 function apply_cse(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_cse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_cse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4750,20 +3918,16 @@ this transform may silently remove payload ops from handles.
 """
 function apply_dce(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_dce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_dce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4781,20 +3945,16 @@ This transform reads the target handle and modifies the payload.
 """
 function apply_licm(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_licm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_licm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4828,25 +3988,19 @@ This transform also fails silently if the pattern application did not
 converge within the default number of iterations/rewrites of the greedy
 pattern rewrite driver.
 """
-function apply_patterns(
-    target::Value; apply_cse=nothing, patterns::Region, location=Location()
-)
+function apply_patterns(target::Value; apply_cse=nothing, patterns::Region, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
-    owned_regions = Region[patterns,]
+    operands = Value[target, ]
+    owned_regions = Region[patterns, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(apply_cse) && push!(attributes, namedattribute("apply_cse", apply_cse))
-
-    return IR.create_operation(
-        "transform.apply_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4865,25 +4019,19 @@ that they operate on, so the target op is guaranteed to still exist. The
 target handle is invalidated because a pass may arbitrarily modify the body
 of targeted ops.
 """
-function apply_registered_pass(
-    target::Value; result::IR.Type, pass_name, options=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function apply_registered_pass(target::Value; result::IR.Type, pass_name, options=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pass_name", pass_name),]
+    attributes = NamedAttribute[namedattribute("pass_name", pass_name), ]
     !isnothing(options) && push!(attributes, namedattribute("options", options))
-
-    return IR.create_operation(
-        "transform.apply_registered_pass",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_registered_pass", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4892,21 +4040,17 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4962,26 +4106,18 @@ the resulting handle is associated with an empty payload. The operation
 produces a definite failure if any of the applied matchers or actions
 produced a definite failure.
 """
-function foreach_match(
-    root::Value; updated::IR.Type, matchers, actions, location=Location()
-)
-    results = IR.Type[updated,]
-    operands = Value[root,]
+function foreach_match(root::Value; updated::IR.Type, matchers, actions, location=Location())
+    results = IR.Type[updated, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("matchers", matchers), namedattribute("actions", actions)
-    ]
-
-    return IR.create_operation(
-        "transform.foreach_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("matchers", matchers), namedattribute("actions", actions), ]
+    
+    IR.create_operation(
+        "transform.foreach_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5007,22 +4143,18 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results...,]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5037,24 +4169,18 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(
-    target::Value; consumers::IR.Type, result_number, location=Location()
-)
-    results = IR.Type[consumers,]
-    operands = Value[target,]
+function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
+    results = IR.Type[consumers, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_consumers_of_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_consumers_of_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5067,21 +4193,17 @@ the targeted value.
 This transform fails silently if the targeted value is a block argument.
 """
 function get_defining_op(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5107,33 +4229,21 @@ on the further transformation applied to the handle produced here.
 If any of the given Payload IR ops has no such suitable parent, the
 transformation fails silently.
 """
-function get_parent_op(
-    target::Value;
-    parent::IR.Type,
-    isolated_from_above=nothing,
-    op_name=nothing,
-    deduplicate=nothing,
-    location=Location(),
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function get_parent_op(target::Value; parent::IR.Type, isolated_from_above=nothing, op_name=nothing, deduplicate=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(isolated_from_above) &&
-        push!(attributes, namedattribute("isolated_from_above", isolated_from_above))
+    !isnothing(isolated_from_above) && push!(attributes, namedattribute("isolated_from_above", isolated_from_above))
     !isnothing(op_name) && push!(attributes, namedattribute("op_name", op_name))
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.get_parent_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_parent_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5147,24 +4257,18 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(
-    target::Value; producer::IR.Type, operand_number, location=Location()
-)
-    results = IR.Type[producer,]
-    operands = Value[target,]
+function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
+    results = IR.Type[producer, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
-
-    return IR.create_operation(
-        "transform.get_producer_of_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
+    
+    IR.create_operation(
+        "transform.get_producer_of_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5178,21 +4282,17 @@ This transform fails silently if the targeted operation does not have enough
 results. It reads the target handle and produces the result handle.
 """
 function get_result(target::Value; result::IR.Type, result_number, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5205,22 +4305,18 @@ type(s) of the value(s) associated with the operand handle.
 This transform never fails.
 """
 function get_type(value::Value; type_param::IR.Type, elemental=nothing, location=Location())
-    results = IR.Type[type_param,]
-    operands = Value[value,]
+    results = IR.Type[type_param, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(elemental) && push!(attributes, namedattribute("elemental", elemental))
-
-    return IR.create_operation(
-        "transform.get_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5244,31 +4340,18 @@ immediately regardless of the mode. The objects associated with the results
 of this operation are the same as those associated with the operands of the
 `transform.yield` in the referenced named sequence.
 """
-function include_(
-    operands::Vector{Value};
-    results::Vector{IR.Type},
-    target,
-    failure_propagation_mode,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operands...,]
+function include_(operands_::Vector{Value}; results_::Vector{IR.Type}, target, failure_propagation_mode, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("target", target),
-        namedattribute("failure_propagation_mode", failure_propagation_mode),
-    ]
-
-    return IR.create_operation(
-        "transform.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("target", target), namedattribute("failure_propagation_mode", failure_propagation_mode), ]
+    
+    IR.create_operation(
+        "transform.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5283,20 +4366,16 @@ produces a definite failure.
 """
 function match_operation_name(operand_handle::Value; op_names, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op_names", op_names),]
-
-    return IR.create_operation(
-        "transform.match.operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("op_names", op_names), ]
+    
+    IR.create_operation(
+        "transform.match.operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5310,20 +4389,16 @@ Produces a silenceable failure otherwise.
 """
 function match_param_cmpi(param::Value, reference::Value; predicate, location=Location())
     results = IR.Type[]
-    operands = Value[param, reference]
+    operands = Value[param, reference, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "transform.match.param.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "transform.match.param.cmpi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5339,29 +4414,20 @@ first, then all Payload IR associated with the second handle and so on. If
 parameter more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    deduplicate=nothing,
-    location=Location(),
-)
+function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5392,36 +4458,21 @@ trait and have the `transform.with_named_sequence` attribute attached.
 Named sequences may include other named sequences via `transform.include`,
 but recursion is *not* allowed.
 """
-function named_sequence(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function named_sequence(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "transform.named_sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.named_sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5434,21 +4485,17 @@ but the general association check may fail if the parameter type does not
 accept the given kind of attribute as valid.
 """
 function param_constant(; param::IR.Type, value, location=Location())
-    results = IR.Type[param,]
+    results = IR.Type[param, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "transform.param.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "transform.param.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5461,7 +4508,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -5469,16 +4516,12 @@ function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Loca
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "transform.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5507,24 +4550,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5542,21 +4579,17 @@ This transform op reads the `target` handle and produces the `result`
 handle. It reads the payload, but does not modify it.
 """
 function select(target::Value; result::IR.Type, op_name, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op_name", op_name),]
-
-    return IR.create_operation(
-        "transform.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("op_name", op_name), ]
+    
+    IR.create_operation(
+        "transform.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5611,35 +4644,20 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    extra_bindings::Vector{Value},
-    results::Vector{IR.Type},
-    failure_propagation_mode,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[extra_bindings...,]
-    owned_regions = Region[body,]
+function sequence(root=nothing::Union{Nothing, Value}; extra_bindings::Vector{Value}, results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[extra_bindings..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "failure_propagation_mode", failure_propagation_mode
-    ),]
+    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
     !isnothing(root) && push!(operands, root)
-    push!(
-        attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(extra_bindings)])
-    )
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(extra_bindings), ]))
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5667,39 +4685,21 @@ the remaining result handles are not mapped to any op. It also succeeds if
 `handle` is empty and `pass_through_empty_handle` is set to \"true\",
 regardless of `fail_on_payload_too_small`.
 """
-function split_handle(
-    handle::Value;
-    results::Vector{IR.Type},
-    pass_through_empty_handle=nothing,
-    fail_on_payload_too_small=nothing,
-    overflow_result=nothing,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[handle,]
+function split_handle(handle::Value; results_::Vector{IR.Type}, pass_through_empty_handle=nothing, fail_on_payload_too_small=nothing, overflow_result=nothing, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(pass_through_empty_handle) && push!(
-        attributes,
-        namedattribute("pass_through_empty_handle", pass_through_empty_handle),
-    )
-    !isnothing(fail_on_payload_too_small) && push!(
-        attributes,
-        namedattribute("fail_on_payload_too_small", fail_on_payload_too_small),
-    )
-    !isnothing(overflow_result) &&
-        push!(attributes, namedattribute("overflow_result", overflow_result))
-
-    return IR.create_operation(
-        "transform.split_handle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(pass_through_empty_handle) && push!(attributes, namedattribute("pass_through_empty_handle", pass_through_empty_handle))
+    !isnothing(fail_on_payload_too_small) && push!(attributes, namedattribute("fail_on_payload_too_small", fail_on_payload_too_small))
+    !isnothing(overflow_result) && push!(attributes, namedattribute("overflow_result", overflow_result))
+    
+    IR.create_operation(
+        "transform.split_handle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5718,20 +4718,16 @@ This transform reads the target handle.
 """
 function verify(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.verify",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.verify", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5742,29 +4738,24 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `apply_patterns_vector_cast_away_vector_leading_one_dim`
@@ -5782,16 +4773,12 @@ function apply_patterns_vector_cast_away_vector_leading_one_dim(; location=Locat
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.cast_away_vector_leading_one_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.cast_away_vector_leading_one_dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5810,16 +4797,12 @@ function apply_patterns_vector_lower_broadcast(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5832,26 +4815,19 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_contraction(;
-    lowering_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_lower_contraction(; lowering_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) &&
-        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_contraction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_contraction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5867,16 +4843,12 @@ function apply_patterns_vector_lower_gather(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5895,16 +4867,12 @@ function apply_patterns_vector_lower_masked_transfers(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_masked_transfers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_masked_transfers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5923,16 +4891,12 @@ function apply_patterns_vector_lower_masks(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_masks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_masks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5945,26 +4909,19 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_multi_reduction(;
-    lowering_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_lower_multi_reduction(; lowering_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) &&
-        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5983,16 +4940,12 @@ function apply_patterns_vector_lower_outerproduct(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6008,16 +4961,12 @@ function apply_patterns_vector_lower_scan(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_scan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6036,16 +4985,12 @@ function apply_patterns_vector_lower_shape_cast(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6058,26 +5003,19 @@ vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_transfer(;
-    max_transfer_rank=nothing, location=Location()
-)
+function apply_patterns_vector_lower_transfer(; max_transfer_rank=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(max_transfer_rank) &&
-        push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_transfer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(max_transfer_rank) && push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_transfer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6090,28 +5028,20 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_transpose(;
-    lowering_strategy=nothing, avx2_lowering_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_lower_transpose(; lowering_strategy=nothing, avx2_lowering_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) &&
-        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-    !isnothing(avx2_lowering_strategy) &&
-        push!(attributes, namedattribute("avx2_lowering_strategy", avx2_lowering_strategy))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    !isnothing(avx2_lowering_strategy) && push!(attributes, namedattribute("avx2_lowering_strategy", avx2_lowering_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6130,16 +5060,12 @@ function apply_patterns_vector_materialize_masks(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.materialize_masks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.materialize_masks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6160,16 +5086,12 @@ function apply_patterns_vector_rank_reducing_subview_patterns(; location=Locatio
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.rank_reducing_subview_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.rank_reducing_subview_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6182,27 +5104,19 @@ partial parts.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_split_transfer_full_partial(;
-    split_transfer_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_split_transfer_full_partial(; split_transfer_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_transfer_strategy) && push!(
-        attributes, namedattribute("split_transfer_strategy", split_transfer_strategy)
-    )
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.split_transfer_full_partial",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(split_transfer_strategy) && push!(attributes, namedattribute("split_transfer_strategy", split_transfer_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.split_transfer_full_partial", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6228,16 +5142,12 @@ function apply_patterns_vector_transfer_permutation_patterns(; location=Location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.transfer_permutation_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.transfer_permutation_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6250,27 +5160,20 @@ loops over finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_transfer_to_scf(;
-    max_transfer_rank=nothing, full_unroll=nothing, location=Location()
-)
+function apply_patterns_vector_transfer_to_scf(; max_transfer_rank=nothing, full_unroll=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(max_transfer_rank) &&
-        push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
+    !isnothing(max_transfer_rank) && push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
     !isnothing(full_unroll) && push!(attributes, namedattribute("full_unroll", full_unroll))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.transfer_to_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.transfer_to_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Transform.jl
+++ b/src/Dialects/17/Transform.jl
@@ -1,8 +1,8 @@
 module transform
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `affine_simplify_bounded_affine_ops`
@@ -33,37 +33,24 @@ handles.
 TODO: Support affine.apply targets.
 TODO: Allow mixed PDL_Operation/int64_t for lower_bounds and upper_bounds.
 """
-function affine_simplify_bounded_affine_ops(
-    target::Value,
-    bounded_values::Vector{Value};
-    lower_bounds,
-    upper_bounds,
-    location=Location(),
-)
+function affine_simplify_bounded_affine_ops(target::Value, bounded_values::Vector{Value}; lower_bounds, upper_bounds, location=Location())
     results = IR.Type[]
-    operands = Value[target, bounded_values...]
+    operands = Value[target, bounded_values..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lower_bounds", lower_bounds),
-        namedattribute("upper_bounds", upper_bounds),
-    ]
-
-    return IR.create_operation(
-        "transform.affine.simplify_bounded_affine_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lower_bounds", lower_bounds), namedattribute("upper_bounds", upper_bounds), ]
+    
+    IR.create_operation(
+        "transform.affine.simplify_bounded_affine_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `bufferization_buffer_loop_hoisting`
@@ -76,20 +63,16 @@ This transform reads the `target` handle and modifies the payload.
 """
 function bufferization_buffer_loop_hoisting(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.buffer_loop_hoisting",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.buffer_loop_hoisting", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -138,20 +121,16 @@ not produce any handle.
 """
 function bufferization_eliminate_empty_tensors(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.eliminate_empty_tensors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.eliminate_empty_tensors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -166,24 +145,18 @@ This operation consumes the `target` handle and produces the `transformed`
 handle. `target` is expected to be a `tensor.empty` operation. The transform
 always succeeds.
 """
-function bufferization_empty_tensor_to_alloc_tensor(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_empty_tensor_to_alloc_tensor(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.bufferization.empty_tensor_to_alloc_tensor",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.empty_tensor_to_alloc_tensor", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -211,61 +184,32 @@ otherwise, said ops would be considered non-bufferizable.
 This operation consumes the `target` handle and produces the `transformed`
 handle.
 """
-function bufferization_one_shot_bufferize(
-    target::Value;
-    transformed::IR.Type,
-    function_boundary_type_conversion=nothing,
-    allow_return_allocs=nothing,
-    allow_unknown_ops=nothing,
-    bufferize_function_boundaries=nothing,
-    create_deallocs=nothing,
-    test_analysis_only=nothing,
-    print_conflicts=nothing,
-    memcpy_op=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function bufferization_one_shot_bufferize(target::Value; transformed::IR.Type, function_boundary_type_conversion=nothing, allow_return_allocs=nothing, allow_unknown_ops=nothing, bufferize_function_boundaries=nothing, create_deallocs=nothing, test_analysis_only=nothing, print_conflicts=nothing, memcpy_op=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(function_boundary_type_conversion) && push!(
-        attributes,
-        namedattribute(
-            "function_boundary_type_conversion", function_boundary_type_conversion
-        ),
-    )
-    !isnothing(allow_return_allocs) &&
-        push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
-    !isnothing(allow_unknown_ops) &&
-        push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
-    !isnothing(bufferize_function_boundaries) && push!(
-        attributes,
-        namedattribute("bufferize_function_boundaries", bufferize_function_boundaries),
-    )
-    !isnothing(create_deallocs) &&
-        push!(attributes, namedattribute("create_deallocs", create_deallocs))
-    !isnothing(test_analysis_only) &&
-        push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
-    !isnothing(print_conflicts) &&
-        push!(attributes, namedattribute("print_conflicts", print_conflicts))
+    !isnothing(function_boundary_type_conversion) && push!(attributes, namedattribute("function_boundary_type_conversion", function_boundary_type_conversion))
+    !isnothing(allow_return_allocs) && push!(attributes, namedattribute("allow_return_allocs", allow_return_allocs))
+    !isnothing(allow_unknown_ops) && push!(attributes, namedattribute("allow_unknown_ops", allow_unknown_ops))
+    !isnothing(bufferize_function_boundaries) && push!(attributes, namedattribute("bufferize_function_boundaries", bufferize_function_boundaries))
+    !isnothing(create_deallocs) && push!(attributes, namedattribute("create_deallocs", create_deallocs))
+    !isnothing(test_analysis_only) && push!(attributes, namedattribute("test_analysis_only", test_analysis_only))
+    !isnothing(print_conflicts) && push!(attributes, namedattribute("print_conflicts", print_conflicts))
     !isnothing(memcpy_op) && push!(attributes, namedattribute("memcpy_op", memcpy_op))
-
-    return IR.create_operation(
-        "transform.bufferization.one_shot_bufferize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.bufferization.one_shot_bufferize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_patterns_gpu_eliminate_barriers`
@@ -300,16 +244,12 @@ function apply_patterns_gpu_eliminate_barriers(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.gpu.eliminate_barriers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.gpu.eliminate_barriers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -351,31 +291,20 @@ The returned handle points to the same LaunchOp operand, consuming it and
 producing a new SSA value to satisfy chaining and linearity of the IR
 properties.
 """
-function gpu_map_forall_to_blocks(
-    target::Value;
-    result::IR.Type,
-    grid_dims=nothing,
-    generate_gpu_launch=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_forall_to_blocks(target::Value; result::IR.Type, grid_dims=nothing, generate_gpu_launch=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(grid_dims) && push!(attributes, namedattribute("grid_dims", grid_dims))
-    !isnothing(generate_gpu_launch) &&
-        push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
-
-    return IR.create_operation(
-        "transform.gpu.map_forall_to_blocks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(generate_gpu_launch) && push!(attributes, namedattribute("generate_gpu_launch", generate_gpu_launch))
+    
+    IR.create_operation(
+        "transform.gpu.map_forall_to_blocks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,39 +399,27 @@ gpu.launch blocks(%bx, %by, %bz) in (%x = %0, %y = %1, %z = %2)
 }
 ```
 """
-function gpu_map_nested_forall_to_threads(
-    target::Value;
-    result::IR.Type,
-    block_dims=nothing,
-    warp_dims=nothing,
-    sync_after_distribute=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function gpu_map_nested_forall_to_threads(target::Value; result::IR.Type, block_dims=nothing, warp_dims=nothing, sync_after_distribute=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(block_dims) && push!(attributes, namedattribute("block_dims", block_dims))
     !isnothing(warp_dims) && push!(attributes, namedattribute("warp_dims", warp_dims))
-    !isnothing(sync_after_distribute) &&
-        push!(attributes, namedattribute("sync_after_distribute", sync_after_distribute))
-
-    return IR.create_operation(
-        "transform.gpu.map_nested_forall_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(sync_after_distribute) && push!(attributes, namedattribute("sync_after_distribute", sync_after_distribute))
+    
+    IR.create_operation(
+        "transform.gpu.map_nested_forall_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `match_structured_body`
@@ -535,32 +452,21 @@ Succeeds if the operation body satisfies the specified criteria, produces a
 silenceable failure otherwise. Produces a definite failure if the operand is
 not associated with a single payload op.
 """
-function match_structured_body(
-    operand_handle::Value;
-    reduction_position=nothing,
-    passthrough=nothing,
-    contraction=nothing,
-    location=Location(),
-)
+function match_structured_body(operand_handle::Value; reduction_position=nothing, passthrough=nothing, contraction=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(reduction_position) &&
-        push!(attributes, namedattribute("reduction_position", reduction_position))
+    !isnothing(reduction_position) && push!(attributes, namedattribute("reduction_position", reduction_position))
     !isnothing(passthrough) && push!(attributes, namedattribute("passthrough", passthrough))
     !isnothing(contraction) && push!(attributes, namedattribute("contraction", contraction))
-
-    return IR.create_operation(
-        "transform.match.structured.body",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.body", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -592,29 +498,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operation has the contraction-like dimensions, produces a
 silenceable failure otherwise.
 """
-function match_structured_classify_contraction_dims(
-    operand_handle::Value;
-    batch::IR.Type,
-    m::IR.Type,
-    n::IR.Type,
-    k::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[batch, m, n, k]
-    operands = Value[operand_handle,]
+function match_structured_classify_contraction_dims(operand_handle::Value; batch::IR.Type, m::IR.Type, n::IR.Type, k::IR.Type, location=Location())
+    results = IR.Type[batch, m, n, k, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.classify_contraction_dims",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.classify_contraction_dims", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -667,36 +562,23 @@ Succeeds if the specified dimensions satisfy the specified criteria,
 produces a silenceable failure otherwise. Produces a definite failure if
 the operand is not associated with a single payload op.
 """
-function match_structured_dim(
-    operand_handle::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    raw_dim_list,
-    is_inverted=nothing,
-    is_all=nothing,
-    parallel=nothing,
-    reduction=nothing,
-    location=Location(),
-)
+function match_structured_dim(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_dim_list, is_inverted=nothing, is_all=nothing, parallel=nothing, reduction=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_dim_list", raw_dim_list),]
+    attributes = NamedAttribute[namedattribute("raw_dim_list", raw_dim_list), ]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(parallel) && push!(attributes, namedattribute("parallel", parallel))
     !isnothing(reduction) && push!(attributes, namedattribute("reduction", reduction))
-
-    return IR.create_operation(
-        "transform.match.structured.dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -715,24 +597,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one payload value of
 `ShapedType`. Produces a silenceable failure otherwise.
 """
-function match_structured_elemental_bitwidth(
-    operand_handle::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_elemental_bitwidth(operand_handle::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.elemental_bitwidth",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.elemental_bitwidth", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -797,37 +673,23 @@ failure otherwise. Additionally, when the result is an operation handle,
 produces a silenceable failure if the init(outs) specification defines
 more than one init(outs) or if the operand is not an operation result.
 """
-function match_structured_init(
-    operand_handle::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    raw_position_list,
-    is_inverted=nothing,
-    is_all=nothing,
-    permutation=nothing,
-    projected_permutation=nothing,
-    location=Location(),
-)
+function match_structured_init(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_position_list, is_inverted=nothing, is_all=nothing, permutation=nothing, projected_permutation=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list),]
+    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list), ]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(permutation) && push!(attributes, namedattribute("permutation", permutation))
-    !isnothing(projected_permutation) &&
-        push!(attributes, namedattribute("projected_permutation", projected_permutation))
-
-    return IR.create_operation(
-        "transform.match.structured.init",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(projected_permutation) && push!(attributes, namedattribute("projected_permutation", projected_permutation))
+    
+    IR.create_operation(
+        "transform.match.structured.init", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -893,37 +755,23 @@ otherwise. Additionally, when the result is an operation handle, produces a
 silenceable failure if the input specification defines more than one input
 or if the operand is not an operation result.
 """
-function match_structured_input(
-    operand_handle::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    raw_position_list,
-    is_inverted=nothing,
-    is_all=nothing,
-    permutation=nothing,
-    projected_permutation=nothing,
-    location=Location(),
-)
+function match_structured_input(operand_handle::Value; result=nothing::Union{Nothing, IR.Type}, raw_position_list, is_inverted=nothing, is_all=nothing, permutation=nothing, projected_permutation=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list),]
+    attributes = NamedAttribute[namedattribute("raw_position_list", raw_position_list), ]
     !isnothing(result) && push!(results, result)
     !isnothing(is_inverted) && push!(attributes, namedattribute("is_inverted", is_inverted))
     !isnothing(is_all) && push!(attributes, namedattribute("is_all", is_all))
     !isnothing(permutation) && push!(attributes, namedattribute("permutation", permutation))
-    !isnothing(projected_permutation) &&
-        push!(attributes, namedattribute("projected_permutation", projected_permutation))
-
-    return IR.create_operation(
-        "transform.match.structured.input",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(projected_permutation) && push!(attributes, namedattribute("projected_permutation", projected_permutation))
+    
+    IR.create_operation(
+        "transform.match.structured.input", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -945,24 +793,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
-function match_structured_num_inits(
-    operand_handle::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_num_inits(operand_handle::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.num_inits",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.num_inits", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -984,24 +826,18 @@ to have been already checked for being a single structured op.
 Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
-function match_structured_num_inputs(
-    operand_handle::Value; result::IR.Type, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_num_inputs(operand_handle::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.num_inputs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.num_inputs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1042,31 +878,19 @@ in \"suppress\" mode as long as the operand handle is associated with exactly
 one payload operation. It produces a definite failure when the handle is
 not associated with exactly one payload operation.
 """
-function match_structured(
-    current::Value;
-    outputs::Vector{IR.Type},
-    failure_propagation_mode=nothing,
-    body_region::Region,
-    location=Location(),
-)
-    results = IR.Type[outputs...,]
-    operands = Value[current,]
-    owned_regions = Region[body_region,]
+function match_structured(current::Value; outputs::Vector{IR.Type}, failure_propagation_mode=nothing, body_region::Region, location=Location())
+    results = IR.Type[outputs..., ]
+    operands = Value[current, ]
+    owned_regions = Region[body_region, ]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(failure_propagation_mode) && push!(
-        attributes, namedattribute("failure_propagation_mode", failure_propagation_mode)
-    )
-
-    return IR.create_operation(
-        "transform.match.structured",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(failure_propagation_mode) && push!(attributes, namedattribute("failure_propagation_mode", failure_propagation_mode))
+    
+    IR.create_operation(
+        "transform.match.structured", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1089,21 +913,17 @@ Succeeds if the operand is associated with exactly one structured payload
 operation. Produces a silenceable failure otherwise.
 """
 function match_structured_rank(operand_handle::Value; rank::IR.Type, location=Location())
-    results = IR.Type[rank,]
-    operands = Value[operand_handle,]
+    results = IR.Type[rank, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.rank",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.rank", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1139,31 +959,20 @@ to have been already checked for being a single structured op.
 Succeeds if the position is in bounds and if the user operation could be
 found when requested. Produces a silenceable failure otherwise.
 """
-function match_structured_result(
-    operand_handle::Value;
-    result::IR.Type,
-    position,
-    any=nothing,
-    single=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[operand_handle,]
+function match_structured_result(operand_handle::Value; result::IR.Type, position, any=nothing, single=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(any) && push!(attributes, namedattribute("any", any))
     !isnothing(single) && push!(attributes, namedattribute("single", single))
-
-    return IR.create_operation(
-        "transform.match.structured.result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1175,26 +984,22 @@ parent op. Always succeeds.
 """
 function match_structured_yield(handles::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.match.structured.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.match.structured.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_patterns_linalg_erase_unnecessary_inputs`
@@ -1208,16 +1013,12 @@ function apply_patterns_linalg_erase_unnecessary_inputs(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.erase_unnecessary_inputs",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.erase_unnecessary_inputs", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1233,16 +1034,12 @@ function apply_patterns_linalg_fold_unit_extent_dims_via_reshapes(; location=Loc
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_reshapes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1258,16 +1055,12 @@ function apply_patterns_linalg_fold_unit_extent_dims_via_slices(; location=Locat
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.fold_unit_extent_dims_via_slices", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1282,16 +1075,12 @@ function apply_patterns_linalg_tiling_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.linalg.tiling_canonicalization",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.linalg.tiling_canonicalization", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1356,39 +1145,22 @@ op are bufferized to a new memory allocation, but not the op itself.
 This operation consumes the `target` handle and produces the
 `allocated_buffer` and `new_ops` handles. It always succeeds.
 """
-function structured_bufferize_to_allocation(
-    target::Value;
-    allocated_buffer::IR.Type,
-    new_ops::IR.Type,
-    memory_space=nothing,
-    memcpy_op=nothing,
-    alloc_op=nothing,
-    bufferize_destination_only=nothing,
-    location=Location(),
-)
-    results = IR.Type[allocated_buffer, new_ops]
-    operands = Value[target,]
+function structured_bufferize_to_allocation(target::Value; allocated_buffer::IR.Type, new_ops::IR.Type, memory_space=nothing, memcpy_op=nothing, alloc_op=nothing, bufferize_destination_only=nothing, location=Location())
+    results = IR.Type[allocated_buffer, new_ops, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(memory_space) &&
-        push!(attributes, namedattribute("memory_space", memory_space))
+    !isnothing(memory_space) && push!(attributes, namedattribute("memory_space", memory_space))
     !isnothing(memcpy_op) && push!(attributes, namedattribute("memcpy_op", memcpy_op))
     !isnothing(alloc_op) && push!(attributes, namedattribute("alloc_op", alloc_op))
-    !isnothing(bufferize_destination_only) && push!(
-        attributes,
-        namedattribute("bufferize_destination_only", bufferize_destination_only),
-    )
-
-    return IR.create_operation(
-        "transform.structured.bufferize_to_allocation",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(bufferize_destination_only) && push!(attributes, namedattribute("bufferize_destination_only", bufferize_destination_only))
+    
+    IR.create_operation(
+        "transform.structured.bufferize_to_allocation", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1440,24 +1212,18 @@ Returns two handles:
 Returns a definite failure if target is not isolated from above.
 Returns a silenceable failure if the pattern application failed.
 """
-function structured_convert_conv2d_to_img2col(
-    target::Value; img2col_tensor::IR.Type, transformed::IR.Type, location=Location()
-)
-    results = IR.Type[img2col_tensor, transformed]
-    operands = Value[target,]
+function structured_convert_conv2d_to_img2col(target::Value; img2col_tensor::IR.Type, transformed::IR.Type, location=Location())
+    results = IR.Type[img2col_tensor, transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.convert_conv2d_to_img2col",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.convert_conv2d_to_img2col", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1466,24 +1232,18 @@ end
 
 TODO
 """
-function structured_decompose_interface(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_decompose_interface(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose_interface",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose_interface", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1503,21 +1263,17 @@ The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
 function structured_decompose(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.decompose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.decompose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1577,20 +1333,16 @@ not produce any handle.
 """
 function structured_eliminate_empty_tensors(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.eliminate_empty_tensors",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.eliminate_empty_tensors", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1629,28 +1381,18 @@ op are rejected by this operation.
 This operation consumes the producer handle.
 This operation only reads the containing op handle.
 """
-function structured_fuse_into_containing_op(
-    producer_op::Value,
-    containing_op::Value;
-    fused_op::IR.Type,
-    new_containing_op::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[fused_op, new_containing_op]
-    operands = Value[producer_op, containing_op]
+function structured_fuse_into_containing_op(producer_op::Value, containing_op::Value; fused_op::IR.Type, new_containing_op::IR.Type, location=Location())
+    results = IR.Type[fused_op, new_containing_op, ]
+    operands = Value[producer_op, containing_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.fuse_into_containing_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.fuse_into_containing_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1660,32 +1402,20 @@ end
 Tiles the operations pointed to by the target handle and fuses their
 producers greedily using the options provided as attributes.
 """
-function structured_fuse(
-    target::Value;
-    transformed::IR.Type,
-    loops::Vector{IR.Type},
-    tile_sizes=nothing,
-    tile_interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed, loops...]
-    operands = Value[target,]
+function structured_fuse(target::Value; transformed::IR.Type, loops::Vector{IR.Type}, tile_sizes=nothing, tile_interchange=nothing, location=Location())
+    results = IR.Type[transformed, loops..., ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-    !isnothing(tile_interchange) &&
-        push!(attributes, namedattribute("tile_interchange", tile_interchange))
-
-    return IR.create_operation(
-        "transform.structured.fuse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(tile_interchange) && push!(attributes, namedattribute("tile_interchange", tile_interchange))
+    
+    IR.create_operation(
+        "transform.structured.fuse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1705,21 +1435,17 @@ equivalent generic operations, which can be empty or contain the original
 ops if they were already in generic form.
 """
 function structured_generalize(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.generalize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.generalize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1741,29 +1467,19 @@ If any non-tensor.pad is passed, the transform emits a silenceable failure.
 The return handle points to only the subset of successfully created packing
 loop nests, which can be empty.
 """
-function structured_hoist_pad_build_packing_loop_nest(
-    target::Value,
-    loop::Value;
-    packing_loop::IR.Type,
-    transpose=nothing,
-    location=Location(),
-)
-    results = IR.Type[packing_loop,]
-    operands = Value[target, loop]
+function structured_hoist_pad_build_packing_loop_nest(target::Value, loop::Value; packing_loop::IR.Type, transpose=nothing, location=Location())
+    results = IR.Type[packing_loop, ]
+    operands = Value[target, loop, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "transform.structured.hoist_pad.build_packing_loop_nest",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_pad.build_packing_loop_nest", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1788,25 +1504,19 @@ transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully hoisted 
 tensor.pad operations, which can be empty.
 """
-function structured_hoist_pad(
-    target::Value; transformed::IR.Type, num_loops, transpose=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_hoist_pad(target::Value; transformed::IR.Type, num_loops, transpose=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
     !isnothing(transpose) && push!(attributes, namedattribute("transpose", transpose))
-
-    return IR.create_operation(
-        "transform.structured.hoist_pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1835,20 +1545,16 @@ The operation always succeeds and returns nothing.
 """
 function structured_hoist_redundant_tensor_subsets(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.hoist_redundant_tensor_subsets",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_redundant_tensor_subsets", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1872,24 +1578,18 @@ TODO: obsolete and should be retired.
 The operation always succeeds and returns a handle to the transformed
 function op.
 """
-function structured_hoist_redundant_vector_transfers(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_hoist_redundant_vector_transfers(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.hoist_redundant_vector_transfers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.hoist_redundant_vector_transfers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1908,24 +1608,18 @@ op (i.e. do not create an additional linalg.copy op).
 The operation always succeeds and returns a handle to the relevant 
 linalg.copy op.
 """
-function structured_insert_slice_to_copy(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_insert_slice_to_copy(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.insert_slice_to_copy",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.insert_slice_to_copy", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1945,26 +1639,19 @@ If any interchange fails, the transform definitely fails.
 The return handle points to only the subset of successfully produced
 interchanged operations, which can be empty.
 """
-function structured_interchange(
-    target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_interchange(target::Value; transformed::IR.Type, iterator_interchange=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iterator_interchange) &&
-        push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
-
-    return IR.create_operation(
-        "transform.structured.interchange",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iterator_interchange) && push!(attributes, namedattribute("iterator_interchange", iterator_interchange))
+    
+    IR.create_operation(
+        "transform.structured.interchange", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1982,28 +1669,18 @@ If all the operations referred to by the `target` are rewritten, the
 transform succeeds.
 Return handles to the newly produced pad, expand_shape and transpose ops.
 """
-function structured_lower_pack(
-    target::Value;
-    pad_op::IR.Type,
-    expand_shape_op::IR.Type,
-    transpose_op::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[pad_op, expand_shape_op, transpose_op]
-    operands = Value[target,]
+function structured_lower_pack(target::Value; pad_op::IR.Type, expand_shape_op::IR.Type, transpose_op::IR.Type, location=Location())
+    results = IR.Type[pad_op, expand_shape_op, transpose_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.lower_pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.lower_pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2022,29 +1699,18 @@ If all the operations referred to by the `target` are rewritten, the
 transform succeeds.
 Return handles to the newly produced empty, transpose, collapse_shape and extract_slice ops.
 """
-function structured_lower_unpack(
-    target::Value;
-    empty_op::IR.Type,
-    transpose_op::IR.Type,
-    collapse_shape_op::IR.Type,
-    extract_slice_op::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[empty_op, transpose_op, collapse_shape_op, extract_slice_op]
-    operands = Value[target,]
+function structured_lower_unpack(target::Value; empty_op::IR.Type, transpose_op::IR.Type, collapse_shape_op::IR.Type, extract_slice_op::IR.Type, location=Location())
+    results = IR.Type[empty_op, transpose_op, collapse_shape_op, extract_slice_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.lower_unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.lower_unpack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2071,32 +1737,18 @@ linalg.copy / tensor.pad) among the targeted op. Otherwise, the operation
 always succeeds and returns a handle to the relevant tiled linalg.copy /
 tensor.pad op and the enclosing scf.forall op.
 """
-function structured_gpu_map_copy_to_threads(
-    target::Value;
-    forall_op::IR.Type,
-    tiled_op::IR.Type,
-    total_num_threads,
-    desired_bit_alignment,
-    location=Location(),
-)
-    results = IR.Type[forall_op, tiled_op]
-    operands = Value[target,]
+function structured_gpu_map_copy_to_threads(target::Value; forall_op::IR.Type, tiled_op::IR.Type, total_num_threads, desired_bit_alignment, location=Location())
+    results = IR.Type[forall_op, tiled_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("total_num_threads", total_num_threads),
-        namedattribute("desired_bit_alignment", desired_bit_alignment),
-    ]
-
-    return IR.create_operation(
-        "transform.structured.gpu.map_copy_to_threads",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("total_num_threads", total_num_threads), namedattribute("desired_bit_alignment", desired_bit_alignment), ]
+    
+    IR.create_operation(
+        "transform.structured.gpu.map_copy_to_threads", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2123,35 +1775,21 @@ values) do not satisfy the constraints mentioned above. It produces a
 silenceable failure if at least one target op is not a Linalg op or fails to
 vectorize.
 """
-function structured_masked_vectorize(
-    target::Value,
-    vector_sizes::Vector{Value};
-    vectorize_nd_extract=nothing,
-    scalable_sizes=nothing,
-    static_vector_sizes=nothing,
-    location=Location(),
-)
+function structured_masked_vectorize(target::Value, vector_sizes::Vector{Value}; vectorize_nd_extract=nothing, scalable_sizes=nothing, static_vector_sizes=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target, vector_sizes...]
+    operands = Value[target, vector_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(scalable_sizes) &&
-        push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
-    !isnothing(static_vector_sizes) &&
-        push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
-
-    return IR.create_operation(
-        "transform.structured.masked_vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(scalable_sizes) && push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
+    !isnothing(static_vector_sizes) && push!(attributes, namedattribute("static_vector_sizes", static_vector_sizes))
+    
+    IR.create_operation(
+        "transform.structured.masked_vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2185,35 +1823,22 @@ Otherwise it succeeds.
 This operation does not consume the target handle and produces new handles:
 it is a navigation op.
 """
-function structured_match(
-    target::Value;
-    results::IR.Type,
-    ops=nothing,
-    interface=nothing,
-    op_attrs=nothing,
-    filter_result_type=nothing,
-    location=Location(),
-)
-    results = IR.Type[results,]
-    operands = Value[target,]
+function structured_match(target::Value; results_::IR.Type, ops=nothing, interface=nothing, op_attrs=nothing, filter_result_type=nothing, location=Location())
+    results = IR.Type[results_, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(ops) && push!(attributes, namedattribute("ops", ops))
     !isnothing(interface) && push!(attributes, namedattribute("interface", interface))
     !isnothing(op_attrs) && push!(attributes, namedattribute("op_attrs", op_attrs))
-    !isnothing(filter_result_type) &&
-        push!(attributes, namedattribute("filter_result_type", filter_result_type))
-
-    return IR.create_operation(
-        "transform.structured.match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(filter_result_type) && push!(attributes, namedattribute("filter_result_type", filter_result_type))
+    
+    IR.create_operation(
+        "transform.structured.match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2273,34 +1898,19 @@ structured.split %common after %splitr { dimension = 0 }
 // ...
 ```
 """
-function structured_multitile_sizes(
-    target::Value;
-    low_size::IR.Type,
-    high_size::IR.Type,
-    split_point::IR.Type,
-    dimension,
-    target_size,
-    divisor=nothing,
-    location=Location(),
-)
-    results = IR.Type[low_size, high_size, split_point]
-    operands = Value[target,]
+function structured_multitile_sizes(target::Value; low_size::IR.Type, high_size::IR.Type, split_point::IR.Type, dimension, target_size, divisor=nothing, location=Location())
+    results = IR.Type[low_size, high_size, split_point, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension), namedattribute("target_size", target_size)
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("target_size", target_size), ]
     !isnothing(divisor) && push!(attributes, namedattribute("divisor", divisor))
-
-    return IR.create_operation(
-        "transform.structured.multitile_sizes",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.multitile_sizes", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2361,43 +1971,21 @@ This operation ignores non-Linalg ops and drops them in the return.
 It returns the list of packed Linalg ops or the original op when all available
 packing strategies failed to apply.
 """
-function structured_pack_greedily(
-    target::Value,
-    matmul_packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_matmul_packed_sizes=nothing,
-    matmul_padded_sizes_next_multiple_of=nothing,
-    matmul_inner_dims_order=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, matmul_packed_sizes...]
+function structured_pack_greedily(target::Value, matmul_packed_sizes::Vector{Value}; packed_op::IR.Type, static_matmul_packed_sizes=nothing, matmul_padded_sizes_next_multiple_of=nothing, matmul_inner_dims_order=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, matmul_packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_matmul_packed_sizes) && push!(
-        attributes,
-        namedattribute("static_matmul_packed_sizes", static_matmul_packed_sizes),
-    )
-    !isnothing(matmul_padded_sizes_next_multiple_of) && push!(
-        attributes,
-        namedattribute(
-            "matmul_padded_sizes_next_multiple_of", matmul_padded_sizes_next_multiple_of
-        ),
-    )
-    !isnothing(matmul_inner_dims_order) && push!(
-        attributes, namedattribute("matmul_inner_dims_order", matmul_inner_dims_order)
-    )
-
-    return IR.create_operation(
-        "transform.structured.pack_greedily",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_matmul_packed_sizes) && push!(attributes, namedattribute("static_matmul_packed_sizes", static_matmul_packed_sizes))
+    !isnothing(matmul_padded_sizes_next_multiple_of) && push!(attributes, namedattribute("matmul_padded_sizes_next_multiple_of", matmul_padded_sizes_next_multiple_of))
+    !isnothing(matmul_inner_dims_order) && push!(attributes, namedattribute("matmul_inner_dims_order", matmul_inner_dims_order))
+    
+    IR.create_operation(
+        "transform.structured.pack_greedily", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2462,30 +2050,19 @@ reason.
 
 The returned handle point to the packed LinalgOp.
 """
-function structured_pack(
-    target::Value,
-    packed_sizes::Vector{Value};
-    packed_op::IR.Type,
-    static_packed_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op,]
-    operands = Value[target, packed_sizes...]
+function structured_pack(target::Value, packed_sizes::Vector{Value}; packed_op::IR.Type, static_packed_sizes=nothing, location=Location())
+    results = IR.Type[packed_op, ]
+    operands = Value[target, packed_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_packed_sizes) &&
-        push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
-
-    return IR.create_operation(
-        "transform.structured.pack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(static_packed_sizes) && push!(attributes, namedattribute("static_packed_sizes", static_packed_sizes))
+    
+    IR.create_operation(
+        "transform.structured.pack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2527,33 +2104,20 @@ the transformed `tensor.pack` and one to the transformed `tensor.unpack`.
 The last handle for `tensor.unpack` is empty if `target_pack_or_unpack_op` 
 was not itself a `tensor.unpack`.
 """
-function structured_pack_transpose(
-    target_pack_or_un_pack_op::Value,
-    target_linalg_op::Value;
-    packed_op::IR.Type,
-    pack_op::IR.Type,
-    un_pack_op::IR.Type,
-    outer_perm=nothing,
-    inner_perm=nothing,
-    location=Location(),
-)
-    results = IR.Type[packed_op, pack_op, un_pack_op]
-    operands = Value[target_pack_or_un_pack_op, target_linalg_op]
+function structured_pack_transpose(target_pack_or_un_pack_op::Value, target_linalg_op::Value; packed_op::IR.Type, pack_op::IR.Type, un_pack_op::IR.Type, outer_perm=nothing, inner_perm=nothing, location=Location())
+    results = IR.Type[packed_op, pack_op, un_pack_op, ]
+    operands = Value[target_pack_or_un_pack_op, target_linalg_op, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(outer_perm) && push!(attributes, namedattribute("outer_perm", outer_perm))
     !isnothing(inner_perm) && push!(attributes, namedattribute("inner_perm", inner_perm))
-
-    return IR.create_operation(
-        "transform.structured.pack_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pack_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2575,44 +2139,24 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 padded operations, which can be empty.
 """
-function structured_pad(
-    target::Value;
-    padded::IR.Type,
-    pad::IR.Type,
-    padding_values=nothing,
-    padding_dimensions=nothing,
-    pad_to_multiple_of=nothing,
-    pack_paddings=nothing,
-    transpose_paddings=nothing,
-    copy_back=nothing,
-    location=Location(),
-)
-    results = IR.Type[padded, pad]
-    operands = Value[target,]
+function structured_pad(target::Value; padded::IR.Type, pad::IR.Type, padding_values=nothing, padding_dimensions=nothing, pad_to_multiple_of=nothing, pack_paddings=nothing, transpose_paddings=nothing, copy_back=nothing, location=Location())
+    results = IR.Type[padded, pad, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(padding_values) &&
-        push!(attributes, namedattribute("padding_values", padding_values))
-    !isnothing(padding_dimensions) &&
-        push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
-    !isnothing(pad_to_multiple_of) &&
-        push!(attributes, namedattribute("pad_to_multiple_of", pad_to_multiple_of))
-    !isnothing(pack_paddings) &&
-        push!(attributes, namedattribute("pack_paddings", pack_paddings))
-    !isnothing(transpose_paddings) &&
-        push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
+    !isnothing(padding_values) && push!(attributes, namedattribute("padding_values", padding_values))
+    !isnothing(padding_dimensions) && push!(attributes, namedattribute("padding_dimensions", padding_dimensions))
+    !isnothing(pad_to_multiple_of) && push!(attributes, namedattribute("pad_to_multiple_of", pad_to_multiple_of))
+    !isnothing(pack_paddings) && push!(attributes, namedattribute("pack_paddings", pack_paddings))
+    !isnothing(transpose_paddings) && push!(attributes, namedattribute("transpose_paddings", transpose_paddings))
     !isnothing(copy_back) && push!(attributes, namedattribute("copy_back", copy_back))
-
-    return IR.create_operation(
-        "transform.structured.pad",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.pad", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2635,43 +2179,24 @@ properly, the transform succeeds.
 When successful, the return handle points to the \$target operation that
 was modified inplace.
 """
-function structured_promote(
-    target::Value;
-    transformed::IR.Type,
-    operands_to_promote=nothing,
-    use_full_tile_buffers=nothing,
-    use_full_tiles_by_default=nothing,
-    use_alloca=nothing,
-    mapping=nothing,
-    alignment=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_promote(target::Value; transformed::IR.Type, operands_to_promote=nothing, use_full_tile_buffers=nothing, use_full_tiles_by_default=nothing, use_alloca=nothing, mapping=nothing, alignment=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(operands_to_promote) &&
-        push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
-    !isnothing(use_full_tile_buffers) &&
-        push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
-    !isnothing(use_full_tiles_by_default) && push!(
-        attributes,
-        namedattribute("use_full_tiles_by_default", use_full_tiles_by_default),
-    )
+    !isnothing(operands_to_promote) && push!(attributes, namedattribute("operands_to_promote", operands_to_promote))
+    !isnothing(use_full_tile_buffers) && push!(attributes, namedattribute("use_full_tile_buffers", use_full_tile_buffers))
+    !isnothing(use_full_tiles_by_default) && push!(attributes, namedattribute("use_full_tiles_by_default", use_full_tiles_by_default))
     !isnothing(use_alloca) && push!(attributes, namedattribute("use_alloca", use_alloca))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
     !isnothing(alignment) && push!(attributes, namedattribute("alignment", alignment))
-
-    return IR.create_operation(
-        "transform.structured.promote",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.promote", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2688,24 +2213,18 @@ This op is for debugging/experiments only.
 
 This operation consumes the `target` handle.
 """
-function structured_replace(
-    target::Value; replacement::IR.Type, bodyRegion::Region, location=Location()
-)
-    results = IR.Type[replacement,]
-    operands = Value[target,]
-    owned_regions = Region[bodyRegion,]
+function structured_replace(target::Value; replacement::IR.Type, bodyRegion::Region, location=Location())
+    results = IR.Type[replacement, ]
+    operands = Value[target, ]
+    owned_regions = Region[bodyRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.replace",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.replace", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2732,24 +2251,18 @@ The return handle points to a subset of successfully produced operations:
   - `tensor.from_elements` case, the returned handle points to the last 
     `tensor.insert`.
 """
-function structured_rewrite_in_destination_passing_style(
-    target::Value; transformed::IR.Type, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_rewrite_in_destination_passing_style(target::Value; transformed::IR.Type, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.rewrite_in_destination_passing_style",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.rewrite_in_destination_passing_style", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2778,21 +2291,17 @@ Loops can always be recovered by navigating from the tiled operations if
 needed.
 """
 function structured_scalarize(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.structured.scalarize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.scalarize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2817,34 +2326,19 @@ of the structured op after splitting, in the same order as the target
 operand, with the first handle corresponding to the part with lower
 iteration space indices.
 """
-function structured_split(
-    target::Value,
-    dynamic_split_point=nothing::Union{Nothing,Value};
-    first::IR.Type,
-    second::IR.Type,
-    dimension,
-    static_split_point,
-    location=Location(),
-)
-    results = IR.Type[first, second]
-    operands = Value[target,]
+function structured_split(target::Value, dynamic_split_point=nothing::Union{Nothing, Value}; first::IR.Type, second::IR.Type, dimension, static_split_point, location=Location())
+    results = IR.Type[first, second, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("dimension", dimension),
-        namedattribute("static_split_point", static_split_point),
-    ]
+    attributes = NamedAttribute[namedattribute("dimension", dimension), namedattribute("static_split_point", static_split_point), ]
     !isnothing(dynamic_split_point) && push!(operands, dynamic_split_point)
-
-    return IR.create_operation(
-        "transform.structured.split",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2984,43 +2478,23 @@ Is transformed to:
  return %4 : tensor<16x32xf32>
 ```
 """
-function structured_split_reduction(
-    target::Value;
-    init_or_alloc_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    split_factor=nothing,
-    insert_split_dimension=nothing,
-    inner_parallel=nothing,
-    use_scaling_algorithm=nothing,
-    use_alloc=nothing,
-    location=Location(),
-)
-    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_split_reduction(target::Value; init_or_alloc_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, split_factor=nothing, insert_split_dimension=nothing, inner_parallel=nothing, use_scaling_algorithm=nothing, use_alloc=nothing, location=Location())
+    results = IR.Type[init_or_alloc_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_factor) &&
-        push!(attributes, namedattribute("split_factor", split_factor))
-    !isnothing(insert_split_dimension) &&
-        push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
-    !isnothing(inner_parallel) &&
-        push!(attributes, namedattribute("inner_parallel", inner_parallel))
-    !isnothing(use_scaling_algorithm) &&
-        push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
+    !isnothing(split_factor) && push!(attributes, namedattribute("split_factor", split_factor))
+    !isnothing(insert_split_dimension) && push!(attributes, namedattribute("insert_split_dimension", insert_split_dimension))
+    !isnothing(inner_parallel) && push!(attributes, namedattribute("inner_parallel", inner_parallel))
+    !isnothing(use_scaling_algorithm) && push!(attributes, namedattribute("use_scaling_algorithm", use_scaling_algorithm))
     !isnothing(use_alloc) && push!(attributes, namedattribute("use_alloc", use_alloc))
-
-    return IR.create_operation(
-        "transform.structured.split_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.split_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3063,36 +2537,21 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    scalable_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, scalable_sizes=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-    !isnothing(scalable_sizes) &&
-        push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(scalable_sizes) && push!(attributes, namedattribute("scalable_sizes", scalable_sizes))
+    
+    IR.create_operation(
+        "transform.structured.tile", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3163,35 +2622,21 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_forall(
-    target::Value;
-    forall_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    num_threads=nothing,
-    tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[forall_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_forall(target::Value; forall_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, num_threads=nothing, tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[forall_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_threads) && push!(attributes, namedattribute("num_threads", num_threads))
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_forall",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_forall", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3265,31 +2710,19 @@ is transformed into:
   } -> tensor<?xf32>
 ```
 """
-function structured_tile_reduction_using_scf(
-    target::Value;
-    for_op::IR.Type,
-    fill_op::IR.Type,
-    split_linalg_op::IR.Type,
-    combining_linalg_op::IR.Type,
-    tile_sizes=nothing,
-    location=Location(),
-)
-    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op]
-    operands = Value[target,]
+function structured_tile_reduction_using_scf(target::Value; for_op::IR.Type, fill_op::IR.Type, split_linalg_op::IR.Type, combining_linalg_op::IR.Type, tile_sizes=nothing, location=Location())
+    results = IR.Type[for_op, fill_op, split_linalg_op, combining_linalg_op, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(tile_sizes) && push!(attributes, namedattribute("tile_sizes", tile_sizes))
-
-    return IR.create_operation(
-        "transform.structured.tile_reduction_using_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_reduction_using_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3350,56 +2783,24 @@ These two returned handles point to:
 %3:2 = transform.structured.tile_to_forall_op %0 tile_sizes [0, %sz, 20]
 ```
 """
-function structured_tile_to_forall_op(
-    target::Value,
-    num_threads::Vector{Value},
-    tile_sizes::Vector{Value},
-    packed_num_threads=nothing::Union{Nothing,Value};
-    packed_tile_sizes=nothing::Union{Nothing,Value},
-    forall_op::IR.Type,
-    tiled_op::IR.Type,
-    static_num_threads=nothing,
-    static_tile_sizes=nothing,
-    mapping=nothing,
-    location=Location(),
-)
-    results = IR.Type[forall_op, tiled_op]
-    operands = Value[target, num_threads..., tile_sizes...]
+function structured_tile_to_forall_op(target::Value, num_threads::Vector{Value}, tile_sizes::Vector{Value}, packed_num_threads=nothing::Union{Nothing, Value}; packed_tile_sizes=nothing::Union{Nothing, Value}, forall_op::IR.Type, tiled_op::IR.Type, static_num_threads=nothing, static_tile_sizes=nothing, mapping=nothing, location=Location())
+    results = IR.Type[forall_op, tiled_op, ]
+    operands = Value[target, num_threads..., tile_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(packed_num_threads) && push!(operands, packed_num_threads)
     !isnothing(packed_tile_sizes) && push!(operands, packed_tile_sizes)
-    push!(
-        attributes,
-        operandsegmentsizes([
-            1,
-            length(num_threads),
-            length(tile_sizes),
-            if (packed_num_threads == nothing)
-                0
-            elseif 1(packed_tile_sizes == nothing)
-                0
-            else
-                1
-            end,
-        ]),
-    )
-    !isnothing(static_num_threads) &&
-        push!(attributes, namedattribute("static_num_threads", static_num_threads))
-    !isnothing(static_tile_sizes) &&
-        push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
+    push!(attributes, operandsegmentsizes([1, length(num_threads), length(tile_sizes), (packed_num_threads==nothing) ? 0 : 1(packed_tile_sizes==nothing) ? 0 : 1]))
+    !isnothing(static_num_threads) && push!(attributes, namedattribute("static_num_threads", static_num_threads))
+    !isnothing(static_tile_sizes) && push!(attributes, namedattribute("static_tile_sizes", static_tile_sizes))
     !isnothing(mapping) && push!(attributes, namedattribute("mapping", mapping))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_forall_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_forall_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3442,33 +2843,20 @@ that of the list associated with the `target` handle.
 If the internal implementation of tiling for any of the operations fails,
 produces a definite failure.
 """
-function structured_tile_to_scf_for(
-    target::Value,
-    dynamic_sizes::Vector{Value};
-    tiled_linalg_op::IR.Type,
-    loops::Vector{IR.Type},
-    static_sizes=nothing,
-    interchange=nothing,
-    location=Location(),
-)
-    results = IR.Type[tiled_linalg_op, loops...]
-    operands = Value[target, dynamic_sizes...]
+function structured_tile_to_scf_for(target::Value, dynamic_sizes::Vector{Value}; tiled_linalg_op::IR.Type, loops::Vector{IR.Type}, static_sizes=nothing, interchange=nothing, location=Location())
+    results = IR.Type[tiled_linalg_op, loops..., ]
+    operands = Value[target, dynamic_sizes..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(static_sizes) &&
-        push!(attributes, namedattribute("static_sizes", static_sizes))
+    !isnothing(static_sizes) && push!(attributes, namedattribute("static_sizes", static_sizes))
     !isnothing(interchange) && push!(attributes, namedattribute("interchange", interchange))
-
-    return IR.create_operation(
-        "transform.structured.tile_to_scf_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.structured.tile_to_scf_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3509,54 +2897,28 @@ reason.
 The operation always returns the handle to the target op that is expected
 to be isolated from above.
 """
-function structured_vectorize(
-    target::Value;
-    transformed::IR.Type,
-    vectorize_padding=nothing,
-    vectorize_nd_extract=nothing,
-    disable_multi_reduction_to_contract_patterns=nothing,
-    disable_transfer_permutation_map_lowering_patterns=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function structured_vectorize(target::Value; transformed::IR.Type, vectorize_padding=nothing, vectorize_nd_extract=nothing, disable_multi_reduction_to_contract_patterns=nothing, disable_transfer_permutation_map_lowering_patterns=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(vectorize_padding) &&
-        push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
-    !isnothing(vectorize_nd_extract) &&
-        push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
-    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_multi_reduction_to_contract_patterns",
-            disable_multi_reduction_to_contract_patterns,
-        ),
-    )
-    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(
-        attributes,
-        namedattribute(
-            "disable_transfer_permutation_map_lowering_patterns",
-            disable_transfer_permutation_map_lowering_patterns,
-        ),
-    )
-
-    return IR.create_operation(
-        "transform.structured.vectorize",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(vectorize_padding) && push!(attributes, namedattribute("vectorize_padding", vectorize_padding))
+    !isnothing(vectorize_nd_extract) && push!(attributes, namedattribute("vectorize_nd_extract", vectorize_nd_extract))
+    !isnothing(disable_multi_reduction_to_contract_patterns) && push!(attributes, namedattribute("disable_multi_reduction_to_contract_patterns", disable_multi_reduction_to_contract_patterns))
+    !isnothing(disable_transfer_permutation_map_lowering_patterns) && push!(attributes, namedattribute("disable_transfer_permutation_map_lowering_patterns", disable_transfer_permutation_map_lowering_patterns))
+    
+    IR.create_operation(
+        "transform.structured.vectorize", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_patterns_memref_expand_ops`
@@ -3575,16 +2937,12 @@ function apply_patterns_memref_expand_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.expand_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.expand_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3600,16 +2958,12 @@ function apply_patterns_memref_expand_strided_metadata(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.expand_strided_metadata",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.expand_strided_metadata", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3637,16 +2991,12 @@ function apply_patterns_memref_extract_address_computations(; location=Location(
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.extract_address_computations",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.extract_address_computations", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3664,16 +3014,12 @@ function apply_patterns_memref_fold_memref_alias_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.fold_memref_alias_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.fold_memref_alias_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3690,16 +3036,12 @@ function apply_patterns_memref_resolve_ranked_shaped_type_result_dims(; location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.memref.resolve_ranked_shaped_type_result_dims",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.memref.resolve_ranked_shaped_type_result_dims", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3728,24 +3070,18 @@ Otherwise, the returned handle points to a subset of the produced ops:
 
 This transform op consumes the target handle and produces a result handle.
 """
-function memref_make_loop_independent(
-    target::Value; transformed::IR.Type, num_loops, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_make_loop_independent(target::Value; transformed::IR.Type, num_loops, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
-
-    return IR.create_operation(
-        "transform.memref.make_loop_independent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
+    
+    IR.create_operation(
+        "transform.memref.make_loop_independent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3766,32 +3102,25 @@ iterations.
 This operation returns the new allocation if multi-buffering
 succeeds, and failure otherwise.
 """
-function memref_multibuffer(
-    target::Value; transformed::IR.Type, factor, skip_analysis=nothing, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function memref_multibuffer(target::Value; transformed::IR.Type, factor, skip_analysis=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-    !isnothing(skip_analysis) &&
-        push!(attributes, namedattribute("skip_analysis", skip_analysis))
-
-    return IR.create_operation(
-        "transform.memref.multibuffer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    !isnothing(skip_analysis) && push!(attributes, namedattribute("skip_analysis", skip_analysis))
+    
+    IR.create_operation(
+        "transform.memref.multibuffer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `nvgpu_create_async_groups`
@@ -3812,25 +3141,19 @@ This op consumes the `target` handle and produces the `result` handle, which
 is mapped to the same payload operations as the `target` handle. The op
 modifies the payload.
 """
-function nvgpu_create_async_groups(
-    target::Value; result::IR.Type, bypass_l1=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function nvgpu_create_async_groups(target::Value; result::IR.Type, bypass_l1=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(bypass_l1) && push!(attributes, namedattribute("bypass_l1", bypass_l1))
-
-    return IR.create_operation(
-        "transform.nvgpu.create_async_groups",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.nvgpu.create_async_groups", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3868,34 +3191,20 @@ TODO: the shared memory part and behavior specific to NVGPU should be
 made orthogonal to pipelining so that `transform.loop.pipeline` becomes
 usable here.
 """
-function nvgpu_pipeline_shared_memory_copies(
-    for_op::Value;
-    result::IR.Type,
-    depth,
-    peel_epilogue=nothing,
-    failure_propagation_mode=nothing,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[for_op,]
+function nvgpu_pipeline_shared_memory_copies(for_op::Value; result::IR.Type, depth, peel_epilogue=nothing, failure_propagation_mode=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[for_op, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("depth", depth),]
-    !isnothing(peel_epilogue) &&
-        push!(attributes, namedattribute("peel_epilogue", peel_epilogue))
-    !isnothing(failure_propagation_mode) && push!(
-        attributes, namedattribute("failure_propagation_mode", failure_propagation_mode)
-    )
-
-    return IR.create_operation(
-        "transform.nvgpu.pipeline_shared_memory_copies",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("depth", depth), ]
+    !isnothing(peel_epilogue) && push!(attributes, namedattribute("peel_epilogue", peel_epilogue))
+    !isnothing(failure_propagation_mode) && push!(attributes, namedattribute("failure_propagation_mode", failure_propagation_mode))
+    
+    IR.create_operation(
+        "transform.nvgpu.pipeline_shared_memory_copies", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3910,26 +3219,22 @@ unchanged.
 """
 function nvgpu_rewrite_matmul_as_mma_sync(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.nvgpu.rewrite_matmul_as_mma_sync",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.nvgpu.rewrite_matmul_as_mma_sync", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_patterns_scf_for_loop_canonicalization`
@@ -3944,16 +3249,12 @@ function apply_patterns_scf_for_loop_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.scf.for_loop_canonicalization",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.scf.for_loop_canonicalization", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -3967,26 +3268,20 @@ of operations associated with the handle contains parent operations in the
 same order as the list associated with the operand, except for operations
 that are parents to more than one input which are only present once.
 """
-function loop_get_parent_for(
-    target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location()
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function loop_get_parent_for(target::Value; parent::IR.Type, num_loops=nothing, affine=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(num_loops) && push!(attributes, namedattribute("num_loops", num_loops))
     !isnothing(affine) && push!(attributes, namedattribute("affine", affine))
-
-    return IR.create_operation(
-        "transform.loop.get_parent_for",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.get_parent_for", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4002,21 +3297,17 @@ The return handle points to the coalesced loop if coalescing happens, or
 the given input loop if coalescing does not happen.
 """
 function loop_coalesce(target::Value; transformed::IR.Type, location=Location())
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.coalesce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.coalesce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4040,24 +3331,18 @@ handle.
 
 Produces a definite failure if outlining failed for any of the targets.
 """
-function loop_outline(
-    target::Value; function_::IR.Type, call::IR.Type, func_name, location=Location()
-)
-    results = IR.Type[function_, call]
-    operands = Value[target,]
+function loop_outline(target::Value; function_::IR.Type, call::IR.Type, func_name, location=Location())
+    results = IR.Type[function_, call, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("func_name", func_name),]
-
-    return IR.create_operation(
-        "transform.loop.outline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("func_name", func_name), ]
+    
+    IR.create_operation(
+        "transform.loop.outline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4085,31 +3370,19 @@ one.
 
 TODO: Return both the peeled loop and the remainder loop.
 """
-function loop_peel(
-    target::Value;
-    transformed::IR.Type,
-    fail_if_already_divisible=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_peel(target::Value; transformed::IR.Type, fail_if_already_divisible=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fail_if_already_divisible) && push!(
-        attributes,
-        namedattribute("fail_if_already_divisible", fail_if_already_divisible),
-    )
-
-    return IR.create_operation(
-        "transform.loop.peel",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fail_if_already_divisible) && push!(attributes, namedattribute("fail_if_already_divisible", fail_if_already_divisible))
+    
+    IR.create_operation(
+        "transform.loop.peel", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4136,32 +3409,20 @@ properly, the transform succeeds. Otherwise the transform silently fails.
 The return handle points to only the subset of successfully produced
 pipelined loops, which can be empty.
 """
-function loop_pipeline(
-    target::Value;
-    transformed::IR.Type,
-    iteration_interval=nothing,
-    read_latency=nothing,
-    location=Location(),
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function loop_pipeline(target::Value; transformed::IR.Type, iteration_interval=nothing, read_latency=nothing, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(iteration_interval) &&
-        push!(attributes, namedattribute("iteration_interval", iteration_interval))
-    !isnothing(read_latency) &&
-        push!(attributes, namedattribute("read_latency", read_latency))
-
-    return IR.create_operation(
-        "transform.loop.pipeline",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(iteration_interval) && push!(attributes, namedattribute("iteration_interval", iteration_interval))
+    !isnothing(read_latency) && push!(attributes, namedattribute("read_latency", read_latency))
+    
+    IR.create_operation(
+        "transform.loop.pipeline", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4180,20 +3441,16 @@ modifies the payload.
 """
 function loop_promote_if_one_iteration(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.loop.promote_if_one_iteration",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.loop.promote_if_one_iteration", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4216,20 +3473,16 @@ removed after a full unrolling.
 """
 function loop_unroll(target::Value; factor, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("factor", factor),]
-
-    return IR.create_operation(
-        "transform.loop.unroll",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("factor", factor), ]
+    
+    IR.create_operation(
+        "transform.loop.unroll", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4254,32 +3507,25 @@ The transform only consumes its operand and does not produce any result.
 The transform definitely fails if `take_else_branch` is specified and the
 `else` region is empty.
 """
-function scf_take_assumed_branch(
-    target::Value; take_else_branch=nothing, location=Location()
-)
+function scf_take_assumed_branch(target::Value; take_else_branch=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(take_else_branch) &&
-        push!(attributes, namedattribute("take_else_branch", take_else_branch))
-
-    return IR.create_operation(
-        "transform.scf.take_assumed_branch",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(take_else_branch) && push!(attributes, namedattribute("take_else_branch", take_else_branch))
+    
+    IR.create_operation(
+        "transform.scf.take_assumed_branch", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion`
@@ -4288,24 +3534,18 @@ Indicates that redundant tensor.insert_slice rank reductions should be
 dropped. E.g., cases where a tensor.extract_slice rank reduction immediately
 follows an inverse tensor.insert_slice rank expansion.
 """
-function apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion(;
-    location=Location()
-)
+function apply_patterns_tensor_drop_redundant_insert_slice_rank_expansion(; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.drop_redundant_insert_slice_rank_expansion",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.drop_redundant_insert_slice_rank_expansion", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4321,16 +3561,12 @@ function apply_patterns_tensor_fold_into_pack_and_unpack(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_into_pack_and_unpack",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_into_pack_and_unpack", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4343,26 +3579,19 @@ folded into tensor.empty.
 If `fold_single_use_only` is set to \"true\", only tensor.empty that have a
 single use are folded.
 """
-function apply_patterns_tensor_fold_tensor_empty(;
-    fold_single_use_only=nothing, location=Location()
-)
+function apply_patterns_tensor_fold_tensor_empty(; fold_single_use_only=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(fold_single_use_only) &&
-        push!(attributes, namedattribute("fold_single_use_only", fold_single_use_only))
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_empty",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(fold_single_use_only) && push!(attributes, namedattribute("fold_single_use_only", fold_single_use_only))
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_empty", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4373,24 +3602,18 @@ Indicates that tensor.extract_slice -> vector.transfer_read and
 vector.transfer_write -> tensor.insert_slice op chains should be folded into
 vector tranfer read and write ops
 """
-function apply_patterns_tensor_fold_tensor_subset_ops_into_vector_transfers(;
-    location=Location()
-)
+function apply_patterns_tensor_fold_tensor_subset_ops_into_vector_transfers(; location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_subset_ops_into_vector_transfers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_subset_ops_into_vector_transfers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4406,16 +3629,12 @@ function apply_patterns_tensor_fold_tensor_subset_ops(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.fold_tensor_subset_ops",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.fold_tensor_subset_ops", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4432,16 +3651,12 @@ function apply_patterns_tensor_merge_consecutive_insert_extract_slice(; location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.merge_consecutive_insert_extract_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.merge_consecutive_insert_extract_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4458,16 +3673,12 @@ function apply_patterns_tensor_reassociative_reshape_folding(; location=Location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.reassociative_reshape_folding",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.reassociative_reshape_folding", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4483,16 +3694,12 @@ function apply_patterns_tensor_rewrite_as_constant(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.tensor.rewrite_as_constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.tensor.rewrite_as_constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4524,30 +3731,24 @@ Otherwise, the returned handle points to a subset of the produced ops:
 
 This transform op consumes the target handle and produces a result handle.
 """
-function tensor_make_loop_independent(
-    target::Value; transformed::IR.Type, num_loops, location=Location()
-)
-    results = IR.Type[transformed,]
-    operands = Value[target,]
+function tensor_make_loop_independent(target::Value; transformed::IR.Type, num_loops, location=Location())
+    results = IR.Type[transformed, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("num_loops", num_loops),]
-
-    return IR.create_operation(
-        "transform.tensor.make_loop_independent",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("num_loops", num_loops), ]
+    
+    IR.create_operation(
+        "transform.tensor.make_loop_independent", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `alternatives`
@@ -4610,28 +3811,19 @@ Remark: this op allows one to implement a simple \"try\" construct as follows:
 }
 ```
 """
-function alternatives(
-    scope=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    alternatives::Vector{Region},
-    location=Location(),
-)
-    results = IR.Type[results...,]
+function alternatives(scope=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, alternatives::Vector{Region}, location=Location())
+    results = IR.Type[results_..., ]
     operands = Value[]
-    owned_regions = Region[alternatives...,]
+    owned_regions = Region[alternatives..., ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(scope) && push!(operands, scope)
-
-    return IR.create_operation(
-        "transform.alternatives",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.alternatives", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4647,25 +3839,19 @@ the order within the handles.
 Fails silently if the length of the parameter payload does not match the length of
 the target payload. Does not consume the provided handles.
 """
-function annotate(
-    target::Value, param=nothing::Union{Nothing,Value}; name, location=Location()
-)
+function annotate(target::Value, param=nothing::Union{Nothing, Value}; name, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("name", name),]
+    attributes = NamedAttribute[namedattribute("name", name), ]
     !isnothing(param) && push!(operands, param)
-
-    return IR.create_operation(
-        "transform.annotate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.annotate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4681,16 +3867,12 @@ function apply_patterns_canonicalization(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.canonicalization",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.canonicalization", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4708,20 +3890,16 @@ mapped to the same operation multiple times.
 """
 function apply_cse(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_cse",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_cse", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4740,20 +3918,16 @@ this transform may silently remove payload ops from handles.
 """
 function apply_dce(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_dce",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_dce", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4771,20 +3945,16 @@ This transform reads the target handle and modifies the payload.
 """
 function apply_licm(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_licm",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_licm", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4818,25 +3988,19 @@ This transform also fails silently if the pattern application did not
 converge within the default number of iterations/rewrites of the greedy
 pattern rewrite driver.
 """
-function apply_patterns(
-    target::Value; apply_cse=nothing, patterns::Region, location=Location()
-)
+function apply_patterns(target::Value; apply_cse=nothing, patterns::Region, location=Location())
     results = IR.Type[]
-    operands = Value[target,]
-    owned_regions = Region[patterns,]
+    operands = Value[target, ]
+    owned_regions = Region[patterns, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(apply_cse) && push!(attributes, namedattribute("apply_cse", apply_cse))
-
-    return IR.create_operation(
-        "transform.apply_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4855,25 +4019,19 @@ that they operate on, so the target op is guaranteed to still exist. The
 target handle is invalidated because a pass may arbitrarily modify the body
 of targeted ops.
 """
-function apply_registered_pass(
-    target::Value; result::IR.Type, pass_name, options=nothing, location=Location()
-)
-    results = IR.Type[result,]
-    operands = Value[target,]
+function apply_registered_pass(target::Value; result::IR.Type, pass_name, options=nothing, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pass_name", pass_name),]
+    attributes = NamedAttribute[namedattribute("pass_name", pass_name), ]
     !isnothing(options) && push!(attributes, namedattribute("options", options))
-
-    return IR.create_operation(
-        "transform.apply_registered_pass",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_registered_pass", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4882,21 +4040,17 @@ end
 
 """
 function cast(input::Value; output::IR.Type, location=Location())
-    results = IR.Type[output,]
-    operands = Value[input,]
+    results = IR.Type[output, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4952,26 +4106,18 @@ the resulting handle is associated with an empty payload. The operation
 produces a definite failure if any of the applied matchers or actions
 produced a definite failure.
 """
-function foreach_match(
-    root::Value; updated::IR.Type, matchers, actions, location=Location()
-)
-    results = IR.Type[updated,]
-    operands = Value[root,]
+function foreach_match(root::Value; updated::IR.Type, matchers, actions, location=Location())
+    results = IR.Type[updated, ]
+    operands = Value[root, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("matchers", matchers), namedattribute("actions", actions)
-    ]
-
-    return IR.create_operation(
-        "transform.foreach_match",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("matchers", matchers), namedattribute("actions", actions), ]
+    
+    IR.create_operation(
+        "transform.foreach_match", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -4997,22 +4143,18 @@ This op generates as many handles as the terminating YieldOp has operands.
 For each result, the payload ops of the corresponding YieldOp operand are
 merged and mapped to the same resulting handle.
 """
-function foreach(target::Value; results::Vector{IR.Type}, body::Region, location=Location())
-    results = IR.Type[results...,]
-    operands = Value[target,]
-    owned_regions = Region[body,]
+function foreach(target::Value; results_::Vector{IR.Type}, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[target, ]
+    owned_regions = Region[body, ]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.foreach",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.foreach", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5027,24 +4169,18 @@ definitely fails.
 The return handle points to the consuming operations operations, which can
 be empty.
 """
-function get_consumers_of_result(
-    target::Value; consumers::IR.Type, result_number, location=Location()
-)
-    results = IR.Type[consumers,]
-    operands = Value[target,]
+function get_consumers_of_result(target::Value; consumers::IR.Type, result_number, location=Location())
+    results = IR.Type[consumers, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_consumers_of_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_consumers_of_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5057,21 +4193,17 @@ the targeted value.
 This transform fails silently if the targeted value is a block argument.
 """
 function get_defining_op(target::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.get_defining_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_defining_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5097,33 +4229,21 @@ on the further transformation applied to the handle produced here.
 If any of the given Payload IR ops has no such suitable parent, the
 transformation fails silently.
 """
-function get_parent_op(
-    target::Value;
-    parent::IR.Type,
-    isolated_from_above=nothing,
-    op_name=nothing,
-    deduplicate=nothing,
-    location=Location(),
-)
-    results = IR.Type[parent,]
-    operands = Value[target,]
+function get_parent_op(target::Value; parent::IR.Type, isolated_from_above=nothing, op_name=nothing, deduplicate=nothing, location=Location())
+    results = IR.Type[parent, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(isolated_from_above) &&
-        push!(attributes, namedattribute("isolated_from_above", isolated_from_above))
+    !isnothing(isolated_from_above) && push!(attributes, namedattribute("isolated_from_above", isolated_from_above))
     !isnothing(op_name) && push!(attributes, namedattribute("op_name", op_name))
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.get_parent_op",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_parent_op", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5137,24 +4257,18 @@ a block argument), the transform silently fails.
 The return handle points to only the subset of successfully produced
 computational operations, which can be empty.
 """
-function get_producer_of_operand(
-    target::Value; producer::IR.Type, operand_number, location=Location()
-)
-    results = IR.Type[producer,]
-    operands = Value[target,]
+function get_producer_of_operand(target::Value; producer::IR.Type, operand_number, location=Location())
+    results = IR.Type[producer, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("operand_number", operand_number),]
-
-    return IR.create_operation(
-        "transform.get_producer_of_operand",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("operand_number", operand_number), ]
+    
+    IR.create_operation(
+        "transform.get_producer_of_operand", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5168,21 +4282,17 @@ This transform fails silently if the targeted operation does not have enough
 results. It reads the target handle and produces the result handle.
 """
 function get_result(target::Value; result::IR.Type, result_number, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("result_number", result_number),]
-
-    return IR.create_operation(
-        "transform.get_result",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("result_number", result_number), ]
+    
+    IR.create_operation(
+        "transform.get_result", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5195,22 +4305,18 @@ type(s) of the value(s) associated with the operand handle.
 This transform never fails.
 """
 function get_type(value::Value; type_param::IR.Type, elemental=nothing, location=Location())
-    results = IR.Type[type_param,]
-    operands = Value[value,]
+    results = IR.Type[type_param, ]
+    operands = Value[value, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(elemental) && push!(attributes, namedattribute("elemental", elemental))
-
-    return IR.create_operation(
-        "transform.get_type",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.get_type", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5234,31 +4340,18 @@ immediately regardless of the mode. The objects associated with the results
 of this operation are the same as those associated with the operands of the
 `transform.yield` in the referenced named sequence.
 """
-function include_(
-    operands::Vector{Value};
-    results::Vector{IR.Type},
-    target,
-    failure_propagation_mode,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[operands...,]
+function include_(operands_::Vector{Value}; results_::Vector{IR.Type}, target, failure_propagation_mode, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("target", target),
-        namedattribute("failure_propagation_mode", failure_propagation_mode),
-    ]
-
-    return IR.create_operation(
-        "transform.include",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("target", target), namedattribute("failure_propagation_mode", failure_propagation_mode), ]
+    
+    IR.create_operation(
+        "transform.include", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5273,20 +4366,16 @@ produces a definite failure.
 """
 function match_operation_name(operand_handle::Value; op_names, location=Location())
     results = IR.Type[]
-    operands = Value[operand_handle,]
+    operands = Value[operand_handle, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op_names", op_names),]
-
-    return IR.create_operation(
-        "transform.match.operation_name",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("op_names", op_names), ]
+    
+    IR.create_operation(
+        "transform.match.operation_name", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5300,20 +4389,16 @@ Produces a silenceable failure otherwise.
 """
 function match_param_cmpi(param::Value, reference::Value; predicate, location=Location())
     results = IR.Type[]
-    operands = Value[param, reference]
+    operands = Value[param, reference, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("predicate", predicate),]
-
-    return IR.create_operation(
-        "transform.match.param.cmpi",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("predicate", predicate), ]
+    
+    IR.create_operation(
+        "transform.match.param.cmpi", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5329,29 +4414,20 @@ first, then all Payload IR associated with the second handle and so on. If
 parameter more than once to the final list regardless of it coming from the
 same or different handles. Consumes the operands and produces a new handle.
 """
-function merge_handles(
-    handles::Vector{Value};
-    result=nothing::Union{Nothing,IR.Type},
-    deduplicate=nothing,
-    location=Location(),
-)
+function merge_handles(handles::Vector{Value}; result=nothing::Union{Nothing, IR.Type}, deduplicate=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[handles...,]
+    operands = Value[handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
     !isnothing(deduplicate) && push!(attributes, namedattribute("deduplicate", deduplicate))
-
-    return IR.create_operation(
-        "transform.merge_handles",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.merge_handles", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -5382,36 +4458,21 @@ trait and have the `transform.with_named_sequence` attribute attached.
 Named sequences may include other named sequences via `transform.include`,
 but recursion is *not* allowed.
 """
-function named_sequence(;
-    sym_name,
-    function_type,
-    sym_visibility=nothing,
-    arg_attrs=nothing,
-    res_attrs=nothing,
-    body::Region,
-    location=Location(),
-)
+function named_sequence(; sym_name, function_type, sym_visibility=nothing, arg_attrs=nothing, res_attrs=nothing, body::Region, location=Location())
     results = IR.Type[]
     operands = Value[]
-    owned_regions = Region[body,]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("sym_name", sym_name), namedattribute("function_type", function_type)
-    ]
-    !isnothing(sym_visibility) &&
-        push!(attributes, namedattribute("sym_visibility", sym_visibility))
+    attributes = NamedAttribute[namedattribute("sym_name", sym_name), namedattribute("function_type", function_type), ]
+    !isnothing(sym_visibility) && push!(attributes, namedattribute("sym_visibility", sym_visibility))
     !isnothing(arg_attrs) && push!(attributes, namedattribute("arg_attrs", arg_attrs))
     !isnothing(res_attrs) && push!(attributes, namedattribute("res_attrs", res_attrs))
-
-    return IR.create_operation(
-        "transform.named_sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.named_sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5424,21 +4485,17 @@ but the general association check may fail if the parameter type does not
 accept the given kind of attribute as valid.
 """
 function param_constant(; param::IR.Type, value, location=Location())
-    results = IR.Type[param,]
+    results = IR.Type[param, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("value", value),]
-
-    return IR.create_operation(
-        "transform.param.constant",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("value", value), ]
+    
+    IR.create_operation(
+        "transform.param.constant", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5451,7 +4508,7 @@ specified, the top-level op is dumped.
 
 This op is useful for printf-style debugging.
 """
-function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Location())
+function print(target=nothing::Union{Nothing, Value}; name=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
@@ -5459,16 +4516,12 @@ function print(target=nothing::Union{Nothing,Value}; name=nothing, location=Loca
     attributes = NamedAttribute[]
     !isnothing(target) && push!(operands, target)
     !isnothing(name) && push!(attributes, namedattribute("name", name))
-
-    return IR.create_operation(
-        "transform.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5497,24 +4550,18 @@ MergeHandlesOp may be used to deduplicate the associated list of payload IR
 ops when necessary. Furthermore, a combination of ReplicateOp and
 MergeHandlesOp can be used to construct arbitrary lists with repetitions.
 """
-function replicate(
-    pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location()
-)
-    results = IR.Type[replicated...,]
-    operands = Value[pattern, handles...]
+function replicate(pattern::Value, handles::Vector{Value}; replicated::Vector{IR.Type}, location=Location())
+    results = IR.Type[replicated..., ]
+    operands = Value[pattern, handles..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.replicate",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.replicate", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5532,21 +4579,17 @@ This transform op reads the `target` handle and produces the `result`
 handle. It reads the payload, but does not modify it.
 """
 function select(target::Value; result::IR.Type, op_name, location=Location())
-    results = IR.Type[result,]
-    operands = Value[target,]
+    results = IR.Type[result, ]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("op_name", op_name),]
-
-    return IR.create_operation(
-        "transform.select",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("op_name", op_name), ]
+    
+    IR.create_operation(
+        "transform.select", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5601,35 +4644,20 @@ The body of the sequence terminates with an implicit or explicit
 `transform.yield` op. The operands of the terminator are returned as the
 results of the sequence op.
 """
-function sequence(
-    root=nothing::Union{Nothing,Value};
-    extra_bindings::Vector{Value},
-    results::Vector{IR.Type},
-    failure_propagation_mode,
-    body::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[extra_bindings...,]
-    owned_regions = Region[body,]
+function sequence(root=nothing::Union{Nothing, Value}; extra_bindings::Vector{Value}, results_::Vector{IR.Type}, failure_propagation_mode, body::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[extra_bindings..., ]
+    owned_regions = Region[body, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute(
-        "failure_propagation_mode", failure_propagation_mode
-    ),]
+    attributes = NamedAttribute[namedattribute("failure_propagation_mode", failure_propagation_mode), ]
     !isnothing(root) && push!(operands, root)
-    push!(
-        attributes, operandsegmentsizes([(root == nothing) ? 0 : 1length(extra_bindings)])
-    )
-
-    return IR.create_operation(
-        "transform.sequence",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    push!(attributes, operandsegmentsizes([(root==nothing) ? 0 : 1length(extra_bindings), ]))
+    
+    IR.create_operation(
+        "transform.sequence", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5657,39 +4685,21 @@ the remaining result handles are not mapped to any op. It also succeeds if
 `handle` is empty and `pass_through_empty_handle` is set to \"true\",
 regardless of `fail_on_payload_too_small`.
 """
-function split_handle(
-    handle::Value;
-    results::Vector{IR.Type},
-    pass_through_empty_handle=nothing,
-    fail_on_payload_too_small=nothing,
-    overflow_result=nothing,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[handle,]
+function split_handle(handle::Value; results_::Vector{IR.Type}, pass_through_empty_handle=nothing, fail_on_payload_too_small=nothing, overflow_result=nothing, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[handle, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(pass_through_empty_handle) && push!(
-        attributes,
-        namedattribute("pass_through_empty_handle", pass_through_empty_handle),
-    )
-    !isnothing(fail_on_payload_too_small) && push!(
-        attributes,
-        namedattribute("fail_on_payload_too_small", fail_on_payload_too_small),
-    )
-    !isnothing(overflow_result) &&
-        push!(attributes, namedattribute("overflow_result", overflow_result))
-
-    return IR.create_operation(
-        "transform.split_handle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(pass_through_empty_handle) && push!(attributes, namedattribute("pass_through_empty_handle", pass_through_empty_handle))
+    !isnothing(fail_on_payload_too_small) && push!(attributes, namedattribute("fail_on_payload_too_small", fail_on_payload_too_small))
+    !isnothing(overflow_result) && push!(attributes, namedattribute("overflow_result", overflow_result))
+    
+    IR.create_operation(
+        "transform.split_handle", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5708,20 +4718,16 @@ This transform reads the target handle.
 """
 function verify(target::Value; location=Location())
     results = IR.Type[]
-    operands = Value[target,]
+    operands = Value[target, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.verify",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.verify", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5732,28 +4738,24 @@ This terminator operation yields operation handles from regions of the
 transform IR ops back to the containing op. It is not itself associated with
 any transformation on the payload IR and is used for flow purposes only.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `apply_patterns_vector_cast_away_vector_leading_one_dim`
@@ -5771,16 +4773,12 @@ function apply_patterns_vector_cast_away_vector_leading_one_dim(; location=Locat
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.cast_away_vector_leading_one_dim",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.cast_away_vector_leading_one_dim", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5799,16 +4797,12 @@ function apply_patterns_vector_lower_broadcast(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5821,26 +4815,19 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_contraction(;
-    lowering_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_lower_contraction(; lowering_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) &&
-        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_contraction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_contraction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5856,16 +4843,12 @@ function apply_patterns_vector_lower_gather(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5884,16 +4867,12 @@ function apply_patterns_vector_lower_masked_transfers(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_masked_transfers",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_masked_transfers", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5912,16 +4891,12 @@ function apply_patterns_vector_lower_masks(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_masks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_masks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5934,26 +4909,19 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_multi_reduction(;
-    lowering_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_lower_multi_reduction(; lowering_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) &&
-        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5972,16 +4940,12 @@ function apply_patterns_vector_lower_outerproduct(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -5997,16 +4961,12 @@ function apply_patterns_vector_lower_scan(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_scan", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6025,16 +4985,12 @@ function apply_patterns_vector_lower_shape_cast(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6047,26 +5003,19 @@ vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_transfer(;
-    max_transfer_rank=nothing, location=Location()
-)
+function apply_patterns_vector_lower_transfer(; max_transfer_rank=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(max_transfer_rank) &&
-        push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_transfer",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(max_transfer_rank) && push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_transfer", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6079,28 +5028,20 @@ finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_lower_transpose(;
-    lowering_strategy=nothing, avx2_lowering_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_lower_transpose(; lowering_strategy=nothing, avx2_lowering_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(lowering_strategy) &&
-        push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
-    !isnothing(avx2_lowering_strategy) &&
-        push!(attributes, namedattribute("avx2_lowering_strategy", avx2_lowering_strategy))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.lower_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(lowering_strategy) && push!(attributes, namedattribute("lowering_strategy", lowering_strategy))
+    !isnothing(avx2_lowering_strategy) && push!(attributes, namedattribute("avx2_lowering_strategy", avx2_lowering_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.lower_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6119,16 +5060,12 @@ function apply_patterns_vector_materialize_masks(; location=Location())
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.materialize_masks",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.materialize_masks", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6149,16 +5086,12 @@ function apply_patterns_vector_rank_reducing_subview_patterns(; location=Locatio
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.rank_reducing_subview_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.rank_reducing_subview_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6171,27 +5104,19 @@ partial parts.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_split_transfer_full_partial(;
-    split_transfer_strategy=nothing, location=Location()
-)
+function apply_patterns_vector_split_transfer_full_partial(; split_transfer_strategy=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(split_transfer_strategy) && push!(
-        attributes, namedattribute("split_transfer_strategy", split_transfer_strategy)
-    )
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.split_transfer_full_partial",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(split_transfer_strategy) && push!(attributes, namedattribute("split_transfer_strategy", split_transfer_strategy))
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.split_transfer_full_partial", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6217,16 +5142,12 @@ function apply_patterns_vector_transfer_permutation_patterns(; location=Location
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.transfer_permutation_patterns",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.transfer_permutation_patterns", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -6239,27 +5160,20 @@ loops over finer-grained vector primitives.
 This is usually a late step that is run after bufferization as part of the
 process of lowering to e.g. LLVM or NVVM.
 """
-function apply_patterns_vector_transfer_to_scf(;
-    max_transfer_rank=nothing, full_unroll=nothing, location=Location()
-)
+function apply_patterns_vector_transfer_to_scf(; max_transfer_rank=nothing, full_unroll=nothing, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(max_transfer_rank) &&
-        push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
+    !isnothing(max_transfer_rank) && push!(attributes, namedattribute("max_transfer_rank", max_transfer_rank))
     !isnothing(full_unroll) && push!(attributes, namedattribute("full_unroll", full_unroll))
-
-    return IR.create_operation(
-        "transform.apply_patterns.vector.transfer_to_scf",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "transform.apply_patterns.vector.transfer_to_scf", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/UB.jl
+++ b/src/Dialects/17/UB.jl
@@ -1,8 +1,8 @@
 module ub
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `poison`
@@ -29,18 +29,22 @@ Examples:
 ```
 """
 function poison(; result::IR.Type, value=nothing, location=Location())
-    results = IR.Type[result, ]
+    results = IR.Type[result,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-    
-    IR.create_operation(
-        "ub.poison", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "ub.poison",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/UB.jl
+++ b/src/Dialects/17/UB.jl
@@ -1,9 +1,8 @@
 module ub
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `poison`
@@ -30,22 +29,18 @@ Examples:
 ```
 """
 function poison(; result::IR.Type, value=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "ub.poison",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ub.poison", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/UB.jl
+++ b/src/Dialects/17/UB.jl
@@ -1,8 +1,8 @@
 module ub
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `poison`
@@ -29,22 +29,18 @@ Examples:
 ```
 """
 function poison(; result::IR.Type, value=nothing, location=Location())
-    results = IR.Type[result,]
+    results = IR.Type[result, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(value) && push!(attributes, namedattribute("value", value))
-
-    return IR.create_operation(
-        "ub.poison",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "ub.poison", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Vector.jl
+++ b/src/Dialects/17/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `vscale`
@@ -18,19 +18,23 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.vscale", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.vscale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -59,17 +63,21 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.bitcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.bitcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -105,17 +113,21 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[source, ]
+    results = IR.Type[vector,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.broadcast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.broadcast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -155,18 +167,28 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
+function compressstore(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore, ]
+    operands = Value[base, indices..., mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.compressstore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.compressstore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -202,17 +224,21 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0, ]
+    results = IR.Type[result_0,]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
-    
-    IR.create_operation(
-        "vector.constant_mask", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
+
+    return IR.create_operation(
+        "vector.constant_mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -327,19 +353,35 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(lhs::Value, rhs::Value, acc::Value; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, acc, ]
+function contract(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    result_0::IR.Type,
+    indexing_maps,
+    iterator_types,
+    kind=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
+    attributes = NamedAttribute[
+        namedattribute("indexing_maps", indexing_maps),
+        namedattribute("iterator_types", iterator_types),
+    ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-    
-    IR.create_operation(
-        "vector.contract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.contract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -373,18 +415,22 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[operands_..., ]
+function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0,]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.create_mask", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.create_mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -424,18 +470,29 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., mask, pass_thru, ]
+function expandload(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.expandload", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.expandload",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -461,19 +518,29 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, ]
+function extractelement(
+    vector::Value,
+    position=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    
-    IR.create_operation(
-        "vector.extractelement", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(result) && push!(results, result)
+
+    return IR.create_operation(
+        "vector.extractelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -491,19 +558,25 @@ the proper position. Degenerates to an element type if n-k is zero.
 %3 = vector.extract %1[]: vector<f32>
 ```
 """
-function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function extract(
+    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
+)
     results = IR.Type[]
-    operands = Value[vector, ]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(result_0) && push!(results, result_0)
-    
-    IR.create_operation(
-        "vector.extract", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -533,18 +606,28 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[vector, ]
+function extract_strided_slice(
+    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
+)
+    results = IR.Type[result_0,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
-    
-    IR.create_operation(
-        "vector.extract_strided_slice", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("offsets", offsets),
+        namedattribute("sizes", sizes),
+        namedattribute("strides", strides),
+    ]
+
+    return IR.create_operation(
+        "vector.extract_strided_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -565,19 +648,29 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function fma(
+    lhs::Value,
+    rhs::Value,
+    acc::Value;
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc, ]
+    operands = Value[lhs, rhs, acc]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.fma", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.fma",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -607,17 +700,23 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[matrix, ]
+    results = IR.Type[res,]
+    operands = Value[matrix,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
-    
-    IR.create_operation(
-        "vector.flat_transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("rows", rows), namedattribute("columns", columns)
+    ]
+
+    return IR.create_operation(
+        "vector.flat_transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -656,18 +755,30 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
+function gather(
+    base::Value,
+    indices::Vector{Value},
+    index_vec::Value,
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., index_vec, mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.gather", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.gather",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -692,20 +803,30 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
+function insertelement(
+    source::Value,
+    dest::Value,
+    position=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-    
-    IR.create_operation(
-        "vector.insertelement", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insertelement",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -725,19 +846,29 @@ position. Degenerates to a scalar or a 0-d vector source type when n = 0.
 %11 = vector.insert %9, %10[3, 3, 3] : vector<f32> into vector<4x8x16xf32>
 ```
 """
-function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
+function insert(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    position,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position), ]
+    attributes = NamedAttribute[namedattribute("position", position),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -763,19 +894,32 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
+function insert_strided_slice(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    offsets,
+    strides,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
+    attributes = NamedAttribute[
+        namedattribute("offsets", offsets), namedattribute("strides", strides)
+    ]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.insert_strided_slice", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.insert_strided_slice",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -836,17 +980,21 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., ]
+    results = IR.Type[result,]
+    operands = Value[base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.load", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.load",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -898,19 +1046,29 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[mask, ]
-    owned_regions = Region[maskRegion, ]
+function mask(
+    mask::Value,
+    passthru=nothing::Union{Nothing,Value};
+    results::Vector{IR.Type},
+    maskRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[mask,]
+    owned_regions = Region[maskRegion,]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-    
-    IR.create_operation(
-        "vector.mask", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.mask",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -948,18 +1106,29 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[base, indices..., mask, pass_thru, ]
+function maskedload(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    pass_thru::Value;
+    result::IR.Type,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[base, indices..., mask, pass_thru]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.maskedload", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.maskedload",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -997,18 +1166,28 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
+function maskedstore(
+    base::Value,
+    indices::Vector{Value},
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore, ]
+    operands = Value[base, indices..., mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.maskedstore", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.maskedstore",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1039,18 +1218,34 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[lhs, rhs, ]
+function matrix_multiply(
+    lhs::Value,
+    rhs::Value;
+    res::IR.Type,
+    lhs_rows,
+    lhs_columns,
+    rhs_columns,
+    location=Location(),
+)
+    results = IR.Type[res,]
+    operands = Value[lhs, rhs]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
-    
-    IR.create_operation(
-        "vector.matrix_multiply", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[
+        namedattribute("lhs_rows", lhs_rows),
+        namedattribute("lhs_columns", lhs_columns),
+        namedattribute("rhs_columns", rhs_columns),
+    ]
+
+    return IR.create_operation(
+        "vector.matrix_multiply",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1071,19 +1266,32 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
+function multi_reduction(
+    source::Value,
+    acc::Value;
+    dest=nothing::Union{Nothing,IR.Type},
+    kind,
+    reduction_dims,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, acc, ]
+    operands = Value[source, acc]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
+    attributes = NamedAttribute[
+        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
+    ]
     !isnothing(dest) && push!(results, dest)
-    
-    IR.create_operation(
-        "vector.multi_reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.multi_reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1137,19 +1345,30 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
-    results = IR.Type[result_0, ]
-    operands = Value[lhs, rhs, acc..., ]
+function outerproduct(
+    lhs::Value,
+    rhs::Value,
+    acc::Vector{Value};
+    result_0::IR.Type,
+    kind=nothing,
+    location=Location(),
+)
+    results = IR.Type[result_0,]
+    operands = Value[lhs, rhs, acc...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-    
-    IR.create_operation(
-        "vector.outerproduct", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.outerproduct",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1179,16 +1398,20 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source, ]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.print", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.print",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1214,19 +1437,29 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
-    results = IR.Type[dest, ]
-    operands = Value[vector, ]
+function reduction(
+    vector::Value,
+    acc=nothing::Union{Nothing,Value};
+    dest::IR.Type,
+    kind,
+    location=Location(),
+)
+    results = IR.Type[dest,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), ]
+    attributes = NamedAttribute[namedattribute("kind", kind),]
     !isnothing(acc) && push!(operands, acc)
-    
-    IR.create_operation(
-        "vector.reduction", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.reduction",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1314,19 +1547,30 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, input_shape..., output_shape..., ]
+function reshape(
+    vector::Value,
+    input_shape::Vector{Value},
+    output_shape::Vector{Value};
+    result::IR.Type,
+    fixed_vector_sizes,
+    location=Location(),
+)
+    results = IR.Type[result,]
+    operands = Value[vector, input_shape..., output_shape...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
-    
-    IR.create_operation(
-        "vector.reshape", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
+
+    return IR.create_operation(
+        "vector.reshape",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1355,17 +1599,21 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[source, ]
+    results = IR.Type[res,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos), ]
-    
-    IR.create_operation(
-        "vector.scalable.extract", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos),]
+
+    return IR.create_operation(
+        "vector.scalable.extract",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1397,19 +1645,29 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
+function scalable_insert(
+    source::Value,
+    dest::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    pos,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, dest, ]
+    operands = Value[source, dest]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    attributes = NamedAttribute[namedattribute("pos", pos),]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "vector.scalable.insert", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scalable.insert",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1430,20 +1688,37 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
+function scan(
+    source::Value,
+    initial_value::Value;
+    dest=nothing::Union{Nothing,IR.Type},
+    accumulated_value=nothing::Union{Nothing,IR.Type},
+    kind,
+    reduction_dim,
+    inclusive,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[source, initial_value, ]
+    operands = Value[source, initial_value]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
+    attributes = NamedAttribute[
+        namedattribute("kind", kind),
+        namedattribute("reduction_dim", reduction_dim),
+        namedattribute("inclusive", inclusive),
+    ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-    
-    IR.create_operation(
-        "vector.scan", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scan",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1486,18 +1761,29 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
+function scatter(
+    base::Value,
+    indices::Vector{Value},
+    index_vec::Value,
+    mask::Value,
+    valueToStore::Value;
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
+    operands = Value[base, indices..., index_vec, mask, valueToStore]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.scatter", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.scatter",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1537,17 +1823,21 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[source, ]
+    results = IR.Type[result,]
+    operands = Value[source,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.shape_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.shape_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1586,19 +1876,25 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
+function shuffle(
+    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
+)
     results = IR.Type[]
-    operands = Value[v1, v2, ]
+    operands = Value[v1, v2]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask), ]
+    attributes = NamedAttribute[namedattribute("mask", mask),]
     !isnothing(vector) && push!(results, vector)
-    
-    IR.create_operation(
-        "vector.shuffle", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.shuffle",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -1616,17 +1912,21 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate, ]
-    operands = Value[input, ]
+    results = IR.Type[aggregate,]
+    operands = Value[input,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.splat", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.splat",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1684,18 +1984,24 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
+function store(
+    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
+)
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices..., ]
+    operands = Value[valueToStore, base, indices...]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.store", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.store",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1880,21 +2186,36 @@ affine.for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
-    results = IR.Type[vector, ]
-    operands = Value[source, indices..., padding, ]
+function transfer_read(
+    source::Value,
+    indices::Vector{Value},
+    padding::Value,
+    mask=nothing::Union{Nothing,Value};
+    vector::IR.Type,
+    permutation_map,
+    in_bounds=nothing,
+    location=Location(),
+)
+    results = IR.Type[vector,]
+    operands = Value[source, indices..., padding]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
     !isnothing(mask) && push!(operands, mask)
-    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
+    push!(
+        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
+    )
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-    
-    IR.create_operation(
-        "vector.transfer_read", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.transfer_read",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -1997,22 +2318,37 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
+function transfer_write(
+    vector::Value,
+    source::Value,
+    indices::Vector{Value},
+    mask=nothing::Union{Nothing,Value};
+    result=nothing::Union{Nothing,IR.Type},
+    permutation_map,
+    in_bounds=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[vector, source, indices..., ]
+    operands = Value[vector, source, indices...]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
     !isnothing(mask) && push!(operands, mask)
-    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
+    push!(
+        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
+    )
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-    
-    IR.create_operation(
-        "vector.transfer_write", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.transfer_write",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2043,17 +2379,21 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[vector, ]
+    results = IR.Type[result,]
+    operands = Value[vector,]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp), ]
-    
-    IR.create_operation(
-        "vector.transpose", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp),]
+
+    return IR.create_operation(
+        "vector.transpose",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2080,17 +2420,21 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result, ]
-    operands = Value[memref, ]
+    results = IR.Type[result,]
+    operands = Value[memref,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.type_cast", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.type_cast",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2196,18 +2540,29 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
-    results = IR.Type[results_..., ]
-    operands = Value[laneid, args..., ]
-    owned_regions = Region[warpRegion, ]
+function warp_execute_on_lane_0(
+    laneid::Value,
+    args::Vector{Value};
+    results::Vector{IR.Type},
+    warp_size,
+    warpRegion::Region,
+    location=Location(),
+)
+    results = IR.Type[results...,]
+    operands = Value[laneid, args...]
+    owned_regions = Region[warpRegion,]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
-    
-    IR.create_operation(
-        "vector.warp_execute_on_lane_0", location;
-        operands, owned_regions, successors, attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
+
+    return IR.create_operation(
+        "vector.warp_execute_on_lane_0",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -2222,18 +2577,22 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands_::Vector{Value}; location=Location())
+function yield(operands::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands_..., ]
+    operands = Value[operands...,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "vector.yield", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "vector.yield",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/Vector.jl
+++ b/src/Dialects/17/Vector.jl
@@ -1,9 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `vscale`
@@ -19,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -64,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -114,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -168,28 +155,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -225,21 +202,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -354,35 +327,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc]
+function contract(lhs::Value, rhs::Value, acc::Value; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -416,22 +373,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -471,29 +424,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -519,29 +461,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -559,25 +491,19 @@ the proper position. Degenerates to an element type if n-k is zero.
 %3 = vector.extract %1[]: vector<f32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -607,28 +533,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -649,29 +565,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -701,23 +607,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -756,30 +656,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -804,30 +692,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -847,29 +725,19 @@ position. Degenerates to a scalar or a 0-d vector source type when n = 0.
 %11 = vector.insert %9, %10[3, 3, 3] : vector<f32> into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -895,32 +763,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -981,21 +836,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1047,29 +898,19 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(
-    mask::Value,
-    passthru=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    maskRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mask,]
-    owned_regions = Region[maskRegion,]
+function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mask, ]
+    owned_regions = Region[maskRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-
-    return IR.create_operation(
-        "vector.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1107,29 +948,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1167,28 +997,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1219,34 +1039,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1267,32 +1071,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1346,30 +1137,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1399,20 +1179,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1438,29 +1214,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1548,30 +1314,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1600,21 +1355,17 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res,]
-    operands = Value[source,]
+    results = IR.Type[res, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
-
-    return IR.create_operation(
-        "vector.scalable.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    
+    IR.create_operation(
+        "vector.scalable.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1646,29 +1397,19 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    pos,
-    location=Location(),
-)
+function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.scalable.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scalable.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1689,37 +1430,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1762,29 +1486,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1824,21 +1537,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1877,25 +1586,19 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1913,21 +1616,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1985,24 +1684,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2187,36 +1880,21 @@ affine.for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2319,37 +1997,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2380,21 +2043,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2421,21 +2080,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2541,29 +2196,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2578,22 +2222,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/Vector.jl
+++ b/src/Dialects/17/Vector.jl
@@ -1,8 +1,8 @@
 module vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `vscale`
@@ -18,23 +18,19 @@ op can be used to calculate the step in vector-length agnostic (VLA) loops.
 Right now we only support one contiguous set of scalable dimensions, all of
 them grouped and scaled with the value returned by \'vscale\'.
 """
-function vscale(; res=nothing::Union{Nothing,IR.Type}, location=Location())
+function vscale(; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.vscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.vscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -63,21 +59,17 @@ equal.
 ```
 """
 function bitcast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.bitcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.bitcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -113,21 +105,17 @@ shaped vector with the same element type is always legal.
 ```
 """
 function broadcast(source::Value; vector::IR.Type, location=Location())
-    results = IR.Type[vector,]
-    operands = Value[source,]
+    results = IR.Type[vector, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.broadcast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.broadcast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -167,28 +155,18 @@ vector.compressstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function compressstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function compressstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.compressstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.compressstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -224,21 +202,17 @@ print %1
 ```
 """
 function constant_mask(; result_0::IR.Type, mask_dim_sizes, location=Location())
-    results = IR.Type[result_0,]
+    results = IR.Type[result_0, ]
     operands = Value[]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes),]
-
-    return IR.create_operation(
-        "vector.constant_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("mask_dim_sizes", mask_dim_sizes), ]
+    
+    IR.create_operation(
+        "vector.constant_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -353,35 +327,19 @@ int only. The default is \"add\".
   : vector<10xf32>, vector<10xf32> into f32
 ```
 """
-function contract(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result_0::IR.Type,
-    indexing_maps,
-    iterator_types,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc]
+function contract(lhs::Value, rhs::Value, acc::Value; result_0::IR.Type, indexing_maps, iterator_types, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("indexing_maps", indexing_maps),
-        namedattribute("iterator_types", iterator_types),
-    ]
+    attributes = NamedAttribute[namedattribute("indexing_maps", indexing_maps), namedattribute("iterator_types", iterator_types), ]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.contract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.contract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -415,22 +373,18 @@ print %1
         3 | 0    0    0
 ```
 """
-function create_mask(operands::Vector{Value}; result_0::IR.Type, location=Location())
-    results = IR.Type[result_0,]
-    operands = Value[operands...,]
+function create_mask(operands_::Vector{Value}; result_0::IR.Type, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.create_mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.create_mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -470,29 +424,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function expandload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function expandload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.expandload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.expandload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -518,29 +461,19 @@ https://llvm.org/docs/LangRef.html#extractelement-instruction
 %2 = vector.extractelement %z[]: vector<f32>
 ```
 """
-function extractelement(
-    vector::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[vector,]
+function extractelement(vector::Value, position=nothing::Union{Nothing, Value}; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
-    !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.extractelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "vector.extractelement", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -558,25 +491,19 @@ the proper position. Degenerates to an element type if n-k is zero.
 %3 = vector.extract %1[]: vector<f32>
 ```
 """
-function extract(
-    vector::Value; result_0=nothing::Union{Nothing,IR.Type}, position, location=Location()
-)
+function extract(vector::Value; result_0=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[vector,]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(result_0) && push!(results, result_0)
-
-    return IR.create_operation(
-        "vector.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.extract", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -606,28 +533,18 @@ attribute. The returned subvector contains the elements starting at offset
   vector<4x8x16xf32> to vector<2x4x16xf32>
 ```
 """
-function extract_strided_slice(
-    vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location()
-)
-    results = IR.Type[result_0,]
-    operands = Value[vector,]
+function extract_strided_slice(vector::Value; result_0::IR.Type, offsets, sizes, strides, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets),
-        namedattribute("sizes", sizes),
-        namedattribute("strides", strides),
-    ]
-
-    return IR.create_operation(
-        "vector.extract_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("sizes", sizes), namedattribute("strides", strides), ]
+    
+    IR.create_operation(
+        "vector.extract_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -648,29 +565,19 @@ to the `llvm.fma.*` intrinsic.
 %3 = vector.fma %0, %1, %2: vector<8x16xf32>
 ```
 """
-function fma(
-    lhs::Value,
-    rhs::Value,
-    acc::Value;
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function fma(lhs::Value, rhs::Value, acc::Value; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[lhs, rhs, acc]
+    operands = Value[lhs, rhs, acc, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.fma",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.fma", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -700,23 +607,17 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-transpose-intrinsic
 ```
 """
 function flat_transpose(matrix::Value; res::IR.Type, rows, columns, location=Location())
-    results = IR.Type[res,]
-    operands = Value[matrix,]
+    results = IR.Type[res, ]
+    operands = Value[matrix, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("rows", rows), namedattribute("columns", columns)
-    ]
-
-    return IR.create_operation(
-        "vector.flat_transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("rows", rows), namedattribute("columns", columns), ]
+    
+    IR.create_operation(
+        "vector.flat_transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -755,30 +656,18 @@ Examples:
    : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function gather(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., index_vec, mask, pass_thru]
+function gather(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., index_vec, mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.gather",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.gather", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -803,30 +692,20 @@ https://llvm.org/docs/LangRef.html#insertelement-instruction
 %2 = vector.insertelement %f, %z[]: vector<f32>
 ```
 """
-function insertelement(
-    source::Value,
-    dest::Value,
-    position=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function insertelement(source::Value, dest::Value, position=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(position) && push!(operands, position)
     !isnothing(result) && push!(results, result)
-
-    return IR.create_operation(
-        "vector.insertelement",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insertelement", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -846,29 +725,19 @@ position. Degenerates to a scalar or a 0-d vector source type when n = 0.
 %11 = vector.insert %9, %10[3, 3, 3] : vector<f32> into vector<4x8x16xf32>
 ```
 """
-function insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    position,
-    location=Location(),
-)
+function insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, position, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("position", position),]
+    attributes = NamedAttribute[namedattribute("position", position), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -894,32 +763,19 @@ the proper location as specified by the offsets.
   vector<2x4xf32> into vector<16x4x8xf32>
 ```
 """
-function insert_strided_slice(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    offsets,
-    strides,
-    location=Location(),
-)
+function insert_strided_slice(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, offsets, strides, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("offsets", offsets), namedattribute("strides", strides)
-    ]
+    attributes = NamedAttribute[namedattribute("offsets", offsets), namedattribute("strides", strides), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.insert_strided_slice",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.insert_strided_slice", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -980,21 +836,17 @@ Example 6:  Explicit out-of-bound vector load.
 ```
 """
 function load(base::Value, indices::Vector{Value}; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[base, indices...]
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.load",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.load", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1046,29 +898,19 @@ Examples:
   vector.mask %mask { vector.transfer_write %val, %t0[%idx] : vector<16xf32>, tensor<?xf32> } : vector<16xi1> -> tensor<?xf32>
 ```
 """
-function mask(
-    mask::Value,
-    passthru=nothing::Union{Nothing,Value};
-    results::Vector{IR.Type},
-    maskRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[mask,]
-    owned_regions = Region[maskRegion,]
+function mask(mask::Value, passthru=nothing::Union{Nothing, Value}; results_::Vector{IR.Type}, maskRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[mask, ]
+    owned_regions = Region[maskRegion, ]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(passthru) && push!(operands, passthru)
-
-    return IR.create_operation(
-        "vector.mask",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.mask", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1106,29 +948,18 @@ Examples:
    : memref<?x?xf32>, vector<16xi1>, vector<16xf32> into vector<16xf32>
 ```
 """
-function maskedload(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    pass_thru::Value;
-    result::IR.Type,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[base, indices..., mask, pass_thru]
+function maskedload(base::Value, indices::Vector{Value}, mask::Value, pass_thru::Value; result::IR.Type, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[base, indices..., mask, pass_thru, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedload",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedload", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1166,28 +997,18 @@ vector.maskedstore %base[%i, %j], %mask, %value
   : memref<?x?xf32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function maskedstore(
-    base::Value,
-    indices::Vector{Value},
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function maskedstore(base::Value, indices::Vector{Value}, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., mask, valueToStore]
+    operands = Value[base, indices..., mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.maskedstore",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.maskedstore", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1218,34 +1039,18 @@ http://llvm.org/docs/LangRef.html#llvm-matrix-multiply-intrinsic
   (vector<64xf64>, vector<48xf64>) -> vector<12xf64>
 ```
 """
-function matrix_multiply(
-    lhs::Value,
-    rhs::Value;
-    res::IR.Type,
-    lhs_rows,
-    lhs_columns,
-    rhs_columns,
-    location=Location(),
-)
-    results = IR.Type[res,]
-    operands = Value[lhs, rhs]
+function matrix_multiply(lhs::Value, rhs::Value; res::IR.Type, lhs_rows, lhs_columns, rhs_columns, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[lhs, rhs, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("lhs_rows", lhs_rows),
-        namedattribute("lhs_columns", lhs_columns),
-        namedattribute("rhs_columns", rhs_columns),
-    ]
-
-    return IR.create_operation(
-        "vector.matrix_multiply",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("lhs_rows", lhs_rows), namedattribute("lhs_columns", lhs_columns), namedattribute("rhs_columns", rhs_columns), ]
+    
+    IR.create_operation(
+        "vector.matrix_multiply", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1266,32 +1071,19 @@ Takes an initial accumulator operand.
   vector<4x16xf32> into f32
 ```
 """
-function multi_reduction(
-    source::Value,
-    acc::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dims,
-    location=Location(),
-)
+function multi_reduction(source::Value, acc::Value; dest=nothing::Union{Nothing, IR.Type}, kind, reduction_dims, location=Location())
     results = IR.Type[]
-    operands = Value[source, acc]
+    operands = Value[source, acc, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims)
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dims", reduction_dims), ]
     !isnothing(dest) && push!(results, dest)
-
-    return IR.create_operation(
-        "vector.multi_reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.multi_reduction", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1345,30 +1137,19 @@ return %6: vector<10xf32>
 
 ```
 """
-function outerproduct(
-    lhs::Value,
-    rhs::Value,
-    acc::Vector{Value};
-    result_0::IR.Type,
-    kind=nothing,
-    location=Location(),
-)
-    results = IR.Type[result_0,]
-    operands = Value[lhs, rhs, acc...]
+function outerproduct(lhs::Value, rhs::Value, acc::Vector{Value}; result_0::IR.Type, kind=nothing, location=Location())
+    results = IR.Type[result_0, ]
+    operands = Value[lhs, rhs, acc..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(kind) && push!(attributes, namedattribute("kind", kind))
-
-    return IR.create_operation(
-        "vector.outerproduct",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.outerproduct", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1398,20 +1179,16 @@ newline).
 """
 function print(source::Value; location=Location())
     results = IR.Type[]
-    operands = Value[source,]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.print",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.print", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1437,29 +1214,19 @@ http://llvm.org/docs/LangRef.html#vector-reduction-intrinsics
 %4 = vector.reduction <mul>, %0, %1 : vector<16xf32> into f32
 ```
 """
-function reduction(
-    vector::Value,
-    acc=nothing::Union{Nothing,Value};
-    dest::IR.Type,
-    kind,
-    location=Location(),
-)
-    results = IR.Type[dest,]
-    operands = Value[vector,]
+function reduction(vector::Value, acc=nothing::Union{Nothing, Value}; dest::IR.Type, kind, location=Location())
+    results = IR.Type[dest, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("kind", kind),]
+    attributes = NamedAttribute[namedattribute("kind", kind), ]
     !isnothing(acc) && push!(operands, acc)
-
-    return IR.create_operation(
-        "vector.reduction",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.reduction", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1547,30 +1314,19 @@ Example
                     [n, o, p, q],
                     [r, -, -, -]]]
 """
-function reshape(
-    vector::Value,
-    input_shape::Vector{Value},
-    output_shape::Vector{Value};
-    result::IR.Type,
-    fixed_vector_sizes,
-    location=Location(),
-)
-    results = IR.Type[result,]
-    operands = Value[vector, input_shape..., output_shape...]
+function reshape(vector::Value, input_shape::Vector{Value}, output_shape::Vector{Value}; result::IR.Type, fixed_vector_sizes, location=Location())
+    results = IR.Type[result, ]
+    operands = Value[vector, input_shape..., output_shape..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes),]
-    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape)]))
-
-    return IR.create_operation(
-        "vector.reshape",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("fixed_vector_sizes", fixed_vector_sizes), ]
+    push!(attributes, operandsegmentsizes([1, length(input_shape), length(output_shape), ]))
+    
+    IR.create_operation(
+        "vector.reshape", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1599,21 +1355,17 @@ Invalid example:
 ```
 """
 function scalable_extract(source::Value; res::IR.Type, pos, location=Location())
-    results = IR.Type[res,]
-    operands = Value[source,]
+    results = IR.Type[res, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
-
-    return IR.create_operation(
-        "vector.scalable.extract",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
+    
+    IR.create_operation(
+        "vector.scalable.extract", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1645,29 +1397,19 @@ Invalid example:
 %2 = vector.scalable.insert %0, %1[5] : vector<4xf32> into vector<[16]xf32>
 ```
 """
-function scalable_insert(
-    source::Value,
-    dest::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    pos,
-    location=Location(),
-)
+function scalable_insert(source::Value, dest::Value; res=nothing::Union{Nothing, IR.Type}, pos, location=Location())
     results = IR.Type[]
-    operands = Value[source, dest]
+    operands = Value[source, dest, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("pos", pos),]
+    attributes = NamedAttribute[namedattribute("pos", pos), ]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "vector.scalable.insert",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scalable.insert", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1688,37 +1430,20 @@ reduction in the scan.
   vector<4x8x16x32xf32>, vector<4x16x32xf32>
 ```
 """
-function scan(
-    source::Value,
-    initial_value::Value;
-    dest=nothing::Union{Nothing,IR.Type},
-    accumulated_value=nothing::Union{Nothing,IR.Type},
-    kind,
-    reduction_dim,
-    inclusive,
-    location=Location(),
-)
+function scan(source::Value, initial_value::Value; dest=nothing::Union{Nothing, IR.Type}, accumulated_value=nothing::Union{Nothing, IR.Type}, kind, reduction_dim, inclusive, location=Location())
     results = IR.Type[]
-    operands = Value[source, initial_value]
+    operands = Value[source, initial_value, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[
-        namedattribute("kind", kind),
-        namedattribute("reduction_dim", reduction_dim),
-        namedattribute("inclusive", inclusive),
-    ]
+    attributes = NamedAttribute[namedattribute("kind", kind), namedattribute("reduction_dim", reduction_dim), namedattribute("inclusive", inclusive), ]
     !isnothing(dest) && push!(results, dest)
     !isnothing(accumulated_value) && push!(results, accumulated_value)
-
-    return IR.create_operation(
-        "vector.scan",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scan", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1761,29 +1486,18 @@ vector.scatter %base[%i, %j][%v], %mask, %value
     : memref<16x16xf32>, vector<16xi32>, vector<16xi1>, vector<16xf32>
 ```
 """
-function scatter(
-    base::Value,
-    indices::Vector{Value},
-    index_vec::Value,
-    mask::Value,
-    valueToStore::Value;
-    location=Location(),
-)
+function scatter(base::Value, indices::Vector{Value}, index_vec::Value, mask::Value, valueToStore::Value; location=Location())
     results = IR.Type[]
-    operands = Value[base, indices..., index_vec, mask, valueToStore]
+    operands = Value[base, indices..., index_vec, mask, valueToStore, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.scatter",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.scatter", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1823,21 +1537,17 @@ is supported in that particular case, for now.
 ```
 """
 function shape_cast(source::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[source,]
+    results = IR.Type[result, ]
+    operands = Value[source, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.shape_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shape_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1876,25 +1586,19 @@ The legality rules are:
            : vector<f32>, vector<f32>           ; yields vector<2xf32>
 ```
 """
-function shuffle(
-    v1::Value, v2::Value; vector=nothing::Union{Nothing,IR.Type}, mask, location=Location()
-)
+function shuffle(v1::Value, v2::Value; vector=nothing::Union{Nothing, IR.Type}, mask, location=Location())
     results = IR.Type[]
-    operands = Value[v1, v2]
+    operands = Value[v1, v2, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("mask", mask),]
+    attributes = NamedAttribute[namedattribute("mask", mask), ]
     !isnothing(vector) && push!(results, vector)
-
-    return IR.create_operation(
-        "vector.shuffle",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.shuffle", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -1912,21 +1616,17 @@ required to be of integer/index/float type.
 ```
 """
 function splat(input::Value; aggregate::IR.Type, location=Location())
-    results = IR.Type[aggregate,]
-    operands = Value[input,]
+    results = IR.Type[aggregate, ]
+    operands = Value[input, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.splat",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.splat", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -1984,24 +1684,18 @@ Example 6:  Explicit out-of-bounds vector store.
 vector.store %valueToStore, %memref[%c0] : memref<7xf32>, vector<8xf32>
 ```
 """
-function store(
-    valueToStore::Value, base::Value, indices::Vector{Value}; location=Location()
-)
+function store(valueToStore::Value, base::Value, indices::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[valueToStore, base, indices...]
+    operands = Value[valueToStore, base, indices..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.store",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.store", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2186,36 +1880,21 @@ affine.for %i0 = 0 to %0 {
   tensor<f32>, vector<1xf32>
 ```
 """
-function transfer_read(
-    source::Value,
-    indices::Vector{Value},
-    padding::Value,
-    mask=nothing::Union{Nothing,Value};
-    vector::IR.Type,
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
-    results = IR.Type[vector,]
-    operands = Value[source, indices..., padding]
+function transfer_read(source::Value, indices::Vector{Value}, padding::Value, mask=nothing::Union{Nothing, Value}; vector::IR.Type, permutation_map, in_bounds=nothing, location=Location())
+    results = IR.Type[vector, ]
+    operands = Value[source, indices..., padding, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, length(indices), 1, (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, length(indices), 1, (mask==nothing) ? 0 : 1]))
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_read",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_read", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2318,37 +1997,22 @@ vector.transfer_write %4, %arg1[%c3, %c3]
   vector<1xf32>, tensor<f32>
 ```
 """
-function transfer_write(
-    vector::Value,
-    source::Value,
-    indices::Vector{Value},
-    mask=nothing::Union{Nothing,Value};
-    result=nothing::Union{Nothing,IR.Type},
-    permutation_map,
-    in_bounds=nothing,
-    location=Location(),
-)
+function transfer_write(vector::Value, source::Value, indices::Vector{Value}, mask=nothing::Union{Nothing, Value}; result=nothing::Union{Nothing, IR.Type}, permutation_map, in_bounds=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[vector, source, indices...]
+    operands = Value[vector, source, indices..., ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map),]
+    attributes = NamedAttribute[namedattribute("permutation_map", permutation_map), ]
     !isnothing(mask) && push!(operands, mask)
-    push!(
-        attributes, operandsegmentsizes([1, 1, length(indices), (mask == nothing) ? 0 : 1])
-    )
+    push!(attributes, operandsegmentsizes([1, 1, length(indices), (mask==nothing) ? 0 : 1]))
     !isnothing(result) && push!(results, result)
     !isnothing(in_bounds) && push!(attributes, namedattribute("in_bounds", in_bounds))
-
-    return IR.create_operation(
-        "vector.transfer_write",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.transfer_write", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2379,21 +2043,17 @@ the transp array [i_1, .., i_n] must be a permutation of [0, .., n-1].
 ```
 """
 function transpose(vector::Value; result::IR.Type, transp, location=Location())
-    results = IR.Type[result,]
-    operands = Value[vector,]
+    results = IR.Type[result, ]
+    operands = Value[vector, ]
     owned_regions = Region[]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("transp", transp),]
-
-    return IR.create_operation(
-        "vector.transpose",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("transp", transp), ]
+    
+    IR.create_operation(
+        "vector.transpose", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2420,21 +2080,17 @@ operation ::= `vector.type_cast` ssa-use : memref-type to memref-type
 ```
 """
 function type_cast(memref::Value; result::IR.Type, location=Location())
-    results = IR.Type[result,]
-    operands = Value[memref,]
+    results = IR.Type[result, ]
+    operands = Value[memref, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.type_cast",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.type_cast", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2540,29 +2196,18 @@ some_synchronization_primitive
 // Execute in parallel on all threads/lanes.
 ```
 """
-function warp_execute_on_lane_0(
-    laneid::Value,
-    args::Vector{Value};
-    results::Vector{IR.Type},
-    warp_size,
-    warpRegion::Region,
-    location=Location(),
-)
-    results = IR.Type[results...,]
-    operands = Value[laneid, args...]
-    owned_regions = Region[warpRegion,]
+function warp_execute_on_lane_0(laneid::Value, args::Vector{Value}; results_::Vector{IR.Type}, warp_size, warpRegion::Region, location=Location())
+    results = IR.Type[results_..., ]
+    operands = Value[laneid, args..., ]
+    owned_regions = Region[warpRegion, ]
     successors = Block[]
-    attributes = NamedAttribute[namedattribute("warp_size", warp_size),]
-
-    return IR.create_operation(
-        "vector.warp_execute_on_lane_0",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    attributes = NamedAttribute[namedattribute("warp_size", warp_size), ]
+    
+    IR.create_operation(
+        "vector.warp_execute_on_lane_0", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -2577,22 +2222,18 @@ parent operation\'s results.
 If the parent operation defines no value the vector.yield may be omitted
 when printing the region.
 """
-function yield(operands::Vector{Value}; location=Location())
+function yield(operands_::Vector{Value}; location=Location())
     results = IR.Type[]
-    operands = Value[operands...,]
+    operands = Value[operands_..., ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "vector.yield",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "vector.yield", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/X86Vector.jl
+++ b/src/Dialects/17/X86Vector.jl
@@ -1,26 +1,32 @@
 module x86vector
 
-import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR:
+    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_dp_ps_256(
+    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, b, c, ]
+    operands = Value[a, b, c]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -42,19 +48,25 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_dot(
+    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, b, ]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.dot", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.dot",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -62,19 +74,25 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_compress(
+    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, src, k, ]
+    operands = Value[a, src, k]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.compress", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -93,21 +111,33 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
+function avx512_mask_compress(
+    k::Value,
+    a::Value,
+    src=nothing::Union{Nothing,Value};
+    dst=nothing::Union{Nothing,IR.Type},
+    constant_src=nothing,
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[k, a, ]
+    operands = Value[k, a]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.compress", location;
-        operands, owned_regions, successors, attributes,
+    !isnothing(constant_src) &&
+        push!(attributes, namedattribute("constant_src", constant_src))
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.compress",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -125,19 +155,31 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_mask_rndscale(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    dst=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.rndscale", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.rndscale",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -145,19 +187,31 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_rndscale_pd_512(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -165,19 +219,31 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_rndscale_ps_512(
+    src::Value,
+    k::Value,
+    a::Value,
+    imm::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding, ]
+    operands = Value[src, k, a, imm, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -195,19 +261,31 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_mask_scalef(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    dst=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-    
-    IR.create_operation(
-        "x86vector.avx512.mask.scalef", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.mask.scalef",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -215,19 +293,31 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_scalef_pd_512(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -235,19 +325,31 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx512_intr_mask_scalef_ps_512(
+    src::Value,
+    a::Value,
+    b::Value,
+    k::Value,
+    rounding::Value;
+    res=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding, ]
+    operands = Value[src, a, b, k, rounding]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -255,19 +357,25 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_intr_rsqrt_ps_256(
+    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
+)
     results = IR.Type[]
-    operands = Value[a, ]
+    operands = Value[a,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-    
-    IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -275,19 +383,23 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, ]
+    operands = Value[a,]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-    
-    IR.create_operation(
-        "x86vector.avx.rsqrt", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx.rsqrt",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false)
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -295,18 +407,24 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+function avx512_intr_vp2intersect_d_512(
+    a::Value, b::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 
@@ -326,18 +444,30 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
-    results = IR.Type[k1, k2, ]
-    operands = Value[a, b, ]
+function avx512_vp2intersect(
+    a::Value,
+    b::Value;
+    k1=nothing::Union{Nothing,IR.Type},
+    k2=nothing::Union{Nothing,IR.Type},
+    location=Location(),
+)
+    results = IR.Type[]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.vp2intersect", location;
-        operands, owned_regions, successors, attributes,
-        results=results,
-        result_inference=false
+    !isnothing(k1) && push!(results, k1)
+    !isnothing(k2) && push!(results, k2)
+
+    return IR.create_operation(
+        "x86vector.avx512.vp2intersect",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
+        results=(length(results) == 0 ? nothing : results),
+        result_inference=(length(results) == 0 ? true : false),
     )
 end
 
@@ -345,18 +475,24 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
-    results = IR.Type[res, ]
-    operands = Value[a, b, ]
+function avx512_intr_vp2intersect_q_512(
+    a::Value, b::Value; res::IR.Type, location=Location()
+)
+    results = IR.Type[res,]
+    operands = Value[a, b]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    
-    IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512", location;
-        operands, owned_regions, successors, attributes,
+
+    return IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512",
+        location;
+        operands,
+        owned_regions,
+        successors,
+        attributes,
         results=results,
-        result_inference=false
+        result_inference=false,
     )
 end
 

--- a/src/Dialects/17/X86Vector.jl
+++ b/src/Dialects/17/X86Vector.jl
@@ -1,33 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
-import ...API
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -49,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -75,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -112,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -156,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -188,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -220,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -262,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -294,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -326,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -358,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -384,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -408,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -445,30 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value,
-    b::Value;
-    k1=nothing::Union{Nothing,IR.Type},
-    k2=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(k1) && push!(results, k1)
-    !isnothing(k2) && push!(results, k2)
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -476,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/Dialects/17/X86Vector.jl
+++ b/src/Dialects/17/X86Vector.jl
@@ -1,32 +1,26 @@
 module x86vector
 
-import ...IR:
-    IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
+import ...IR: IR, NamedAttribute, Value, Location, Block, Region, Attribute, context, IndexType
 import ..Dialects: namedattribute, operandsegmentsizes
+
 
 """
 `avx_intr_dp_ps_256`
 
 """
-function avx_intr_dp_ps_256(
-    a::Value, b::Value, c::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dp_ps_256(a::Value, b::Value, c::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b, c]
+    operands = Value[a, b, c, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dp.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dp.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -48,25 +42,19 @@ dot product of the two source vectors.
 %d = arith.addf %1, %2 : f32
 ```
 """
-function avx_intr_dot(
-    a::Value, b::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_dot(a::Value, b::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, b]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.dot",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.dot", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -74,25 +62,19 @@ end
 `avx512_intr_mask_compress`
 
 """
-function avx512_intr_mask_compress(
-    a::Value, src::Value, k::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx512_intr_mask_compress(a::Value, src::Value, k::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a, src, k]
+    operands = Value[a, src, k, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -111,33 +93,21 @@ Contiguously store the active integer/floating-point elements in `a` (those
 with their respective bit set in writemask `k`) to `dst`, and pass through the
 remaining elements from `src`.
 """
-function avx512_mask_compress(
-    k::Value,
-    a::Value,
-    src=nothing::Union{Nothing,Value};
-    dst=nothing::Union{Nothing,IR.Type},
-    constant_src=nothing,
-    location=Location(),
-)
+function avx512_mask_compress(k::Value, a::Value, src=nothing::Union{Nothing, Value}; dst=nothing::Union{Nothing, IR.Type}, constant_src=nothing, location=Location())
     results = IR.Type[]
-    operands = Value[k, a]
+    operands = Value[k, a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(src) && push!(operands, src)
     !isnothing(dst) && push!(results, dst)
-    !isnothing(constant_src) &&
-        push!(attributes, namedattribute("constant_src", constant_src))
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.compress",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    !isnothing(constant_src) && push!(attributes, namedattribute("constant_src", constant_src))
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.compress", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -155,31 +125,19 @@ Round packed floating-point elements in `a` to the number of fraction bits
 specified by `imm`, and store the results in `dst` using writemask `k`
 (elements are copied from src when the corresponding mask bit is not set).
 """
-function avx512_mask_rndscale(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_rndscale(src::Value, k::Value, a::Value, imm::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.rndscale",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.rndscale", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -187,31 +145,19 @@ end
 `avx512_intr_mask_rndscale_pd_512`
 
 """
-function avx512_intr_mask_rndscale_pd_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_pd_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -219,31 +165,19 @@ end
 `avx512_intr_mask_rndscale_ps_512`
 
 """
-function avx512_intr_mask_rndscale_ps_512(
-    src::Value,
-    k::Value,
-    a::Value,
-    imm::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_rndscale_ps_512(src::Value, k::Value, a::Value, imm::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, k, a, imm, rounding]
+    operands = Value[src, k, a, imm, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.rndscale.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.rndscale.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -261,31 +195,19 @@ Scale the packed floating-point elements in `a` using values from `b`, and
 store the results in `dst` using writemask `k` (elements are copied from src
 when the corresponding mask bit is not set).
 """
-function avx512_mask_scalef(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    dst=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_mask_scalef(src::Value, a::Value, b::Value, k::Value, rounding::Value; dst=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(dst) && push!(results, dst)
-
-    return IR.create_operation(
-        "x86vector.avx512.mask.scalef",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.mask.scalef", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -293,31 +215,19 @@ end
 `avx512_intr_mask_scalef_pd_512`
 
 """
-function avx512_intr_mask_scalef_pd_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_pd_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.pd.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.pd.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -325,31 +235,19 @@ end
 `avx512_intr_mask_scalef_ps_512`
 
 """
-function avx512_intr_mask_scalef_ps_512(
-    src::Value,
-    a::Value,
-    b::Value,
-    k::Value,
-    rounding::Value;
-    res=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
+function avx512_intr_mask_scalef_ps_512(src::Value, a::Value, b::Value, k::Value, rounding::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[src, a, b, k, rounding]
+    operands = Value[src, a, b, k, rounding, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.mask.scalef.ps.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.mask.scalef.ps.512", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -357,25 +255,19 @@ end
 `avx_intr_rsqrt_ps_256`
 
 """
-function avx_intr_rsqrt_ps_256(
-    a::Value; res=nothing::Union{Nothing,IR.Type}, location=Location()
-)
+function avx_intr_rsqrt_ps_256(a::Value; res=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(res) && push!(results, res)
-
-    return IR.create_operation(
-        "x86vector.avx.intr.rsqrt.ps.256",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.intr.rsqrt.ps.256", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -383,23 +275,19 @@ end
 `avx_rsqrt`
 
 """
-function avx_rsqrt(a::Value; b=nothing::Union{Nothing,IR.Type}, location=Location())
+function avx_rsqrt(a::Value; b=nothing::Union{Nothing, IR.Type}, location=Location())
     results = IR.Type[]
-    operands = Value[a,]
+    operands = Value[a, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
     !isnothing(b) && push!(results, b)
-
-    return IR.create_operation(
-        "x86vector.avx.rsqrt",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx.rsqrt", location;
+        operands, owned_regions, successors, attributes,
         results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+        result_inference=(length(results) == 0 ? true : false)
     )
 end
 
@@ -407,24 +295,18 @@ end
 `avx512_intr_vp2intersect_d_512`
 
 """
-function avx512_intr_vp2intersect_d_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_d_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.d.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.d.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 
@@ -444,30 +326,18 @@ specified by `k1` and `k2`. A match in corresponding elements of `a` and
 `b` is indicated by a set bit in the corresponding bit of the mask
 registers.
 """
-function avx512_vp2intersect(
-    a::Value,
-    b::Value;
-    k1=nothing::Union{Nothing,IR.Type},
-    k2=nothing::Union{Nothing,IR.Type},
-    location=Location(),
-)
-    results = IR.Type[]
-    operands = Value[a, b]
+function avx512_vp2intersect(a::Value, b::Value; k1::IR.Type, k2::IR.Type, location=Location())
+    results = IR.Type[k1, k2, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-    !isnothing(k1) && push!(results, k1)
-    !isnothing(k2) && push!(results, k2)
-
-    return IR.create_operation(
-        "x86vector.avx512.vp2intersect",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
-        results=(length(results) == 0 ? nothing : results),
-        result_inference=(length(results) == 0 ? true : false),
+    
+    IR.create_operation(
+        "x86vector.avx512.vp2intersect", location;
+        operands, owned_regions, successors, attributes,
+        results=results,
+        result_inference=false
     )
 end
 
@@ -475,24 +345,18 @@ end
 `avx512_intr_vp2intersect_q_512`
 
 """
-function avx512_intr_vp2intersect_q_512(
-    a::Value, b::Value; res::IR.Type, location=Location()
-)
-    results = IR.Type[res,]
-    operands = Value[a, b]
+function avx512_intr_vp2intersect_q_512(a::Value, b::Value; res::IR.Type, location=Location())
+    results = IR.Type[res, ]
+    operands = Value[a, b, ]
     owned_regions = Region[]
     successors = Block[]
     attributes = NamedAttribute[]
-
-    return IR.create_operation(
-        "x86vector.avx512.intr.vp2intersect.q.512",
-        location;
-        operands,
-        owned_regions,
-        successors,
-        attributes,
+    
+    IR.create_operation(
+        "x86vector.avx512.intr.vp2intersect.q.512", location;
+        operands, owned_regions, successors, attributes,
         results=results,
-        result_inference=false,
+        result_inference=false
     )
 end
 

--- a/src/IR/Pass.jl
+++ b/src/IR/Pass.jl
@@ -156,13 +156,15 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided `OpPassManager`.
 """
 function Base.parse(opm::OpPassManager, pipeline::String)
-    result = LogicalResult(if MLIR_VERSION[] >= v"16"
-        io = IOBuffer()
-        c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
-        API.mlirParsePassPipeline(opm, pipeline, c_print_callback, Ref(io))
-    else
-        API.mlirParsePassPipeline(opm, pipeline)
-    end)
+    result = LogicalResult(
+        if MLIR_VERSION[] >= v"16"
+            io = IOBuffer()
+            c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
+            API.mlirParsePassPipeline(opm, pipeline, c_print_callback, Ref(io))
+        else
+            API.mlirParsePassPipeline(opm, pipeline)
+        end,
+    )
 
     if isfailure(result)
         throw(AddPipelineException(String(take!(io))))

--- a/src/IR/Pass.jl
+++ b/src/IR/Pass.jl
@@ -156,15 +156,13 @@ end
 Parse a textual MLIR pass pipeline and add it to the provided `OpPassManager`.
 """
 function Base.parse(opm::OpPassManager, pipeline::String)
-    result = LogicalResult(
-        if MLIR_VERSION[] >= v"16"
-            io = IOBuffer()
-            c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
-            API.mlirParsePassPipeline(opm, pipeline, c_print_callback, Ref(io))
-        else
-            API.mlirParsePassPipeline(opm, pipeline)
-        end,
-    )
+    result = LogicalResult(if MLIR_VERSION[] >= v"16"
+        io = IOBuffer()
+        c_print_callback = @cfunction(print_callback, Cvoid, (API.MlirStringRef, Any))
+        API.mlirParsePassPipeline(opm, pipeline, c_print_callback, Ref(io))
+    else
+        API.mlirParsePassPipeline(opm, pipeline)
+    end)
 
     if isfailure(result)
         throw(AddPipelineException(String(take!(io))))


### PR DESCRIPTION
I added all local variables used in the generated functions to the `reservedKeyword` list. In due time a more robust solution could be implemented but this fixes quite a lot of cases already.

Should PRs like these include the generated code as well? I've added it as separate commits.
I didn't change the API bindings script but the bindings have changed nevertheless, has it been a while since this has been updated or are the results machine-dependent?

The dialect binding generation threw an error for LLVM14, I ran it using `Julia 1.10.3`, not sure what's up.
```
Included from /tmp/jl_TbvR47/x86_64-linux-gnu-libgfortran5-cxx11-libstdcxx30-llvm_version+14-julia_version+1.9.0/destdir/include/mlir/Dialect/OpenACC/OpenACCOps.td:16:
Included from /tmp/jl_TbvR47/x86_64-linux-gnu-libgfortran5-cxx11-libstdcxx30-llvm_version+14-julia_version+1.9.0/destdir/include/mlir/IR/EnumAttr.td:12:
/tmp/jl_TbvR47/x86_64-linux-gnu-libgfortran5-cxx11-libstdcxx30-llvm_version+14-julia_version+1.9.0/destdir/include/mlir/IR/OpBase.td:2130:1: error: Record `AttrSizedOperandSegments' does not have a field named `dependentTraits'!

def AttrSizedOperandSegments : NativeOpTrait<"AttrSizedOperandSegments">;
^
ERROR: LoadError: failed process: Process(`/home/jumerckx/.julia/scratchspaces/bfde9dd4-8f40-4a1e-be09-1475335e1c92/build/bin/mlir-jl-tblgen --generator=jl-op-defs --disable-module-wrap /tmp/jl_TbvR47/x86_64-linux-gnu-libgfortran5-cxx11-libstdcxx30-llvm_version+14-julia_version+1.9.0/destdir/include/mlir/Dialect/OpenACC/OpenACCOps.td -I /tmp/jl_TbvR47/x86_64-linux-gnu-libgfortran5-cxx11-libstdcxx30-llvm_version+14-julia_version+1.9.0/destdir/include/mlir/Dialect/OpenACC -I /tmp/jl_TbvR47/x86_64-linux-gnu-libgfortran5-cxx11-libstdcxx30-llvm_version+14-julia_version+1.9.0/destdir/include -o /tmp/jl_CT9KRy`, ProcessExited(1)) [1]

Stacktrace:
  [1] pipeline_error
    @ Base ./process.jl:565 [inlined]
  [2] run(::Cmd; wait::Bool)
    @ Base ./process.jl:480
  [3] run
    @ ./process.jl:477 [inlined]
  [4] (::var"#4#7"{String, String})(td::String)
    @ Main ~/.julia/dev/MLIR/bindings/make.jl:264
  [5] iterate
    @ ./generator.jl:47 [inlined]
  [6] _collect(c::Vector{String}, itr::Base.Generator{Vector{String}, var"#4#7"{String, String}}, ::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:854
  [7] collect_similar
    @ ./array.jl:763 [inlined]
  [8] map
    @ ./abstractarray.jl:3282 [inlined]
  [9] (::var"#3#6"{VersionNumber, VersionNumber})(prefix::Prefix)
    @ Main ~/.julia/dev/MLIR/bindings/make.jl:253
 [10] #66
    @ ~/.julia/packages/BinaryBuilderBase/JOwzH/src/Prefix.jl:46 [inlined]
 [11] mktempdir(fn::BinaryBuilderBase.var"#66#68"{var"#3#6"{VersionNumber, VersionNumber}}, parent::String; prefix::String)
    @ Base.Filesystem ./file.jl:766
 [12] mktempdir
    @ Base.Filesystem ./file.jl:762 [inlined]
 [13] temp_prefix(func::var"#3#6"{VersionNumber, VersionNumber})
    @ BinaryBuilderBase ~/.julia/packages/BinaryBuilderBase/JOwzH/src/Prefix.jl:42
 [14] top-level scope
    @ ~/.julia/dev/MLIR/bindings/make.jl:207
in expression starting at /home/jumerckx/.julia/dev/MLIR/bindings/make.jl:204
```